### PR TITLE
test(cli): remove unit tests and add integration tests for env command

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "prepare": "simple-git-hooks",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:integration": "pnpm build && vitest run --config vitest.integration.config.ts",
+    "test:all": "pnpm test && pnpm test:integration",
     "generate-changelog": "tsx ./scripts/changelog.ts",
     "extract": "tsx ./scripts/sync.ts"
   },

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -14,21 +14,4 @@ describe('cli', () => {
 
     expect(stdout).toContain('@antdv-next/cli v0.0.0')
   })
-
-  it('run antdv env command in text format', async () => {
-    const { stdout } = await run(['env'])
-
-    expect(stdout).toContain('Environment')
-    expect(stdout).toContain('Dependencies')
-  })
-
-  it('run antdv env command in json format', async () => {
-    const { stdout } = await run(['env', '--format', 'json'])
-    const data = JSON.parse(stdout)
-
-    expect(data).toHaveProperty('envinfo')
-    expect(data).toHaveProperty('dependencies')
-    expect(data).toHaveProperty('ecosystem')
-    expect(data).toHaveProperty('buildTools')
-  })
 })

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -30,6 +30,7 @@ vi.mock('tinyexec', () => ({
 }))
 
 let projectPath: string
+const mockProjectPath = join(tmpdir(), 'antdv-cli-env-mock')
 
 async function writePackage(packageName: string, version?: string): Promise<void> {
   const packageDirectory = join(projectPath, 'node_modules', packageName)
@@ -48,15 +49,20 @@ async function writeProjectPackage(packageJson: Record<string, unknown>): Promis
   }))
 }
 
-beforeEach(async () => {
-  projectPath = await fs.mkdtemp(join(tmpdir(), 'antdv-cli-env-'))
+beforeEach(() => {
   vi.clearAllMocks()
 })
 
-afterEach(async () => await fs.rm(projectPath, {
-  recursive: true,
-  force: true,
-}))
+function useProjectFixture(): void {
+  beforeEach(async () => {
+    projectPath = await fs.mkdtemp(join(tmpdir(), 'antdv-cli-env-'))
+  })
+
+  afterEach(async () => await fs.rm(projectPath, {
+    recursive: true,
+    force: true,
+  }))
+}
 
 describe('collectEnvinfo', () => {
   it('normalizes envinfo values and adds the project npm registry', async () => {
@@ -73,7 +79,7 @@ describe('collectEnvinfo', () => {
     })
 
     const result = await collectEnvinfo({
-      cwd: projectPath,
+      cwd: mockProjectPath,
       format: 'text',
     })
 
@@ -91,7 +97,7 @@ describe('collectEnvinfo', () => {
     expect(mocks.x).toHaveBeenCalledWith('npm', ['config', 'get', 'registry'], {
       timeout: 5000,
       nodeOptions: {
-        cwd: projectPath,
+        cwd: mockProjectPath,
         stdio: 'pipe',
       },
     })
@@ -106,7 +112,7 @@ describe('collectEnvinfo', () => {
     mocks.x.mockRejectedValueOnce(new Error('npm not found'))
 
     const result = await collectEnvinfo({
-      cwd: projectPath,
+      cwd: mockProjectPath,
       format: 'text',
     })
 
@@ -120,7 +126,7 @@ describe('collectEnvinfo', () => {
     mocks.envinfoRun.mockRejectedValueOnce(new Error('envinfo failed'))
 
     const result = await collectEnvinfo({
-      cwd: projectPath,
+      cwd: mockProjectPath,
       format: 'text',
     })
 
@@ -130,6 +136,8 @@ describe('collectEnvinfo', () => {
 })
 
 describe('getInstalledPackageVersion', () => {
+  useProjectFixture()
+
   it('reads the package version from the target project', async () => {
     await writePackage('antdv-next', '1.2.3')
 
@@ -145,6 +153,8 @@ describe('getInstalledPackageVersion', () => {
 })
 
 describe('collectDependencies', () => {
+  useProjectFixture()
+
   it('reports only the four antdv core dependencies and includes missing packages', async () => {
     await Promise.all([
       writePackage('antdv-next', '1.0.0'),
@@ -163,6 +173,8 @@ describe('collectDependencies', () => {
 })
 
 describe('scanEcosystem', () => {
+  useProjectFixture()
+
   it('collects declared non-core @antdv-next and @v-c packages', async () => {
     await writeProjectPackage({
       dependencies: {
@@ -207,6 +219,8 @@ describe('scanEcosystem', () => {
 })
 
 describe('collectBuildTools', () => {
+  useProjectFixture()
+
   it('reports only the requested installed build tools', async () => {
     const versions = {
       vue: '3.5.0',

--- a/test/integration/cli-env.test.ts
+++ b/test/integration/cli-env.test.ts
@@ -1,0 +1,28 @@
+import fs from 'node:fs/promises'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { createMockDir, genPath, run } from '../run'
+
+beforeEach(async () => await createMockDir())
+afterAll(async () => await fs.rm(genPath, {
+  recursive: true,
+  force: true,
+}))
+
+describe('cli env integration', () => {
+  it('runs the env command in text format', async () => {
+    const { stdout } = await run(['env'])
+
+    expect(stdout).toContain('Environment')
+    expect(stdout).toContain('Dependencies')
+  })
+
+  it('runs the env command in json format', async () => {
+    const { stdout } = await run(['env', '--format', 'json'])
+    const data = JSON.parse(stdout)
+
+    expect(data).toHaveProperty('envinfo')
+    expect(data).toHaveProperty('dependencies')
+    expect(data).toHaveProperty('ecosystem')
+    expect(data).toHaveProperty('buildTools')
+  })
+})

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,6 +1,5 @@
 import { createVitestConfig } from './vitest.shared.ts'
 
 export default createVitestConfig({
-  include: ['./test/**/*.{test,spec}.ts'],
-  exclude: ['./test/integration/**'],
+  include: ['./test/integration/**/*.{test,spec}.ts'],
 })

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -1,0 +1,27 @@
+import type { ViteUserConfig } from 'vitest/config'
+import { readFileSync } from 'node:fs'
+import { defineConfig } from 'vitest/config'
+
+interface TestFiles {
+  include: string[]
+  exclude?: string[]
+}
+
+const { version } = JSON.parse(readFileSync('package.json', 'utf-8'))
+
+export function createVitestConfig({ include, exclude }: TestFiles): ViteUserConfig {
+  return defineConfig({
+    define: {
+      __CLI_VERSION__: JSON.stringify(version),
+    },
+    resolve: {
+      alias: {
+        '@/': new URL('./src/', import.meta.url).pathname,
+      },
+    },
+    test: {
+      include,
+      exclude,
+    },
+  })
+}


### PR DESCRIPTION
- Remove unit tests for env command from cli.test.ts
- Add integration tests for env command in test/integration/cli-env.test.ts
- Create shared vitest configuration in vitest.shared.ts
- Update vitest.config.ts to use shared configuration
- Add integration test script to package.json
- Move test isolation logic to useProjectFixture helper function
- Update test paths to use mockProjectPath variable consistently