### PR TITLE
ci: restrict workflow triggers to source and test directories

### DIFF
--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -1,7 +1,9 @@
 name: Publish pkg.pr.new
 
 on:
-  pull_request: { }
+  pull_request:
+    paths:
+      - 'src/**'
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Test
 
 on:
   pull_request:
+    paths:
+      - 'src/**'
+      - 'test/**'
 
 jobs:
   test:


### PR DESCRIPTION
- Limit pkg.pr.new workflow to run only when src files change
- Add path filtering to test workflow for src and test directories
- Prevent unnecessary workflow executions on unrelated file changes
- Optimize CI resource usage by focusing on relevant file changes