### PR TITLE
ci(build-size): enable build size check for pull requests

### DIFF
--- a/.github/workflows/build-size.yml
+++ b/.github/workflows/build-size.yml
@@ -2,8 +2,8 @@ name: Build size
 
 on:
   pull_request:
-#    paths:
-#      - 'src/**'
+    paths:
+      - 'src/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
- Activated path filtering for src directory in build-size workflow
- Removed commented out configuration that disabled the check
- Ensured workflow runs on pull requests with proper permissions set