### PR TITLE
feat(sync): add semantic structure parsing for components

### DIFF
--- a/data/v1.0.5.json
+++ b/data/v1.0.5.json
@@ -1805,7 +1805,8 @@
           "descriptionZh": "用 `target` 设置 `Affix` 需要监听其滚动事件的元素，默认为 `window`。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst container = shallowRef()\n</script>\n\n<template>\n  <div ref=\"container\" style=\"width: 100%;height: 100px;overflow: auto;box-shadow: 0 0 0 1px #1677ff;scrollbar-width: thin;scrollbar-gutter: stable\">\n    <div style=\"width: 100%;height: 1000px\">\n      <a-affix :target=\"() => container\">\n        <a-button type=\"primary\">\n          Fixed at the top of container\n        </a-button>\n      </a-affix>\n    </div>\n  </div>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Alert",
@@ -2074,14 +2075,43 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Alert by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Alert 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { AlertProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: AlertProps['classes'] = {\n  root: 'demo-alert-root',\n}\n\nconst stylesObject: AlertProps['styles'] = {\n  icon: {\n    fontSize: '18px',\n  },\n  section: {\n    fontWeight: 500,\n  },\n}\n\nconst stylesFn: AlertProps['styles'] = (info) => {\n  if (info?.props?.type === 'success') {\n    return {\n      root: {\n        backgroundColor: 'rgba(82, 196, 26, 0.1)',\n        borderColor: '#b7eb8f',\n      },\n      icon: {\n        color: '#52c41a',\n      },\n    }\n  }\n  if (info?.props?.type === 'warning') {\n    return {\n      root: {\n        backgroundColor: 'rgba(250, 173, 20, 0.1)',\n        borderColor: '#ffe58f',\n      },\n      icon: {\n        color: '#faad14',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"small\">\n    <a-alert\n      title=\"Object styles\"\n      type=\"info\"\n      show-icon\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n    >\n      <template #action>\n        <a-button size=\"small\">\n          Action\n        </a-button>\n      </template>\n    </a-alert>\n    <a-alert\n      title=\"Function styles\"\n      type=\"success\"\n      show-icon\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with border, background, padding, border-radius, and positioning styles for the alert container",
+          "descriptionZh": "根元素，包含边框、背景色、内边距、圆角、位置布局等警告提示框的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Alert\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-alert\n        closable\n        title=\"Info Text\"\n        show-icon\n        description=\"Info Description Info Description Info Description Info Description\"\n        type=\"info\"\n        :classes=\"classes\"\n      >\n        <template #action>\n          <a-space direction=\"vertical\">\n            <a-button size=\"small\" type=\"primary\">\n              Accept\n            </a-button>\n            <a-button size=\"small\" danger ghost>\n              Decline\n            </a-button>\n          </a-space>\n        </template>\n      </a-alert>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Content element with flex layout controlling content area typography and minimum width",
+          "descriptionZh": "内容元素，采用 flex 布局控制内容区域的排版和最小宽度"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with color, line-height, and margin styles, supporting different status icon types",
+          "descriptionZh": "图标元素，包含图标的颜色、行高、外边距等样式，支持不同类型的状态图标"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text color and font styling for the alert title",
+          "descriptionZh": "标题元素，包含标题文字的颜色、字体等样式"
+        },
+        {
+          "key": "description",
+          "description": "Description element with font-size and line-height styles for additional content",
+          "descriptionZh": "描述元素，包含描述文字的字体大小、行高等排版样式"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element with layout and spacing styles for action buttons",
+          "descriptionZh": "操作组元素，包含操作按钮的布局和间距样式"
+        },
+        {
+          "key": "close",
+          "description": "Close button element with basic button styling",
+          "descriptionZh": "关闭按钮元素，包含按钮的基础样式"
         }
       ]
     },
@@ -2319,14 +2349,28 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Anchor by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "您可以通过 `classes` 和 `styles` 传入对象/函数可以自定义 Anchor 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { AnchorProps } from 'antdv-next'\n\nconst classesObject: AnchorProps['classes'] = {\n  root: 'demo-anchor-root',\n  item: 'demo-anchor-item',\n  itemTitle: 'demo-anchor-title',\n  indicator: 'demo-anchor-indicator',\n}\n\nconst stylesFn: AnchorProps['styles'] = (info) => {\n  if (info.props.direction === 'vertical') {\n    return {\n      root: {\n        backgroundColor: 'rgba(255,251,230,0.5)',\n        height: '100vh',\n      },\n    }\n  }\n  return {}\n}\n\nconst items: NonNullable<AnchorProps['items']> = [\n  {\n    key: 'part-1',\n    href: '#part-1',\n    title: 'Part 1',\n  },\n  {\n    key: 'part-2',\n    href: '#part-2',\n    title: 'Part 2',\n  },\n  {\n    key: 'part-3',\n    href: '#part-3',\n    title: 'Part 3',\n  },\n]\n</script>\n\n<template>\n  <a-row>\n    <a-col :span=\"16\">\n      <div id=\"part-1\" style=\"height: 100vh; background: rgba(255, 0, 0, 0.08)\" />\n      <div id=\"part-2\" style=\"height: 100vh; background: rgba(0, 255, 0, 0.08)\" />\n      <div id=\"part-3\" style=\"height: 100vh; background: rgba(0, 0, 255, 0.08)\" />\n    </a-col>\n    <a-col :span=\"8\">\n      <a-anchor replace :items=\"items\" :styles=\"stylesFn\" :classes=\"classesObject\" />\n    </a-col>\n  </a-row>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with layout positioning, padding, margin, background color and other basic styles",
+          "descriptionZh": "根元素，包含布局定位、内边距、边距、背景色等基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'itemTitle', desc: t('itemTitle'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n])\n\nconst items = [\n  {\n    key: 'api',\n    href: '#api',\n    title: 'API',\n    children: [\n      { key: '4', href: '#anchor-props', title: 'Anchor Props' },\n      { key: '5', href: '#link-props', title: 'Link Props' },\n    ],\n  },\n  { key: '1', href: '#anchor-demo-basic', title: 'Basic demo' },\n  { key: '2', href: '#anchor-demo-static', title: 'Static demo' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Anchor\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-anchor :affix=\"false\" :items=\"items\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Link item element with padding, text color, hover states, transition animations and other styles",
+          "descriptionZh": "链接项元素，包含内边距、文字颜色、悬停状态、过渡动画等样式"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Title text element with font styles, color changes, text decoration, transition effects and other styles",
+          "descriptionZh": "标题文字元素，包含字体样式、颜色变化、文本装饰、过渡效果等样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element with width, height, background color, position changes, transition animations and other styles",
+          "descriptionZh": "指示器元素，包含宽度、高度、背景色、位置变化、过渡动画等样式"
         }
       ]
     },
@@ -2389,7 +2433,8 @@
           "descriptionZh": "对 `message`、`notification` 进行配置。。",
           "code": "<script setup lang=\"ts\">\nimport MyPage2 from './myPage2.vue'\n</script>\n\n<template>\n  <a-app :message=\"{ maxCount: 1 }\" :notification=\"{ placement: 'bottomLeft' }\">\n    <MyPage2 />\n  </a-app>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "AutoComplete",
@@ -2692,14 +2737,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of AutoComplete by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 AutoComplete 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst stylesObject = {\n  popup: {\n    root: {\n      borderWidth: '1px',\n      borderStyle: 'solid',\n      borderColor: '#1890ff',\n    },\n    list: {\n      backgroundColor: 'rgba(240, 240, 240, 0.85)',\n    },\n    listItem: {\n      color: '#272727',\n    },\n  },\n}\n\nfunction stylesFn({ props }: { props: { variant?: string } }) {\n  if (props.variant === 'filled') {\n    return {\n      popup: {\n        root: {\n          borderWidth: '1px',\n          borderStyle: 'solid',\n          borderColor: '#ccc',\n        },\n        list: {\n          backgroundColor: 'rgba(240, 240, 240, 0.85)',\n        },\n        listItem: {\n          color: '#272727',\n        },\n      },\n    }\n  }\n  return {}\n}\n\nconst options = [\n  { value: 'Burnaby' },\n  { value: 'Seattle' },\n  { value: 'Los Angeles' },\n  { value: 'San Francisco' },\n  { value: 'Meet student' },\n]\n\nconst sharedProps = {\n  options,\n  classes: {\n    root: 'auto-complete-style-root',\n  },\n  style: { width: '200px' },\n}\n\nconst value = ref('')\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-auto-complete v-model:value=\"value\" v-bind=\"sharedProps\" placeholder=\"object styles\" :styles=\"stylesObject\" />\n    <a-auto-complete\n      v-model:value=\"value\"\n      v-bind=\"sharedProps\"\n      placeholder=\"function styles\"\n      :styles=\"stylesFn\"\n      variant=\"filled\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, cursor styles, transitions, border and other basic selector container styles",
+          "descriptionZh": "根元素，包含相对定位、行内 flex 布局、光标样式、过渡动画、边框等选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'placeholder', desc: t('placeholder') },\n  { name: 'content', desc: t('content') },\n  { name: 'clear', desc: t('clear') },\n  { name: 'popup.root', desc: t('popup.root') },\n  { name: 'popup.list', desc: t('popup.list') },\n  { name: 'popup.listItem', desc: t('popup.listItem') },\n])\n\nconst options = ref([\n  { value: 'aojunhao123', label: 'aojunhao123' },\n  { value: 'thinkasany', label: 'thinkasany' },\n  { value: 'meet-student', label: 'meet-student' },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"AutoComplete\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <a-auto-complete\n          prefix=\"prefix\"\n          :style=\"{ width: '200px' }\"\n          :options=\"options\"\n          placeholder=\"input here\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with layout and styling for prefix content",
+          "descriptionZh": "前缀元素，包含前缀内容的布局和样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with search input styling, cursor control, font inheritance and other search-related styles. Remove border styles",
+          "descriptionZh": "输入框元素，包含搜索输入框的样式、光标控制、字体继承等搜索相关样式，去除了边框样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "clear",
+          "description": "Clear button element with layout, styling and interactive effects for clear button",
+          "descriptionZh": "清除按钮元素，包含清除按钮的布局、样式和交互效果"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with popup layer positioning, z-index, background, border, box-shadow and other popup container styles",
+          "descriptionZh": "弹出菜单元素，包含弹出层的定位、层级、背景、边框、阴影等弹出容器样式"
+        },
+        {
+          "key": "popup.list",
+          "description": "Popup list element with option list layout, scrolling, max-height and other list container styles",
+          "descriptionZh": "弹出菜单列表元素，包含选项列表的布局、滚动、最大高度等列表容器样式"
+        },
+        {
+          "key": "popup.listItem",
+          "description": "Popup item element with option item padding, hover effects, selected states, disabled states and other option interactive styles",
+          "descriptionZh": "弹出菜单条目元素，包含选项项的内边距、悬浮效果、选中状态、禁用状态等选项交互样式"
         }
       ]
     },
@@ -2988,7 +3072,8 @@
           "descriptionZh": "",
           "code": "<script setup lang=\"ts\">\nimport { AntDesignOutlined } from '@antdv-next/icons'\n</script>\n\n<template>\n  <a-avatar\n    :size=\"{ xs: 24, sm: 32, md: 40, lg: 64, xl: 80, xxl: 100 }\"\n  >\n    <template #icon>\n      <AntDesignOutlined />\n    </template>\n  </a-avatar>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Badge",
@@ -3258,22 +3343,33 @@
           "description": "The badge will display `title` when hovered over, instead of `count`.",
           "descriptionZh": "设置鼠标放在状态点上时显示的文字。",
           "code": "<script setup lang=\"ts\">\n</script>\n\n<template>\n  <a-space size=\"large\">\n    <a-badge :count=\"5\" title=\"Custom hover text\">\n      <a-avatar shape=\"square\" size=\"large\" />\n    </a-badge>\n    <a-badge :count=\"-5\" title=\"Negative\">\n      <a-avatar shape=\"square\" size=\"large\" />\n    </a-badge>\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-block display, and fit-content width for basic layout",
+          "descriptionZh": "根元素，包含相对定位、行内块布局、适应内容宽度等基础布局样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Badge\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-badge :count=\"5\" :classes=\"classes\">\n        <a-avatar shape=\"square\" size=\"large\" />\n      </a-badge>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "indicator",
+          "description": "Indicator element with positioning, z-index, dimensions, colors, fonts, text alignment, background, border-radius, box-shadow, and transition animations for complete badge styling",
+          "descriptionZh": "指示器元素，包含定位、层级、尺寸、颜色、字体、文本对齐、背景、圆角、阴影、过渡动画等完整的徽标样式"
         },
         {
-          "name": "_semantic_ribbon",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('ribbonRoot'), version: '1.0.0' },\n  { name: 'indicator', desc: t('ribbonIndicator'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <div style=\"display: flex; flex-direction: column; gap: 24px;\">\n    <SemanticPreview\n      component-name=\"Badge\"\n      :semantics=\"semantics\"\n    >\n      <template #default=\"{ classes }\">\n        <div style=\"width: 100%;\">\n          <a-badge-ribbon text=\"Hippies\" color=\"magenta\" :classes=\"classes\">\n            <a-card title=\"Pushes open the window\" size=\"small\">\n              and raises the spyglass.\n            </a-card>\n          </a-badge-ribbon>\n        </div>\n      </template>\n    </SemanticPreview>\n  </div>\n</template>"
+          "key": "ribbonRoot",
+          "description": "Root element, set relative positioning and wrapper container styles",
+          "descriptionZh": "根元素，设置相对定位和包装容器样式"
+        },
+        {
+          "key": "ribbonIndicator",
+          "description": "Indicator element, set absolute positioning, padding, background color, border radius and ribbon styles",
+          "descriptionZh": "指示器元素，设置绝对定位、内边距、背景色、圆角和缎带样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element, set text color and ribbon content display styles",
+          "descriptionZh": "文本元素，设置文本颜色和缎带内容显示样式"
         }
       ]
     },
@@ -3455,14 +3551,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Breadcrumb by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Breadcrumb 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { BreadcrumbProps } from 'antdv-next'\n\nconst classesObject = {\n  root: 'demo-breadcrumb-root',\n  item: 'demo-breadcrumb-item',\n  separator: 'demo-breadcrumb-separator',\n}\n\nconst stylesObject: BreadcrumbProps['styles'] = {\n  root: { border: '1px solid #f0f0f0', padding: '8px', borderRadius: '4px' },\n  item: { color: '#1890ff' },\n  separator: { color: 'rgba(0, 0, 0, 0.45)' },\n}\n\nconst stylesFn: BreadcrumbProps['styles'] = (info) => {\n  const items = info.props.items || []\n  if (items.length > 2) {\n    return {\n      root: { border: '1px solid #F5EFFF', padding: '8px', borderRadius: '4px' },\n      item: { color: '#8F87F1' },\n    }\n  }\n  return {}\n}\n\nconst items = [\n  { title: 'Antdv Next' },\n  { title: 'Component' },\n  { title: 'Breadcrumb' },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-breadcrumb\n      :classes=\"classesObject\"\n      :items=\"items.slice(0, 2)\"\n      :styles=\"stylesObject\"\n      aria-label=\"Breadcrumb with Object\"\n    />\n    <a-breadcrumb\n      :classes=\"classesObject\"\n      :items=\"items\"\n      :styles=\"stylesFn\"\n      aria-label=\"Breadcrumb with Function\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with text color, font size, icon size and other basic styles, using flex layout with ordered list",
+          "descriptionZh": "根元素，包含文字颜色、字体大小、图标尺寸等基础样式，内部使用 flex 布局的有序列表"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { HomeOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'separator', desc: t('separator'), version: '1.0.0' },\n])\n\nconst items = [\n  { href: '', title: h(HomeOutlined) },\n  { href: '', title: [h(UserOutlined), h('span', 'Application List')] },\n  { title: 'Application' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Breadcrumb\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-breadcrumb :items=\"items\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with text color, link color transitions, hover effects, padding, border-radius, height, and margin styles",
+          "descriptionZh": "Item 元素，包含文字颜色、链接的颜色变化、悬浮效果、内边距、圆角、高度、外边距等样式"
+        },
+        {
+          "key": "separator",
+          "description": "Separator element with margin and color styles for the divider",
+          "descriptionZh": "分隔符元素，包含分隔符的外边距和颜色样式"
         }
       ]
     },
@@ -3976,20 +4081,29 @@
           "code": "<script setup lang=\"ts\">\nimport type { ButtonProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: ButtonProps['classes'] = {\n  root: 'demo-button-root',\n  content: 'demo-button-content',\n}\n\nconst stylesObject: ButtonProps['styles'] = {\n  root: {\n    boxShadow: '0 1px 2px 0 rgba(0,0,0,0.05)',\n  },\n}\n\nconst stylesFn: ButtonProps['styles'] = (info) => {\n  if (info?.props?.type === 'primary') {\n    return {\n      root: {\n        backgroundColor: '#171717',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"small\">\n    <a-button type=\"default\" :classes=\"classes\" :styles=\"stylesObject\">\n      Object\n    </a-button>\n    <a-button type=\"primary\" :classes=\"classes\" :styles=\"stylesFn\">\n      Function\n    </a-button>\n  </a-flex>\n</template>"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AntDesignOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Button\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-button type=\"primary\" :classes=\"classes\">\n        <template #icon>\n          <AntDesignOutlined />\n        </template>\n        Antdv Next\n      </a-button>\n    </template>\n  </SemanticPreview>\n</template>"
-        },
-        {
           "name": "chinese-space",
           "title": "",
           "titleZh": "移除两个汉字之间的空格",
           "description": "We add a space between two Chinese characters by default, which can be removed by setting `autoInsertSpace` to `false`.",
           "descriptionZh": "我们默认在两个汉字之间添加空格，可以通过设置 `autoInsertSpace` 为 `false` 关闭。",
           "code": "<template>\n  <a-flex gap=\"small\" wrap>\n    <a-button type=\"primary\" :auto-insert-space=\"false\">\n      确定\n    </a-button>\n    <a-button type=\"primary\" auto-insert-space>\n      确定\n    </a-button>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with comprehensive button styling including border, background, padding, border-radius, box-shadow, transitions, cursor, font-weight, alignment, and layout properties",
+          "descriptionZh": "根元素，包含边框样式、背景色、内边距、圆角、阴影效果、过渡动画、光标样式、文字权重、对齐方式等完整的按钮外观样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element that wraps button text with typography styles including nowrap, text-align center, and Chinese character spacing optimization",
+          "descriptionZh": "内容元素，包装按钮文本内容，控制文本的不换行显示、居中对齐、中文字符间距优化等文本排版样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with font-size, color inheritance, and SVG style reset for proper icon display",
+          "descriptionZh": "图标元素，包含图标的字体大小、颜色继承、SVG 样式重置等图标显示相关样式"
         }
       ]
     },
@@ -4277,14 +4391,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Calendar by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Calendar 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CalendarProps } from 'antdv-next'\nimport type { Dayjs } from 'dayjs'\n\nconst classes = {\n  root: 'custom-calendar-root',\n}\n\nconst stylesObject: CalendarProps<Dayjs>['styles'] = {\n  root: {\n    borderRadius: '8px',\n    width: '600px',\n  },\n}\n\nconst stylesFunction: CalendarProps<Dayjs>['styles'] = (info) => {\n  if (info.props.fullscreen) {\n    return {\n      root: {\n        border: '2px solid #BDE3C3',\n        borderRadius: '10px',\n        backgroundColor: 'rgba(189,227,195, 0.3)',\n      },\n    } satisfies CalendarProps<Dayjs>['styles']\n  }\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-calendar :fullscreen=\"false\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-calendar :classes=\"classes\" :styles=\"stylesFunction\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element containing background, border, border-radius and overall layout structure of the calendar component",
+          "descriptionZh": "根元素，包含日历组件的背景色、边框、圆角等基础样式和整体布局结构"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Calendar\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-calendar :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with layout and style control for year selector, month selector and mode switcher",
+          "descriptionZh": "头部元素，包含年份选择器、月份选择器、模式切换器的布局和样式控制"
+        },
+        {
+          "key": "body",
+          "description": "Body element with padding and layout control for the calendar table that contains the calendar grid",
+          "descriptionZh": "主体元素，包含日历表格的内边距、布局控制等样式，用于容纳日历网格"
+        },
+        {
+          "key": "content",
+          "description": "Content element with width, height and table styling control for the calendar table",
+          "descriptionZh": "内容元素，包含日历表格的宽度、高度等尺寸控制和表格样式"
+        },
+        {
+          "key": "item",
+          "description": "Item element with background, border, hover state, selected state and other interactive styles for calendar cells",
+          "descriptionZh": "条目元素，包含日历单元格的背景色、边框、悬停态、选中态等交互样式"
         }
       ]
     },
@@ -4754,14 +4887,43 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Card by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Card 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CardProps } from 'antdv-next'\nimport { EditOutlined, HeartOutlined, ShareAltOutlined } from '@antdv-next/icons'\nimport { theme } from 'antdv-next'\nimport { computed } from 'vue'\n\nconst { token } = theme.useToken()\n\nconst classes = computed(() => ({\n  root: 'custom-card-root',\n  header: 'custom-card-header',\n  body: 'custom-card-body',\n}))\n\nconst stylesCard = computed(() => ({\n  root: {\n    boxShadow: '0 2px 8px rgba(0,0,0,0.06)',\n    borderRadius: '8px',\n  },\n  title: {\n    fontSize: '16px',\n    fontWeight: 500,\n  },\n}))\n\nconst stylesCardFn = computed(() => {\n  return (info: { props: CardProps }) => {\n    if (info.props.variant === 'outlined') {\n      return {\n        root: {\n          borderColor: '#696FC7',\n          boxShadow: '0 2px 8px #A7AAE1',\n          borderRadius: '8px',\n        },\n        extra: {\n          color: '#696FC7',\n        },\n        title: {\n          fontSize: '16px',\n          fontWeight: 500,\n          color: '#A7AAE1',\n        },\n      }\n    }\n    return {}\n  }\n})\n\nconst stylesCardMeta = {\n  title: {\n    color: '#A7AAE1',\n  },\n  description: {\n    color: '#A7AAE1',\n  },\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-card\n      title=\"Object Card\"\n      :classes=\"classes\"\n      :styles=\"stylesCard\"\n      variant=\"borderless\"\n    >\n      <template #extra>\n        <a-button type=\"link\">\n          More\n        </a-button>\n      </template>\n      <template #actions>\n        <HeartOutlined key=\"heart\" style=\"color: #ff6b6b\" />\n        <ShareAltOutlined key=\"share\" style=\"color: #4ecdc4\" />\n        <EditOutlined key=\"edit\" style=\"color: #45b7d1\" />\n      </template>\n      <a-card-meta title=\"Object Card Meta title\" description=\"This is the description\">\n        <template #avatar>\n          <a-avatar src=\"https://api.dicebear.com/7.x/miniavs/svg?seed=1\" />\n        </template>\n      </a-card-meta>\n    </a-card>\n    <a-card\n      title=\"Function Card\"\n      :classes=\"classes\"\n      :styles=\"stylesCardFn\"\n    >\n      <template #extra>\n        <a-button type=\"link\" :styles=\"{ root: { color: '#A7AAE1' } }\">\n          More\n        </a-button>\n      </template>\n      <template #actions>\n        <HeartOutlined key=\"heart\" style=\"color: #ff6b6b\" />\n        <ShareAltOutlined key=\"share\" style=\"color: #4ecdc4\" />\n        <EditOutlined key=\"edit\" style=\"color: #45b7d1\" />\n      </template>\n      <a-card-meta\n        title=\"Function Card Meta title\"\n        description=\"This is the description\"\n        :styles=\"stylesCardMeta\"\n      >\n        <template #avatar>\n          <a-avatar src=\"https://api.dicebear.com/7.x/miniavs/svg?seed=1\" />\n        </template>\n      </a-card-meta>\n    </a-card>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Card root element with positioning, background, border, border-radius, box-shadow, padding and other container styles",
+          "descriptionZh": "卡片根元素，包含位置定位、背景色、边框、圆角、阴影、内边距等卡片容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, EllipsisOutlined, SettingOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'cover', desc: t('cover'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Card\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ position: 'absolute' }\">\n        <a-card\n          title=\"Card title\"\n          extra=\"More\"\n          :style=\"{ width: '300px' }\"\n          :classes=\"classes\"\n        >\n          <template #cover>\n            <img\n              draggable=\"false\"\n              alt=\"example\"\n              src=\"https://gw.alipayobjects.com/zos/rmsportal/JiqGstEfoWAOHiTxclqi.png\"\n            >\n          </template>\n          <template #actions>\n            <SettingOutlined key=\"setting\" />\n            <EditOutlined key=\"edit\" />\n            <EllipsisOutlined key=\"ellipsis\" />\n          </template>\n          <a-card-meta\n            title=\"Card Meta title\"\n            description=\"This is the description\"\n          >\n            <template #avatar>\n              <a-avatar src=\"https://api.dicebear.com/7.x/miniavs/svg?seed=8\" />\n            </template>\n          </a-card-meta>\n        </a-card>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Card header area with flex layout, min-height, padding, text color, font-weight, font-size, background, bottom border and top border-radius",
+          "descriptionZh": "卡片头部区域，包含 flex 布局、最小高度、内边距、文字颜色、字体权重、字体大小、背景色、下边框、顶部圆角等样式"
+        },
+        {
+          "key": "body",
+          "description": "Card content area with padding, font-size and other content display styles",
+          "descriptionZh": "卡片内容区域，包含内边距、字体大小等内容展示的基础样式"
+        },
+        {
+          "key": "extra",
+          "description": "Card extra operation area in top-right corner with text color and layout styles for additional content",
+          "descriptionZh": "卡片右上角的操作区域，包含额外内容的文字颜色和布局样式"
+        },
+        {
+          "key": "title",
+          "description": "Card title with inline-block display, flex-grow, text ellipsis and other title display styles",
+          "descriptionZh": "卡片标题，包含行内块布局、flex 占比、文本省略等标题显示样式"
+        },
+        {
+          "key": "actions",
+          "description": "Card bottom action group with flex layout, list-style reset, background, top border and bottom border-radius for action buttons container",
+          "descriptionZh": "卡片底部操作组，包含 flex 布局、列表样式重置、背景色、上边框、底部圆角等操作按钮容器样式"
+        },
+        {
+          "key": "cover",
+          "description": "Title cover with styles for cover image display and layout",
+          "descriptionZh": "标题封面，包含封面图片的显示和布局样式"
         }
       ]
     },
@@ -5027,7 +5189,8 @@
           "descriptionZh": "展示指示点的进度。",
           "code": "<template>\n  <a-carousel :autoplay=\"{ dotDuration: true }\" :autoplay-speed=\"5000\">\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        1\n      </h3>\n    </div>\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        2\n      </h3>\n    </div>\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        3\n      </h3>\n    </div>\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        4\n      </h3>\n    </div>\n  </a-carousel>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Cascader",
@@ -5419,14 +5582,6 @@
           "code": "<script setup lang=\"ts\">\nimport type { CascaderEmits } from 'antdv-next'\nimport { ref } from 'vue'\n\ninterface Option {\n  value: string | number\n  label: string\n  children?: Option[]\n}\n\nconst options: Option[] = [\n  {\n    value: 'zhejiang',\n    label: 'Zhejiang',\n    children: [\n      {\n        value: 'hangzhou',\n        label: 'Hangzhou',\n        children: [\n          {\n            value: 'xihu',\n            label: 'West Lake',\n          },\n        ],\n      },\n    ],\n  },\n  {\n    value: 'jiangsu',\n    label: 'Jiangsu',\n    children: [\n      {\n        value: 'nanjing',\n        label: 'Nanjing',\n        children: [\n          {\n            value: 'zhonghuamen',\n            label: 'Zhong Hua Men',\n          },\n        ],\n      },\n    ],\n  },\n]\n\nconst disabled = ref(false)\n\nconst onChange: CascaderEmits['change'] = (value) => {\n  console.log(value)\n}\n\nconst onMultipleChange: CascaderEmits['change'] = (value) => {\n  console.log(value)\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"small\" align=\"flex-start\">\n    <a-switch\n      v-model:checked=\"disabled\"\n      checked-children=\"Enabled\"\n      un-checked-children=\"Disabled\"\n      aria-label=\"disabled switch\"\n    />\n    <a-cascader-panel :options=\"options\" :disabled=\"disabled\" @change=\"onChange\" />\n    <a-cascader-panel multiple :options=\"options\" :disabled=\"disabled\" @change=\"onMultipleChange\" />\n    <a-cascader-panel />\n  </a-flex>\n</template>"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'selector', desc: t('selector') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'popup', desc: t('popup') },\n  { name: 'item', desc: t('item') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst options = [\n  {\n    value: 'contributors',\n    label: 'contributors',\n    children: [\n      { value: 'aojunhao123', label: 'aojunhao123' },\n      { value: 'thinkasany', label: 'thinkasany' },\n      { value: 'meet-student', label: 'meet-student' },\n    ],\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Cascader\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <a-cascader\n          prefix=\"prefix\"\n          :style=\"{ width: '200px' }\"\n          :options=\"options\"\n          :default-value=\"['contributors', 'thinkasany']\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
-        },
-        {
           "name": "basic",
           "title": "",
           "titleZh": "基本",
@@ -5473,6 +5628,46 @@
           "description": "Allows the selection of only parent options.",
           "descriptionZh": "这种交互允许只选中父级选项。",
           "code": "<script setup lang=\"ts\">\nimport type { CascaderEmits } from 'antdv-next'\nimport { shallowRef } from 'vue'\n\ninterface Option {\n  value: string\n  label: string\n  children?: Option[]\n}\n\nconst options: Option[] = [\n  {\n    value: 'zhejiang',\n    label: 'Zhejiang',\n    children: [\n      {\n        value: 'hangzhou',\n        label: 'Hanzhou',\n        children: [\n          {\n            value: 'xihu',\n            label: 'West Lake',\n          },\n        ],\n      },\n    ],\n  },\n  {\n    value: 'jiangsu',\n    label: 'Jiangsu',\n    children: [\n      {\n        value: 'nanjing',\n        label: 'Nanjing',\n        children: [\n          {\n            value: 'zhonghuamen',\n            label: 'Zhong Hua Men',\n          },\n        ],\n      },\n    ],\n  },\n]\n\nconst onChange: CascaderEmits['change'] = (value) => {\n  console.log(value)\n}\nconst value = shallowRef()\n</script>\n\n<template>\n  <a-cascader v-model:value=\"value\" :options=\"options\" change-on-select @change=\"onChange\" />\n</template>"
+        },
+        {
+          "name": "_semantic",
+          "title": "",
+          "titleZh": "",
+          "description": "",
+          "descriptionZh": "",
+          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'selector', desc: t('selector') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'popup', desc: t('popup') },\n  { name: 'item', desc: t('item') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst options = [\n  {\n    value: 'contributors',\n    label: 'contributors',\n    children: [\n      { value: 'aojunhao123', label: 'aojunhao123' },\n      { value: 'thinkasany', label: 'thinkasany' },\n      { value: 'meet-student', label: 'meet-student' },\n    ],\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Cascader\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <a-cascader\n          prefix=\"prefix\"\n          :style=\"{ width: '200px' }\"\n          :options=\"options\"\n          :default-value=\"['contributors', 'thinkasany']\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set inline flex layout, relative positioning, padding and border styles",
+          "descriptionZh": "根元素，设置行内flex布局、相对定位、内边距和边框样式"
+        },
+        {
+          "key": "prefix",
+          "description": "Prefix element with layout and styling for prefix content",
+          "descriptionZh": "前缀元素，包含前缀内容的布局和样式"
+        },
+        {
+          "key": "selector",
+          "description": "Selector element, set padding, flex layout and selected item display styles",
+          "descriptionZh": "选择器元素，设置内边距、flex布局和选中项显示样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with layout and styling for suffix content like arrow icon, etc.",
+          "descriptionZh": "后缀元素，包含后缀内容的布局和样式，如箭头图标等"
+        },
+        {
+          "key": "popup",
+          "description": "Popup element, set absolute positioning, z-index, background color, border radius, shadow and dropdown options styles",
+          "descriptionZh": "弹出框元素，设置绝对定位、层级、背景色、圆角、阴影和下拉选项样式"
+        },
+        {
+          "key": "item",
+          "description": "Option element, set padding, background color, hover state and selected state styles",
+          "descriptionZh": "选项元素，设置内边距、背景色、悬停态和选中态样式"
         }
       ]
     },
@@ -5701,14 +5896,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Checkbox by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Checkbox 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CheckboxProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\nimport { ref } from 'vue'\n\nconst checked = ref(true)\nconst { token } = theme.useToken()\n\n// Object styles — 静态样式对象\nconst stylesObject: CheckboxProps['styles'] = {\n  icon: {\n    borderRadius: '6px',\n  },\n  label: {\n    color: 'blue',\n  },\n}\n\n// Function classes — 根据 checked 状态动态返回类名\nconst classesFn: CheckboxProps['classes'] = (info) => {\n  const base: Record<string, string> = {\n    root: 'checkbox-demo-root',\n    icon: 'checkbox-demo-icon',\n    label: 'checkbox-demo-label',\n  }\n  if (info.props.checked) {\n    return {\n      root: base.root,\n      icon: `${base.icon} checkbox-demo-icon-checked`,\n      label: `${base.label} checkbox-demo-label-checked`,\n    }\n  }\n  return base\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-checkbox :styles=\"stylesObject\">\n      Object styles\n    </a-checkbox>\n    <a-checkbox\n      v-model:checked=\"checked\"\n      :classes=\"classesFn\"\n    >\n      Function classes\n    </a-checkbox>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with inline-flex layout, baseline alignment, cursor style, reset styles and other basic checkbox container styles",
+          "descriptionZh": "根元素，包含行内 flex 布局、基线对齐、光标样式、重置样式等复选框容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Checkbox\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-checkbox :classes=\"classes\">\n        Checkbox\n      </a-checkbox>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Checkbox icon element with size, direction, background, border, border-radius, transitions, and checked state checkmark styles",
+          "descriptionZh": "选中框元素，包含尺寸、方向、背景色、边框、圆角、过渡动画，以及选中状态的勾选标记样式"
+        },
+        {
+          "key": "label",
+          "description": "Label text element with padding and spacing styles relative to the checkbox",
+          "descriptionZh": "文本元素，包含文本的内边距和与复选框的间距样式"
         }
       ]
     },
@@ -6048,14 +6252,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Collapse by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Collapse 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CollapseProps } from 'antdv-next'\nimport { h } from 'vue'\n\nconst text\n  = 'A dog is a type of domesticated animal. Known for its loyalty and faithfulness, it can be found as a welcome guest in many households across the world.'\n\nconst element = h('p', text)\n\nconst items = [\n  {\n    key: '1',\n    label: 'This is panel header 1',\n    content: element,\n  },\n  {\n    key: '2',\n    label: 'This is panel header 2',\n    content: element,\n  },\n  {\n    key: '3',\n    label: 'This is panel header 3',\n    content: element,\n  },\n]\n\nconst classes: CollapseProps['classes'] = {\n  root: 'demo-collapse-root',\n}\n\nconst stylesObject: CollapseProps['styles'] = {\n  root: {\n    backgroundColor: '#fafafa',\n    border: '1px solid #e0e0e0',\n    borderRadius: '8px',\n  },\n  header: {\n    backgroundColor: '#f0f0f0',\n    padding: '12px 16px',\n    color: '#141414',\n  },\n}\n\nconst stylesFn: CollapseProps['styles'] = (info) => {\n  if (info?.props?.size === 'large') {\n    return {\n      root: {\n        backgroundColor: '#fff',\n        border: '1px solid #696FC7',\n        borderRadius: '8px',\n      },\n      header: {\n        backgroundColor: '#F5EFFF',\n        padding: '12px 16px',\n        color: '#141414',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-collapse :items=\"items\" :classes=\"classes\" :styles=\"stylesObject\" :default-active-key=\"['1']\" />\n    <a-collapse :items=\"items\" :classes=\"classes\" :styles=\"stylesFn\" size=\"large\" :default-active-key=\"['2']\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with border, border-radius, background color and container styles that control the overall layout and appearance of collapse panels",
+          "descriptionZh": "根元素，包含折叠面板的边框、圆角、背景色等容器样式，控制面板的整体布局和外观"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { theme } from 'antdv-next'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n])\n\nconst { token } = theme.useToken()\n\nconst items = computed(() => [\n  {\n    key: '1',\n    label: 'This is panel header',\n    children: 'This is panel body',\n  },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Collapse\"\n    items-a-p-i=\"items\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ position: 'absolute', inset: 0, margin: `${token.marginXL}px` }\">\n        <a-collapse\n          :items=\"items\"\n          :default-active-key=\"['1']\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with flex layout, padding, color, line-height, cursor style, transition animations and other interactive styles for panel headers",
+          "descriptionZh": "头部元素，包含flex布局、内边距、颜色、行高、光标样式、过渡动画等面板头部的交互和样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with flex auto layout and margin styles for title text layout and typography",
+          "descriptionZh": "标题元素，包含flex自适应布局、右边距等标题文字的布局和排版样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with padding, color, background color and other styles for panel content area display",
+          "descriptionZh": "内容元素，包含内边距、颜色、背景色等面板内容区域的展示样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with font size, transition animations, rotation transforms and other styles and animations for expand/collapse arrows",
+          "descriptionZh": "图标元素，包含字体大小、过渡动画、旋转变换等展开收起箭头的样式和动效"
         }
       ]
     },
@@ -6403,14 +6626,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of ColorPicker by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或函数可以自定义 ColorPicker 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst classes = { root: 'custom-color-picker' }\n\nconst color = shallowRef('#1677ff')\nconst colorLarge = shallowRef('#722ed1')\n\nconst stylesObject = {\n  popup: {\n    root: {\n      border: '1px solid #fff',\n    },\n  },\n}\n\nfunction stylesFn(info: any) {\n  if (info?.props?.size === 'large') {\n    return {\n      popup: {\n        root: {\n          border: '1px solid #722ed1',\n        },\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-space size=\"middle\" wrap>\n    <a-color-picker\n      v-model:value=\"color\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    />\n    <a-color-picker\n      v-model:value=\"colorLarge\"\n      size=\"large\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n    />\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Trigger container with border styles, transition animations, size controls, displaying color block and text content",
+          "descriptionZh": "触发器容器，包含边框样式、过渡动画、尺寸控制等样式，显示颜色块和文本内容"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'body', desc: t('body') },\n  { name: 'content', desc: t('content') },\n  { name: 'description', desc: t('description') },\n  { name: 'popup.root', desc: t('popup.root') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\nconst body = document?.body\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"ColorPicker\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" :style=\"{ height: '300px' }\" align=\"flex-start\" gap=\"small\">\n        <a-color-picker\n          default-value=\"#1677ff\"\n          open\n          show-text\n          :get-popup-container=\"() => divRef || body\"\n          :styles=\"{ popup: { root: { zIndex: 1 } } }\"\n          :classes=\"classes\"\n        />\n        <a-color-picker :open=\"false\" allow-clear :classes=\"classes\" />\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "popup.root",
+          "description": "Popup panel root container with background color, shadow effects, color selection panel, slider controls and preset colors",
+          "descriptionZh": "弹出面板根容器，包含背景色、阴影效果、色彩选择面板、滑块控制和预设颜色等样式"
+        },
+        {
+          "key": "body",
+          "description": "Color block container with background color, border styles",
+          "descriptionZh": "色块容器，包含底色、边框等样式"
+        },
+        {
+          "key": "content",
+          "description": "Color block element with actual selected color styles",
+          "descriptionZh": "色块颜色元素，包含实际选择的颜色样式"
+        },
+        {
+          "key": "description",
+          "description": "Description text content with font styles and color",
+          "descriptionZh": "描述文本内容，包含字体样式、颜色等样式"
         }
       ]
     },
@@ -6624,7 +6866,8 @@
           "descriptionZh": "获取父级 `Provider` 的值。如 `DisabledContextProvider`、`SizeContextProvider`。",
           "code": "<script setup lang=\"ts\">\nimport type { ConfigProviderProps } from 'antdv-next'\nimport { ref } from 'vue'\nimport ConfigDisplay from './use-config-display.vue'\n\ntype SizeType = ConfigProviderProps['componentSize']\n\nconst componentSize = ref<SizeType>('small')\nconst disabled = ref(true)\n</script>\n\n<template>\n  <div>\n    <a-space>\n      <a-radio-group v-model:value=\"componentSize\">\n        <a-radio-button value=\"small\">\n          Small\n        </a-radio-button>\n        <a-radio-button value=\"middle\">\n          Middle\n        </a-radio-button>\n        <a-radio-button value=\"large\">\n          Large\n        </a-radio-button>\n      </a-radio-group>\n      <a-checkbox v-model:checked=\"disabled\">\n        Form disabled\n      </a-checkbox>\n    </a-space>\n    <a-divider />\n    <a-config-provider :component-size=\"componentSize\">\n      <div class=\"example\">\n        <a-form :disabled=\"disabled\">\n          <ConfigDisplay />\n        </a-form>\n      </div>\n    </a-config-provider>\n  </div>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "DatePicker",
@@ -7251,14 +7494,63 @@
           "description": "Custom `prefix` and `suffixIcon`.",
           "descriptionZh": "自定义前缀 `prefix` 和后缀图标 `suffixIcon`。",
           "code": "<script setup lang=\"ts\">\nimport type { Dayjs } from 'dayjs'\nimport { SmileOutlined } from '@antdv-next/icons'\nimport { h } from 'vue'\n\nconst smileIcon = h(SmileOutlined)\n\nfunction handleChange(date: Dayjs | (Dayjs | null)[] | null, dateString: string | string[] | null) {\n  console.log(date, dateString)\n}\n</script>\n\n<template>\n  <a-space vertical :size=\"12\">\n    <a-date-picker :suffix-icon=\"smileIcon\" @change=\"handleChange\" />\n    <a-date-picker :suffix-icon=\"smileIcon\" picker=\"month\" @change=\"handleChange\" />\n    <a-range-picker :suffix-icon=\"smileIcon\" @change=\"handleChange\" />\n    <a-date-picker :suffix-icon=\"smileIcon\" picker=\"week\" @change=\"handleChange\" />\n    <a-date-picker suffix-icon=\"ab\" @change=\"handleChange\" />\n    <a-date-picker suffix-icon=\"ab\" picker=\"month\" @change=\"handleChange\" />\n    <a-range-picker suffix-icon=\"ab\" @change=\"handleChange\" />\n    <a-date-picker suffix-icon=\"ab\" picker=\"week\" @change=\"handleChange\" />\n    <a-date-picker :prefix=\"smileIcon\" picker=\"week\" @change=\"handleChange\" />\n    <a-date-picker prefix=\"Event Period\" picker=\"week\" @change=\"handleChange\" />\n    <a-range-picker :prefix=\"smileIcon\" picker=\"week\" @change=\"handleChange\" />\n    <a-range-picker prefix=\"Event Period\" picker=\"week\" @change=\"handleChange\" />\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, padding, border-radius, transition animations and other basic styles for date picker container",
+          "descriptionZh": "根元素，包含相对定位、行内flex布局、内边距、边框圆角、过渡动画等日期选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { SmileOutlined } from '@antdv-next/icons'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'popup.root', desc: t('popup') },\n  { name: 'popup.container', desc: t('popup.container') },\n  { name: 'popup.header', desc: t('popup.header') },\n  { name: 'popup.body', desc: t('popup.body') },\n  { name: 'popup.content', desc: t('popup.content') },\n  { name: 'popup.item', desc: t('popup.item') },\n  { name: 'popup.footer', desc: t('popup.footer') },\n])\n\nconst type = ref<'Single' | 'Multiple'>('Single')\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    :component-name=\"type === 'Single' ? 'DatePicker' : 'DatePicker.RangePicker'\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" vertical :style=\"{ alignSelf: 'flex-start' }\" gap=\"middle\" align=\"center\">\n        <a-segmented\n          :options=\"['Single', 'Multiple']\"\n          :value=\"type\"\n          @change=\"(val: 'Single' | 'Multiple') => type = val\"\n        />\n        <a-date-picker\n          v-if=\"type === 'Single'\"\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-date-picker>\n        <a-range-picker\n          v-else\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-range-picker>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with flex layout and margin styles for prefix content layout",
+          "descriptionZh": "前缀元素，包含flex布局、右外边距等前缀内容的布局样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with relative positioning, width, color, font, line-height, transition animations and other core interactive styles for input field",
+          "descriptionZh": "输入框元素，包含相对定位、宽度、颜色、字体、行高、过渡动画等输入框的核心交互样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with flex layout, color, line-height, pointer events, transition animations and other styles for suffix content",
+          "descriptionZh": "后缀元素，包含flex布局、颜色、行高、指针事件、过渡动画等后缀内容的样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup element",
+          "descriptionZh": "弹出框元素"
+        },
+        {
+          "key": "popup.container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "popup.header",
+          "description": "Popup header element with navigation buttons, month/year selectors and other header control area layout and styles",
+          "descriptionZh": "弹出框头部元素，包含导航按钮、月份年份选择器等头部控制区域的布局和样式"
+        },
+        {
+          "key": "popup.body",
+          "description": "Popup body element with container layout and styles for date panel table",
+          "descriptionZh": "弹出框主体元素，包含日期面板表格的容器布局和样式"
+        },
+        {
+          "key": "popup.content",
+          "description": "Popup content element with width, border, cell and other content display styles for date table",
+          "descriptionZh": "弹出框内容元素，包含日期表格的宽度、边框、单元格等内容展示样式"
+        },
+        {
+          "key": "popup.item",
+          "description": "Popup item element with size, background, border-radius, hover state, selected state and other interactive styles for date cells",
+          "descriptionZh": "弹出框单项元素，包含日期单元格的尺寸、背景色、边框圆角、悬停态、选中态等交互样式"
+        },
+        {
+          "key": "popup.footer",
+          "description": "Popup footer element with layout styles for bottom operation area including confirm/cancel buttons and shortcuts",
+          "descriptionZh": "弹出框底部元素，包含确认取消按钮、快捷选择等底部操作区域的布局样式"
         }
       ]
     },
@@ -7504,14 +7796,38 @@
           "description": "Display of the entire line.",
           "descriptionZh": "整行的展示。",
           "code": "<script setup lang=\"ts\">\nimport type { DescriptionsItemType } from 'antdv-next'\n\nconst items: DescriptionsItemType[] = [\n  {\n    label: 'UserName',\n    content: 'Zhou Maomao',\n  },\n  {\n    label: 'Live',\n    span: 'filled', // span = 2\n    content: 'Hangzhou, Zhejiang',\n  },\n  {\n    label: 'Remark',\n    span: 'filled', // span = 3\n    content: 'empty',\n  },\n  {\n    label: 'Address',\n    span: 1, // span will be 3 and warning for span is not align to the end\n    content: 'No. 18, Wantang Road, Xihu District, Hangzhou, Zhejiang, China',\n  },\n]\n</script>\n\n<template>\n  <a-descriptions title=\"User Info\" :items=\"items\" bordered />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with basic styles, reset styles, border styles, layout direction and other overall styles for description list container",
+          "descriptionZh": "根元素，包含描述列表容器的基础样式、重置样式、边框样式、布局方向等整体样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n\nconst bordered = ref(false)\n\nconst items = [\n  { key: '1', label: 'Telephone', children: '1810000000' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Descriptions\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ width: '100%', height: '100%' }\">\n        <a-switch v-model:checked=\"bordered\" />\n        Toggle Border\n        <a-divider />\n        <a-descriptions\n          title=\"User Info\"\n          :items=\"items\"\n          :bordered=\"bordered\"\n          :classes=\"classes\"\n        >\n          <template #extra>\n            <a-button type=\"primary\">\n              Edit\n            </a-button>\n          </template>\n        </a-descriptions>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with flex layout, alignment, bottom margin and other layout and style controls for header area",
+          "descriptionZh": "头部元素，包含flex布局、对齐方式、下边距等头部区域的布局和样式控制"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text ellipsis, flex ratio, color, font weight, font size, line height and other title text styles",
+          "descriptionZh": "标题元素，包含文本省略、flex占比、颜色、字体权重、字体大小、行高等标题文字样式"
+        },
+        {
+          "key": "extra",
+          "description": "Extra content element with left margin, color, font size and other styles for additional operation area",
+          "descriptionZh": "额外内容元素，包含左边距、颜色、字体大小等额外操作区域的样式"
+        },
+        {
+          "key": "label",
+          "description": "Label element with color, font weight, font size, line height, text align, colon styles and other label text styles",
+          "descriptionZh": "标签元素，包含颜色、字体权重、字体大小、行高、文本对齐、冒号样式等标签文字的样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with table cell layout, color, font size, line height, word break and other content display styles",
+          "descriptionZh": "内容元素，包含表格单元格布局、颜色、字体大小、行高、文字换行等内容展示样式"
         }
       ]
     },
@@ -7680,14 +7996,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of divider by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义分割线的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { DividerProps } from 'antdv-next'\n\nconst classesObject: DividerProps['classes'] = {\n  root: 'demo-divider-root',\n  content: 'demo-divider-content',\n  rail: 'demo-divider-rail',\n}\n\nconst classesFn: DividerProps['classes'] = (info) => {\n  if (info?.props?.titlePlacement === 'start') {\n    return {\n      root: 'demo-divider-root--start',\n    }\n  }\n  return {\n    root: 'demo-divider-root--default',\n  }\n}\n\nconst stylesObject: DividerProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed' },\n  content: { fontStyle: 'italic' },\n  rail: { opacity: 0.85 },\n}\n\nconst stylesFn: DividerProps['styles'] = (info) => {\n  if (info?.props?.size === 'small') {\n    return {\n      root: { opacity: 0.6, cursor: 'default' },\n    }\n  }\n  return {\n    root: { backgroundColor: '#fafafa', borderColor: '#d9d9d9' },\n  }\n}\n</script>\n\n<template>\n  <div>\n    <a-divider :classes=\"classesObject\">\n      classes Object\n    </a-divider>\n    <a-divider title-placement=\"start\" :classes=\"classesFn\">\n      classes Function\n    </a-divider>\n    <a-divider :styles=\"stylesObject\">\n      styles Object\n    </a-divider>\n    <a-divider size=\"small\" :styles=\"stylesFn\">\n      styles Function\n    </a-divider>\n  </div>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with border-top style, divider styling and other basic divider container styles",
+          "descriptionZh": "根元素，包含边框顶部样式、分隔线样式等分割线容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'rail', desc: t('rail') },\n  { name: 'content', desc: t('content') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Divider\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div>\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider :classes=\"classes\" />\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider :classes=\"classes\">\n          Solid\n        </a-divider>\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider title-placement=\"left\" variant=\"dotted\" :classes=\"classes\">\n          Dotted\n        </a-divider>\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider title-placement=\"right\" variant=\"dashed\" :classes=\"classes\">\n          Dashed\n        </a-divider>\n        These\n        <a-divider orientation=\"vertical\" :classes=\"classes\" />\n        are\n        <a-divider orientation=\"vertical\" :classes=\"classes\" />\n        vertical\n        <a-divider orientation=\"vertical\" :classes=\"classes\" />\n        Dividers\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "content",
+          "description": "Content element with inline-block display, padding and other divider text content styles",
+          "descriptionZh": "内容元素，包含行内块显示、内边距等分割线文本内容的样式"
+        },
+        {
+          "key": "rail",
+          "description": "Background rail element with border-top style and other divider connection line styles",
+          "descriptionZh": "背景条元素，包含边框顶部样式等分割线连接条的样式"
         }
       ]
     },
@@ -8064,14 +8389,58 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Drawer by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Drawer 组件的 [语义化结构](#semantic-dom) 样式。",
           "code": "<script setup lang=\"ts\">\nimport type { DrawerProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\nimport { ref } from 'vue'\n\nconst { token } = theme.useToken()\nconst open = ref(false)\nconst openFn = ref(false)\n\nconst classes: DrawerProps['classes'] = {\n  header: 'demo-drawer-header',\n  body: 'demo-drawer-body',\n}\n\nconst stylesObject: DrawerProps['styles'] = {\n  body: {\n    backgroundColor: '#f5f5f5',\n  },\n  footer: {\n    backgroundColor: '#fafafa',\n  },\n}\n\nconst stylesFn: DrawerProps['styles'] = (info) => {\n  if (info?.props?.placement === 'right') {\n    return {\n      mask: {\n        backgroundColor: 'rgba(0, 0, 0, 0.2)',\n      },\n      wrapper: {\n        boxShadow: '0 8px 24px rgba(0, 0, 0, 0.15)',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-button @click=\"open = true\">\n      Object Style\n    </a-button>\n    <a-button type=\"primary\" @click=\"openFn = true\">\n      Function Style\n    </a-button>\n  </a-flex>\n\n  <a-drawer\n    v-model:open=\"open\"\n    title=\"Custom Style Drawer\"\n    :classes=\"classes\"\n    :styles=\"stylesObject\"\n    @close=\"open = false\"\n  >\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n  </a-drawer>\n\n  <a-drawer\n    v-model:open=\"openFn\"\n    title=\"Custom Function Drawer\"\n    :classes=\"classes\"\n    :styles=\"stylesFn\"\n    @close=\"openFn = false\"\n  >\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n  </a-drawer>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with fixed positioning, z-index control, pointer events, color and other basic styles and layout control for drawer container",
+          "descriptionZh": "根元素，包含固定定位、层级控制、指针事件、颜色等抽屉容器的基础样式和布局控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'mask', desc: t('mask'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n  { name: 'dragger', desc: t('dragger'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Drawer\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-drawer\n        title=\"Title\"\n        placement=\"right\"\n        open\n        :get-container=\"false\"\n        :size=\"300\"\n        :resizable=\"{}\"\n        :classes=\"classes\"\n      >\n        <template #footer>\n          <a-typography-link>Footer</a-typography-link>\n        </template>\n        <template #extra>\n          <a-button>Cancel</a-button>\n        </template>\n        <p>Some contents...</p>\n      </a-drawer>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "mask",
+          "description": "Mask element with absolute positioning, z-index, background color, pointer events and other mask layer styles and interaction controls",
+          "descriptionZh": "遮罩层元素，包含绝对定位、层级、背景色、指针事件等遮罩层的样式和交互控制"
+        },
+        {
+          "key": "section",
+          "description": "Drawer container element with flex layout, width/height, overflow control, background color, pointer events and other drawer body styles",
+          "descriptionZh": "Drawer 容器元素，包含flex布局、宽高、溢出控制、背景色、指针事件等抽屉主体的样式"
+        },
+        {
+          "key": "header",
+          "description": "Header element with flex layout, alignment, padding, font size, line height, bottom border and other header area styles",
+          "descriptionZh": "头部元素，包含flex布局、对齐方式、内边距、字体大小、行高、下边框等头部区域的样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with flex ratio, minimum size, padding, overflow scroll and other content area display and layout styles",
+          "descriptionZh": "内容元素，包含flex占比、最小尺寸、内边距、溢出滚动等内容区域的展示和布局样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with flex shrink, padding, top border and other bottom operation area styles",
+          "descriptionZh": "底部元素，包含flex收缩、内边距、上边框等底部操作区域的样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with flex ratio, margin, font weight, font size, line height and other title text styles",
+          "descriptionZh": "标题元素，包含flex占比、外边距、字体权重、字体大小、行高等标题文字的样式"
+        },
+        {
+          "key": "extra",
+          "description": "Extra element with flex fixed layout and other additional operation content style controls",
+          "descriptionZh": "额外元素，包含flex固定布局等额外操作内容的样式控制"
+        },
+        {
+          "key": "dragger",
+          "description": "Dragger element used to resize the drawer, with absolute positioning, transparent background, pointer events control, hover state styles, and dragging state styles",
+          "descriptionZh": "拖拽元素，用于调整抽屉大小的拖拽手柄，包含绝对定位、背景透明、指针事件控制、hover状态样式、拖拽状态样式等"
+        },
+        {
+          "key": "close",
+          "description": "Close button element with basic button styling",
+          "descriptionZh": "关闭按钮元素，包含按钮的基础样式"
         }
       ]
     },
@@ -8428,14 +8797,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of the Dropdown by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Dropdown 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { DropdownProps, MenuItemType } from 'antdv-next'\nimport { DownOutlined, LogoutOutlined, SettingOutlined } from '@antdv-next/icons'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst items: MenuItemType[] = [\n  {\n    key: '1',\n    label: 'Profile',\n  },\n  {\n    key: '2',\n    label: 'Settings',\n    icon: SettingOutlined,\n  },\n  {\n    type: 'divider',\n  },\n  {\n    key: '3',\n    label: 'Logout',\n    icon: LogoutOutlined,\n    danger: true,\n  },\n]\n\nconst classes: DropdownProps['classes'] = {\n  root: 'demo-dropdown-root',\n}\n\nconst objectStyles: DropdownProps['styles'] = {\n  root: {\n    backgroundColor: '#ffffff',\n    border: '1px solid #d9d9d9',\n    borderRadius: '4px',\n  },\n  item: {\n    padding: '8px 12px',\n    fontSize: '14px',\n  },\n  itemTitle: {\n    fontWeight: '500',\n  },\n  itemIcon: {\n    color: '#1890ff',\n    marginRight: '8px',\n  },\n  itemContent: {\n    backgroundColor: 'transparent',\n  },\n}\n\nconst functionStyles: DropdownProps['styles'] = (info) => {\n  const isClick = info.props.trigger?.includes('click')\n  if (isClick) {\n    return {\n      root: {\n        borderColor: '#1890ff',\n        borderRadius: '8px',\n      },\n    }\n  }\n  return {}\n}\n\nconst sharedProps: DropdownProps = {\n  menu: { items },\n  placement: 'bottomLeft',\n  classes,\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\" wrap=\"wrap\">\n    <a-space direction=\"vertical\" size=\"large\">\n      <a-dropdown v-bind=\"sharedProps\" :styles=\"objectStyles\">\n        <a-button>\n          <a-space>\n            Object Style\n            <DownOutlined />\n          </a-space>\n        </a-button>\n      </a-dropdown>\n\n      <a-dropdown v-bind=\"sharedProps\" :styles=\"functionStyles\" :trigger=\"['click']\">\n        <a-button type=\"primary\">\n          <a-space>\n            Function Style\n            <DownOutlined />\n          </a-space>\n        </a-button>\n      </a-dropdown>\n    </a-space>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element of dropdown, sets positioning, z-index and container styles",
+          "descriptionZh": "dropdown 的根元素，设置定位、层级和容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { DeleteOutlined, DownOutlined, EditOutlined, SaveOutlined } from '@antdv-next/icons'\nimport { computed, h, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'itemTitle', desc: t('itemTitle') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst items: any[] = [\n  {\n    key: '1',\n    type: 'group',\n    label: 'Group title',\n    children: [\n      { key: '1-1', label: '1st menu item', icon: h(SaveOutlined) },\n      { key: '1-2', label: '2nd menu item', icon: h(EditOutlined) },\n    ],\n  },\n  {\n    key: 'SubMenu',\n    label: 'SubMenu',\n    children: [\n      {\n        key: 'g1',\n        label: 'Item 1',\n        type: 'group',\n        children: [\n          { key: '1', label: 'Option 1' },\n          { key: '2', label: 'Option 2' },\n        ],\n      },\n    ],\n  },\n  { key: '3', type: 'divider' },\n  { key: '4', label: 'Delete', icon: h(DeleteOutlined), danger: true },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Dropdown\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ height: '120px', position: 'absolute', top: '50px' }\">\n        <a-dropdown\n          open\n          :menu=\"{ items }\"\n          :styles=\"{ root: { width: '200px', zIndex: 1 } }\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        >\n          <a @click.prevent>\n            <a-space>\n              Hover me\n              <DownOutlined />\n            </a-space>\n          </a>\n        </a-dropdown>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "itemTitle",
+          "description": "Title content area of dropdown option, sets layout and text styles",
+          "descriptionZh": "dropdown 选项的标题内容区域，设置布局和文字样式"
+        },
+        {
+          "key": "item",
+          "description": "Individual dropdown option element, sets interaction states and background styles",
+          "descriptionZh": "dropdown 的单个选项元素，设置选项的交互状态和背景样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Main content area of dropdown option, sets content layout and link styles",
+          "descriptionZh": "dropdown 选项的主要内容区域，设置内容布局和链接样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Icon area of dropdown option, sets icon size and spacing styles",
+          "descriptionZh": "dropdown 选项的图标区域，设置图标的尺寸和间距样式"
         }
       ]
     },
@@ -8545,14 +8933,28 @@
           "description": "Hide default description.",
           "descriptionZh": "隐藏默认描述。",
           "code": "<template>\n  <a-empty :description=\"false\" />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets text alignment, font and line height styles",
+          "descriptionZh": "根元素，设置文本对齐、字体和行高样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'image', desc: t('image'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Empty\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-empty\n        :image=\"1\"\n        :styles=\"{ image: { height: '60px' } }\"\n        :classes=\"classes\"\n      >\n        <template #description>\n          <a-typography-text>\n            Customize <a href=\"#API\">Description</a>\n          </a-typography-text>\n        </template>\n        <a-button type=\"primary\">\n          Create Now\n        </a-button>\n      </a-empty>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "image",
+          "description": "Image element, sets height, opacity, margin and image styles",
+          "descriptionZh": "图标元素，设置高度、透明度、边距和图片样式"
+        },
+        {
+          "key": "description",
+          "description": "Description element, sets text color styles",
+          "descriptionZh": "描述元素，设置文本颜色样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element, sets top margin and action button styles",
+          "descriptionZh": "底部元素，设置顶部边距和操作按钮样式"
         }
       ]
     },
@@ -8662,7 +9064,8 @@
           "descriptionZh": "嵌套使用，可以实现更复杂的布局。",
           "code": "<script setup lang=\"ts\">\nimport type { CSSProperties } from 'vue'\n\nconst cardStyle: CSSProperties = {\n  width: '620px',\n}\nconst imgStyle: CSSProperties = {\n  display: 'block',\n  width: '273px',\n}\n</script>\n\n<template>\n  <a-card :style=\"cardStyle\" :styles=\"{ body: { padding: 0, overflow: 'hidden' } }\">\n    <a-flex justify=\"space-between\">\n      <img\n        alt=\"avatar\"\n        src=\"https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png\"\n        :style=\"imgStyle\"\n      >\n      <a-flex vertical align=\"flex-end\" justify=\"space-between\" :style=\"{ padding: '32px' }\">\n        <a-typography>\n          <a-typography-title :level=\"3\">\n            “antd is an enterprise-class UI design language and Vue UI library.”\n          </a-typography-title>\n        </a-typography>\n        <a-button type=\"primary\" href=\"https://antdv.com\" target=\"_blank\">\n          Get Start\n        </a-button>\n      </a-flex>\n    </a-flex>\n  </a-card>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "FloatButton",
@@ -9071,22 +9474,63 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of FloatButton by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 FloatButton 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { FloatButtonProps } from 'antdv-next'\nimport { QuestionCircleOutlined } from '@antdv-next/icons'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: FloatButtonProps['classes'] = {\n  root: 'demo-float-button-root',\n  content: 'demo-float-button-content',\n}\n\nconst stylesObject: FloatButtonProps['styles'] = {\n  root: {\n    boxShadow: '0 1px 2px 0 rgba(0,0,0,0.05)',\n  },\n}\n\nconst stylesFn: FloatButtonProps['styles'] = (info) => {\n  if (info?.props?.type === 'primary') {\n    return {\n      root: {\n        backgroundColor: '#171717',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-float-button-group shape=\"circle\" style=\"inset-inline-end: 94px;\">\n    <a-float-button\n      type=\"primary\"\n      :classes=\"classes\"\n      href=\"https://ant.design/index-cn\"\n      :styles=\"stylesFn\"\n    >\n      <template #tooltip>\n        <div>custom style class</div>\n      </template>\n    </a-float-button>\n    <a-float-button\n      type=\"default\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n    >\n      <template #icon>\n        <QuestionCircleOutlined />\n      </template>\n    </a-float-button>\n  </a-float-button-group>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with float button base styles, shape size, type theme, fixed positioning, z-index, shadow, spacing and other container styles",
+          "descriptionZh": "根元素，设置悬浮按钮的基础样式、形状尺寸、类型主题、固定定位、层级、阴影、间距等容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { QuestionCircleOutlined } from '@antdv-next/icons'\nimport { FloatButton } from 'antdv-next'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst PurePanel = (FloatButton as any)._InternalPanelDoNotUseOrYouWillBeFired\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'icon', desc: t('icon') },\n  { name: 'content', desc: t('content') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"FloatButton\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <PurePanel\n        type=\"primary\"\n        shape=\"square\"\n        content=\"HELP\"\n        :classes=\"classes\"\n      >\n        <template #icon>\n          <QuestionCircleOutlined />\n        </template>\n      </PurePanel>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "content",
+          "description": "Content element with button text content font size, color, alignment, line wrap and other text display styles",
+          "descriptionZh": "内容元素，设置按钮内文字内容的字体大小、颜色、对齐、换行等文本显示样式"
         },
         {
-          "name": "_semantic_group",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AlertOutlined, BugOutlined, BulbOutlined } from '@antdv-next/icons'\nimport { FloatButton } from 'antdv-next'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst PurePanel = (FloatButton as any)._InternalPanelDoNotUseOrYouWillBeFired\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('group.root') },\n  { name: 'list', desc: t('group.list') },\n  { name: 'item', desc: t('group.item') },\n  { name: 'itemIcon', desc: t('group.itemIcon') },\n  { name: 'itemContent', desc: t('group.itemContent') },\n  { name: 'trigger', desc: t('group.trigger') },\n  { name: 'triggerIcon', desc: t('group.triggerIcon') },\n  { name: 'triggerContent', desc: t('group.triggerContent') },\n])\n\nconst items = [\n  {\n    icon: h(AlertOutlined),\n    content: 'warn',\n  },\n  {\n    icon: h(BugOutlined),\n    content: 'bug',\n  },\n  {\n    icon: h(BulbOutlined),\n    content: 'idea',\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"FloatButton\"\n    :semantics=\"semantics\"\n    :style=\"{ paddingTop: '100px' }\"\n  >\n    <template #default=\"{ classes }\">\n      <PurePanel\n        type=\"primary\"\n        shape=\"square\"\n        :items=\"items\"\n        trigger=\"hover\"\n        :open=\"true\"\n        content=\"back\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element with button icon size, color, line height, alignment and other icon display styles",
+          "descriptionZh": "图标元素，设置按钮内图标的尺寸、颜色、行高、对齐等图标显示样式"
+        },
+        {
+          "key": "group.root",
+          "description": "Root element with float button group container styles, fixed positioning, z-index, padding, gap, direction mode and other combined layout styles",
+          "descriptionZh": "根元素，设置悬浮按钮组的容器样式、固定定位、层级、内边距、间距、方向模式等组合布局样式"
+        },
+        {
+          "key": "group.list",
+          "description": "List element with button group list flex layout, border radius, shadow, animation transition, vertical alignment and other list container styles",
+          "descriptionZh": "列表元素，设置按钮组列表的Flex布局、圆角、阴影、动画过渡、垂直对齐等列表容器样式"
+        },
+        {
+          "key": "group.item",
+          "description": "Item element with individual float button styles, size, shape, type, state, icon content and other button base styles",
+          "descriptionZh": "列表项元素，设置单个悬浮按钮的样式、尺寸、形状、类型、状态、图标内容等按钮基础样式"
+        },
+        {
+          "key": "group.itemIcon",
+          "description": "Item icon element with float button icon size, color, alignment and other icon display styles",
+          "descriptionZh": "列表项图标元素，设置悬浮按钮内图标的尺寸、颜色、对齐等图标显示样式"
+        },
+        {
+          "key": "group.itemContent",
+          "description": "Item content element with float button text content, badge, description and other content area styles",
+          "descriptionZh": "列表项内容元素，设置悬浮按钮内文字内容、徽标、描述等内容区域样式"
+        },
+        {
+          "key": "group.trigger",
+          "description": "Trigger element with menu mode trigger button styles, shape, icon, hover state, expand/collapse state and other interaction styles",
+          "descriptionZh": "触发元素，设置菜单模式下触发按钮的样式、形状、图标、悬停态、展开收起状态等交互样式"
+        },
+        {
+          "key": "group.triggerIcon",
+          "description": "Trigger icon element with trigger button icon styles, rotation animation, toggle state and other icon interaction styles",
+          "descriptionZh": "触发图标元素，设置触发按钮内图标的样式、旋转动画、切换状态等图标交互样式"
+        },
+        {
+          "key": "group.triggerContent",
+          "description": "Trigger content element with trigger button content area text, identifier, state indicator and other content styles",
+          "descriptionZh": "触发内容元素，设置触发按钮内容区域的文字、标识、状态指示等内容样式"
         }
       ]
     },
@@ -10016,14 +10460,23 @@
           "description": "Custom semantic dom styling.",
           "descriptionZh": "自定义语义化结构的样式和类。",
           "code": "<script setup lang=\"ts\">\nimport { reactive } from 'vue'\n\nconst model = reactive({\n  name: '',\n  email: '',\n})\n\nconst classes = {\n  root: 'form-demo-root',\n  label: 'form-demo-label',\n  content: 'form-demo-content',\n}\n\nconst styles = {\n  root: { background: '#f6f7fb', padding: '16px', borderRadius: '8px' },\n}\n</script>\n\n<template>\n  <a-form\n    :model=\"model\"\n    layout=\"vertical\"\n    :classes=\"classes\"\n    :styles=\"styles\"\n    style=\"max-width: 600px\"\n  >\n    <a-form-item label=\"Name\" name=\"name\" :rules=\"[{ required: true }]\">\n      <a-input v-model:value=\"model.name\" />\n    </a-form-item>\n    <a-form-item label=\"Email\" name=\"email\" :rules=\"[{ type: 'email' }]\">\n      <a-input v-model:value=\"model.email\" />\n    </a-form-item>\n    <a-form-item :label=\"null\">\n      <a-button type=\"primary\">\n        Submit\n      </a-button>\n    </a-form-item>\n  </a-form>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with form item margin-bottom, vertical-align, transitions, hidden states, error/warning states and other basic form item container styles",
+          "descriptionZh": "根元素，包含表单项的底边距、垂直对齐、过渡动画、隐藏状态、错误警告状态等表单项容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Form\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-form\n        name=\"basic\"\n        :label-col=\"{ span: 8 }\"\n        :wrapper-col=\"{ span: 16 }\"\n        :style=\"{ maxWidth: '600px' }\"\n        :initial-values=\"{ remember: true }\"\n        autocomplete=\"off\"\n        :classes=\"classes\"\n      >\n        <a-form-item\n          label=\"Username\"\n          name=\"username\"\n          :rules=\"[{ required: true, message: 'Please input your username!' }]\"\n        >\n          <a-input />\n        </a-form-item>\n        <a-form-item\n          label=\"Password\"\n          name=\"password\"\n          :rules=\"[{ required: true, message: 'Please input your password!' }]\"\n        >\n          <a-input-password />\n        </a-form-item>\n      </a-form>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "label",
+          "description": "Label element with flex layout, overflow hidden, whitespace nowrap, text alignment, vertical alignment, plus label color, font size, height, required marks and other label display styles",
+          "descriptionZh": "标签元素，包含 flex 布局、溢出隐藏、文本不换行、文本对齐、垂直对齐，以及标签的颜色、字体大小、高度、必填标记等标签显示样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with form content area layout, styling and control container related styles",
+          "descriptionZh": "内容元素，包含表单内容区域的布局、样式和控件容器的相关样式"
         }
       ]
     },
@@ -10301,7 +10754,8 @@
           "descriptionZh": "使用 `useBreakpoint` Hook 实现个性化布局，其中 `xs` 仅当满足最小宽度时生效。",
           "code": "<script setup lang=\"ts\">\nimport { useBreakpoint } from 'antdv-next'\nimport { computed } from 'vue'\n\nconst screens = useBreakpoint()\nconst screenKeys = computed(() => Object.entries(screens.value ?? {}).filter(screen => !!screen[1]))\n</script>\n\n<template>\n  Current break point:\n  <div class=\"gap-2 inline-flex\">\n    <template v-for=\"item in screenKeys\" :key=\"item[0]\">\n      <a-tag color=\"blue\">\n        {{ item[0] }}\n      </a-tag>\n    </template>\n  </div>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Icon",
@@ -10364,7 +10818,8 @@
           "descriptionZh": "`scriptUrl` 可引用多个资源，用户可灵活的管理 [iconfont.cn](http://iconfont.cn/) 图标。如果资源的图标出现重名，会按照数组顺序进行覆盖。",
           "code": "<script setup lang=\"ts\">\nimport { createFromIconfontCN } from '@antdv-next/icons'\n\nconst IconFont = createFromIconfontCN({\n  scriptUrl: [\n    '//at.alicdn.com/t/font_1788044_0dwu4guekcwr.js', // icon-javascript, icon-java, icon-shoppingcart (overridden)\n    '//at.alicdn.com/t/font_1788592_a5xf2bdic3u.js', // icon-shoppingcart, icon-python\n  ],\n})\n</script>\n\n<template>\n  <a-space>\n    <IconFont type=\"icon-javascript\" />\n    <IconFont type=\"icon-java\" />\n    <IconFont type=\"icon-shoppingcart\" />\n    <IconFont type=\"icon-python\" />\n  </a-space>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Image",
@@ -10591,14 +11046,48 @@
           "description": "Nested in the modal.",
           "descriptionZh": "嵌套在弹框当中使用。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst show1 = ref(false)\nconst show2 = ref(false)\nconst show3 = ref(false)\n\nfunction handlePreviewGroupChange(current: number, prev: number) {\n  console.log(`current index: ${current}, prev index: ${prev}`)\n}\n</script>\n\n<template>\n  <a-button @click=\"show1 = true\">\n    showModal\n  </a-button>\n  <a-modal\n    v-model:open=\"show1\"\n    @cancel=\"show1 = false\"\n    @ok=\"show1 = false\"\n  >\n    <a-button @click=\"show2 = true\">\n      test2\n    </a-button>\n    <a-modal\n      v-model:open=\"show2\"\n      @cancel=\"show2 = false\"\n      @ok=\"show2 = false\"\n    >\n      <a-button @click=\"show3 = true\">\n        test3\n      </a-button>\n      <a-modal\n        v-model:open=\"show3\"\n        @cancel=\"show3 = false\"\n        @ok=\"show3 = false\"\n      >\n        <a-image\n          :width=\"200\"\n          alt=\"svg image\"\n          src=\"https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg\"\n        />\n        <a-divider />\n        <a-image-preview-group\n          :preview=\"{\n            onChange: handlePreviewGroupChange,\n          }\"\n        >\n          <a-image\n            :width=\"200\"\n            alt=\"svg image\"\n            src=\"https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg\"\n          />\n          <a-image\n            :width=\"200\"\n            src=\"https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg\"\n          />\n        </a-image-preview-group>\n      </a-modal>\n    </a-modal>\n  </a-modal>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets relative positioning and inline-block layout styles",
+          "descriptionZh": "根元素，设置相对定位和行内块布局样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { theme } from 'antdv-next'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'image', desc: t('image') },\n  { name: 'cover', desc: t('cover') },\n  { name: 'popup.root', desc: t('popup.root') },\n  { name: 'popup.mask', desc: t('popup.mask') },\n  { name: 'popup.body', desc: t('popup.body') },\n  { name: 'popup.footer', desc: t('popup.footer') },\n  { name: 'popup.actions', desc: t('popup.actions') },\n])\n\nconst { token } = theme.useToken()\nconst holderRef = ref<HTMLDivElement | null>(null)\n\nconst previewItems = [\n  'https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg',\n  'https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg',\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Image\"\n    :padding=\"false\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical align=\"center\" :style=\"{ minHeight: '100%', width: '100%' }\">\n        <a-flex :style=\"{ padding: `${token.padding}px`, flex: 'none' }\" justify=\"center\">\n          <a-image\n            :width=\"200\"\n            src=\"https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png\"\n            :classes=\"classes\"\n            :preview=\"{ getContainer: () => holderRef! }\"\n          />\n        </a-flex>\n        <div ref=\"holderRef\" :style=\"{ flex: 1, position: 'relative', minHeight: '500px', width: '100%' }\">\n          <a-image-preview-group\n            :items=\"previewItems\"\n            :classes=\"classes\"\n            :styles=\"{ popup: { root: { position: 'absolute' } } }\"\n            :preview=\"{ getContainer: () => holderRef!, open: true }\"\n          />\n        </div>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "image",
+          "description": "Image element, sets width, height and vertical alignment styles",
+          "descriptionZh": "图片元素，设置宽度、高度和垂直对齐样式"
+        },
+        {
+          "key": "cover",
+          "description": "Image hover display prompt element, sets absolute positioning, background color, opacity and transition animation styles",
+          "descriptionZh": "悬浮图片显示的提示元素，设置绝对定位、背景色、透明度和过渡动画样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Preview root element, sets fixed positioning, z-index and background mask styles",
+          "descriptionZh": "预览根元素，设置固定定位、层级和背景遮罩样式"
+        },
+        {
+          "key": "popup.mask",
+          "description": "Preview mask element, sets absolute positioning and semi-transparent background styles",
+          "descriptionZh": "预览遮罩元素，设置绝对定位和半透明背景样式"
+        },
+        {
+          "key": "popup.body",
+          "description": "Preview body element, sets flex layout, center alignment and pointer event styles",
+          "descriptionZh": "预览内容元素，设置flex布局、居中对齐和指针事件样式"
+        },
+        {
+          "key": "popup.footer",
+          "description": "Preview footer element, sets absolute positioning, center layout and bottom operation area styles",
+          "descriptionZh": "预览页脚元素，设置绝对定位、居中布局和底部操作区域样式"
+        },
+        {
+          "key": "popup.actions",
+          "description": "Preview actions group element, sets flex layout, background color, border radius and action button styles",
+          "descriptionZh": "预览操作组元素，设置flex布局、背景色、圆角和操作按钮样式"
         }
       ]
     },
@@ -11321,46 +11810,68 @@
           "description": "You can customize the [semantic dom](#semantic-input) style of Input by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Input 的[语义化结构](#semantic-input)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { InputOTPProps, InputPasswordProps, InputProps, InputSearchProps, TextAreaProps } from 'antdv-next'\n\nconst classes: InputProps['classes'] = {\n  root: 'effect',\n}\n\nconst stylesFn: InputProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      root: {\n        borderColor: '#696FC7',\n      },\n    } satisfies InputProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnTextArea: TextAreaProps['styles'] = (info) => {\n  if (info.props.showCount) {\n    return {\n      root: { borderColor: '#BDE3C3' },\n      textarea: { resize: 'none' },\n      count: { color: '#BDE3C3' },\n    } satisfies TextAreaProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnPassword: InputPasswordProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      root: {\n        borderColor: '#F5D3C4',\n      },\n    } satisfies InputPasswordProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnOTP: InputOTPProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      input: {\n        borderColor: '#6E8CFB',\n        width: '32px',\n      },\n    } satisfies InputOTPProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnSearch: InputSearchProps['styles'] = (info) => {\n  if (info.props.size === 'large') {\n    return {\n      root: { color: '#4DA8DA' },\n      input: { color: '#4DA8DA', borderColor: '#4DA8DA' },\n      prefix: { color: '#4DA8DA' },\n      suffix: { color: '#4DA8DA' },\n      count: { color: '#4DA8DA' },\n      button: {\n        root: { color: '#4DA8DA', borderColor: '#4DA8DA' },\n        icon: { color: '#4DA8DA' },\n      },\n    } satisfies InputSearchProps['styles']\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-input :classes=\"classes\" placeholder=\"Object\" name=\"input-object\" />\n    <a-input :classes=\"classes\" :styles=\"stylesFn\" placeholder=\"Function\" size=\"middle\" name=\"input-fn\" />\n    <a-textarea :classes=\"classes\" :styles=\"stylesFnTextArea\" placeholder=\"Textarea\" show-count name=\"textarea-fn\" />\n    <a-input-password :classes=\"classes\" :styles=\"stylesFnPassword\" placeholder=\"Password\" size=\"middle\" name=\"password-fn\" />\n    <a-input-otp :classes=\"classes\" :styles=\"stylesFnOTP\" size=\"middle\" :length=\"6\" separator=\"*\" name=\"otp-fn\" />\n    <a-input-search :classes=\"classes\" :styles=\"stylesFnSearch\" placeholder=\"Search\" size=\"large\" name=\"search-fn\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-block display, width, min-width, padding, colors, fonts, line-height, border-radius, transitions and other input container basic styles",
+          "descriptionZh": "根元素，包含相对定位、行内块布局、宽度、最小宽度、内边距、颜色、字体、行高、圆角、过渡动画等输入框容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'count', desc: t('count') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Input\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-input\n          default-value=\"Hello, Antdv-Next\"\n          show-count\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <UserOutlined />\n          </template>\n          <template #suffix>\n            <EditOutlined />\n          </template>\n        </a-input>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "input",
+          "description": "Input element with core interactive styles and text input related styling",
+          "descriptionZh": "输入框元素，包含输入框的核心交互样式和文本输入相关的样式"
         },
         {
-          "name": "_semantic-textarea",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('TextAreaRoot') },\n  { name: 'textarea', desc: t('textarea') },\n  { name: 'count', desc: t('TextAreaCount') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"TextArea\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-textarea\n          default-value=\"Hello, Antdv-Next\"\n          :maxlength=\"100\"\n          show-count\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix wrapper element with layout and styling for prefix content",
+          "descriptionZh": "前缀的包裹元素，包含前缀内容的布局和样式"
         },
         {
-          "name": "_semantic-search",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'count', desc: t('count') },\n  { name: 'button.root', desc: t('button.root') },\n  { name: 'button.icon', desc: t('button.icon') },\n  { name: 'button.content', desc: t('button.content') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputSearch\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-input-search\n          default-value=\"Hello, Antdv-Next\"\n          enter-button=\"Searching...\"\n          loading\n          show-count\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <UserOutlined />\n          </template>\n          <template #suffix>\n            <EditOutlined />\n          </template>\n        </a-input-search>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "suffix",
+          "description": "Suffix wrapper element with layout and styling for suffix content",
+          "descriptionZh": "后缀的包裹元素，包含后缀内容的布局和样式"
         },
         {
-          "name": "_semantic-password",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'count', desc: t('count') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputPassword\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-input-password\n          default-value=\"Hello, Antdv-Next\"\n          show-count\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <UserOutlined />\n          </template>\n          <template #suffix>\n            <EditOutlined />\n          </template>\n        </a-input-password>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "count",
+          "description": "Character count element with font and color styles for count display",
+          "descriptionZh": "文字计数元素，包含字符计数显示的字体和颜色样式"
         },
         {
-          "name": "_semantic-otp",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'input', desc: t('input') },\n  { name: 'separator', desc: t('OTPSeparator') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputOTP\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-input-otp\n        :length=\"6\"\n        separator=\"-\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "TextAreaRoot",
+          "description": "Root element with textarea wrapper styles, border, border radius, transition animation and state control",
+          "descriptionZh": "根元素，设置文本域包装器的样式、边框、圆角、过渡动画和状态控制"
+        },
+        {
+          "key": "textarea",
+          "description": "Textarea element with font, line height, padding, color, background, border, text input and multi-line text display styles",
+          "descriptionZh": "文本域元素，设置字体、行高、内边距、颜色、背景、边框、文本输入和多行文本展示样式"
+        },
+        {
+          "key": "TextAreaCount",
+          "description": "Count element with character count display position, font, color and numeric statistics styles",
+          "descriptionZh": "文字计数元素，设置字符计数显示的位置、字体、颜色和数值统计样式"
+        },
+        {
+          "key": "button.root",
+          "description": "Search button root element with button styles, hover effects and click interactions",
+          "descriptionZh": "搜索按钮的根元素，设置按钮的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "button.icon",
+          "description": "Search button icon element with icon styles, hover effects and click interactions",
+          "descriptionZh": "搜索按钮的图标元素，设置图标的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "button.content",
+          "description": "Search button content element with text styles, hover effects and click interactions",
+          "descriptionZh": "搜索按钮的内容元素，设置文本的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "OTPSeparator",
+          "description": "Separator element, set separator display styles between OTP input boxes",
+          "descriptionZh": "分隔符元素，设置OTP输入框之间的分隔符显示样式"
         }
       ]
     },
@@ -11920,14 +12431,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of the InputNumber by passing objects/functions through",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 InputNumber 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { InputNumberProps } from 'antdv-next'\n\nconst shardStyle = {\n  root: 'shard',\n}\nconst styleObject: InputNumberProps['styles'] = {\n  input: {\n    fontSize: '14px',\n  },\n}\nconst styleFn: InputNumberProps['styles'] = ({ props }) => {\n  if (props.size === 'large') {\n    return {\n      root: {\n        backgroundColor: 'rgba(250,250,250, 0.5)',\n        borderColor: '#722ed1',\n      },\n    } satisfies InputNumberProps['styles']\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-input-number :classes=\"shardStyle\" :styles=\"styleObject\" placeholder=\"Object\" />\n    <a-input-number :classes=\"shardStyle\" :styles=\"styleFn\" placeholder=\"Function\" size=\"large\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets inline-block layout, width, border radius and reset styles",
+          "descriptionZh": "根元素，设置行内块布局、宽度、边框圆角和重置样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'actions', desc: t('actions') },\n  { name: 'action', desc: t('action') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputNumber\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ display: 'flex', flexDirection: 'column', gap: '16px' }\">\n        <a-input-number\n          prefix=\"￥\"\n          suffix=\"RMB\"\n          :default-value=\"100\"\n          :style=\"{ width: '200px' }\"\n          :styles=\"{ actions: { opacity: 1, width: '24px' }, suffix: { marginRight: '28px' } }\"\n          :classes=\"classes\"\n        />\n        <a-input-number\n          :default-value=\"100\"\n          :style=\"{ width: '200px' }\"\n          :styles=\"{ actions: { opacity: 1, width: '24px' }, suffix: { marginRight: '28px' } }\"\n          mode=\"spinner\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "input",
+          "description": "Input element, sets font, line height, text input and interaction styles",
+          "descriptionZh": "输入框元素，设置字体、行高、文本输入和交互样式"
+        },
+        {
+          "key": "prefix",
+          "description": "Prefix wrapper element, sets flex layout, alignment and right margin styles",
+          "descriptionZh": "前缀的包裹元素，设置flex布局、对齐方式和右边距样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix wrapper element, sets flex layout, margin and transition animation styles",
+          "descriptionZh": "后缀的包裹元素，设置flex布局、边距和过渡动画样式"
+        },
+        {
+          "key": "action",
+          "description": "Single action button element, sets button styling, hover effects and click interactions",
+          "descriptionZh": "单个操作按钮元素，设置按钮的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element, sets absolute positioning, width, flex layout and number adjustment button styles",
+          "descriptionZh": "操作元素，设置绝对定位、宽度、flex布局和数值调节按钮样式"
         }
       ]
     },
@@ -12239,7 +12774,8 @@
           "descriptionZh": "当内容较长时，使用固定侧边栏可以提供更好的体验。",
           "code": "<script setup lang=\"ts\">\nimport type { MenuItemType } from 'antdv-next'\nimport type { CSSProperties } from 'vue'\nimport {\n  AppstoreOutlined,\n  BarChartOutlined,\n  CloudOutlined,\n  ShopOutlined,\n  TeamOutlined,\n  UploadOutlined,\n  UserOutlined,\n  VideoCameraOutlined,\n} from '@antdv-next/icons'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\nconst year = new Date().getFullYear()\n\nconst siderStyle: CSSProperties = {\n  overflow: 'auto',\n  height: '100vh',\n  position: 'sticky',\n  insetInlineStart: 0,\n  top: 0,\n  scrollbarWidth: 'thin',\n  scrollbarGutter: 'stable',\n}\n\nconst items: MenuItemType[] = [\n  UserOutlined,\n  VideoCameraOutlined,\n  UploadOutlined,\n  BarChartOutlined,\n  CloudOutlined,\n  AppstoreOutlined,\n  TeamOutlined,\n  ShopOutlined,\n].map((icon, index) => ({\n  key: String(index + 1),\n  icon,\n  label: `nav ${index + 1}`,\n}))\n</script>\n\n<template>\n  <a-layout :has-sider=\"true\">\n    <a-layout-sider :style=\"siderStyle\">\n      <div class=\"demo-logo-vertical\" />\n      <a-menu\n        theme=\"dark\"\n        mode=\"inline\"\n        :default-selected-keys=\"['4']\"\n        :items=\"items\"\n      />\n    </a-layout-sider>\n    <a-layout>\n      <a-layout-header class=\"fixed-header\" :style=\"{ background: token.colorBgContainer }\" />\n      <a-layout-content class=\"fixed-content\">\n        <div\n          class=\"fixed-content-box\"\n          :style=\"{\n            background: token.colorBgContainer,\n            borderRadius: `${token.borderRadiusLG}px`,\n          }\"\n        >\n          <p>long content</p>\n          <template v-for=\"index in 100\" :key=\"index\">\n            {{ index % 20 === 0 && index !== 0 ? 'more' : '...' }}\n            <br>\n          </template>\n        </div>\n      </a-layout-content>\n      <a-layout-footer class=\"fixed-footer\">\n        Antdv Next ©{{ year }} Created by Ant UED\n      </a-layout-footer>\n    </a-layout>\n  </a-layout>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Masonry",
@@ -12361,14 +12897,18 @@
           "description": "When `fresh` is enabled, the masonry will continuously monitor size changes of child items and automatically re-layout. Click on cards to change their height.",
           "descriptionZh": "开启 `fresh` 属性后，瀑布流会持续监听子项的尺寸变化并自动重新布局。点击卡片可以改变其高度。",
           "code": "<script setup lang=\"ts\">\nimport { Card } from 'antdv-next'\nimport { defineComponent, h, ref } from 'vue'\n\nconst RandomHeightCard = defineComponent({\n  props: {\n    index: {\n      type: Number,\n      required: true,\n    },\n    defaultHeight: {\n      type: Number,\n      required: true,\n    },\n  },\n  setup(props) {\n    const height = ref(props.defaultHeight)\n\n    const handleClick = () => {\n      height.value = Math.floor(Math.random() * 100) + 50\n    }\n\n    return () =>\n      h(\n        Card,\n        {\n          size: 'small',\n          style: { height: `${height.value}px`, transition: 'height 0.3s' },\n          onClick: handleClick,\n        },\n        () => `${props.index + 1} - Click`,\n      )\n  },\n})\n\nconst heights = [150, 50, 90, 70, 110, 150, 130, 80, 50, 90, 100, 150, 60, 50, 80].map(\n  (height, index) => {\n    const item: {\n      key: string\n      data: number\n      column?: number\n    } = {\n      key: `item-${index}`,\n      data: height,\n    }\n\n    if (index === 4) {\n      item.column = 0\n    }\n\n    return item\n  },\n)\n</script>\n\n<template>\n  <a-masonry\n    fresh\n    :columns=\"4\"\n    :gutter=\"16\"\n    :items=\"heights\"\n  >\n    <template #itemRender=\"{ data, index }\">\n      <RandomHeightCard :index=\"index\" :default-height=\"data\" />\n    </template>\n  </a-masonry>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets relative positioning, flex layout and masonry container styles",
+          "descriptionZh": "根元素，设置相对定位、flex布局和瀑布流容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n])\n\nconst heights = [75, 50, 70, 60, 85, 75, 50].map((height, index) => ({\n  key: `item-${index}`,\n  data: height,\n}))\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Masonry\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-masonry\n        :columns=\"3\"\n        :gutter=\"16\"\n        :items=\"heights\"\n        style=\"width: 100%\"\n        :classes=\"classes\"\n      >\n        <template #itemRender=\"{ data, index }\">\n          <a-card size=\"small\" :style=\"{ height: data }\">\n            {{ index + 1 }}\n          </a-card>\n        </template>\n      </a-masonry>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element, sets absolute positioning, width calculation, transition animation and masonry item styles",
+          "descriptionZh": "条目元素，设置绝对定位、宽度计算、过渡动画和瀑布流项目样式"
         }
       ]
     },
@@ -12751,14 +13291,28 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Mentions by passing objects/functions through `classes` and `styles`. For example, set the textarea to be resizable.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Mentions 的[语义化结构](#semantic-dom)样式，例如设置文本框可缩放。",
           "code": "<script setup lang=\"ts\">\nimport type { MentionsProps } from 'antdv-next'\n\nconst options: MentionsProps['options'] = [\n  { value: 'afc163', label: 'afc163' },\n  { value: 'zombieJ', label: 'zombieJ' },\n  { value: 'meet-student', label: 'meet-student' },\n  { value: 'thinkasany', label: 'thinkasany' },\n]\n\nconst classes: MentionsProps['classes'] = {\n  root: 'mentions-demo-root',\n}\n\nconst stylesObject: MentionsProps['styles'] = {\n  textarea: {\n    fontSize: '14px',\n    resize: 'vertical',\n    fontWeight: 200,\n  },\n}\n\nconst stylesFn: MentionsProps['styles'] = ({ props }) => {\n  if (props.variant === 'filled') {\n    return {\n      root: {\n        border: '1px solid #722ed1',\n      },\n      popup: {\n        border: '1px solid #722ed1',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-mentions\n      :options=\"options\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      placeholder=\"Object\"\n      :rows=\"2\"\n    />\n    <a-mentions\n      :options=\"options\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      variant=\"filled\"\n      placeholder=\"Function\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set inline flex layout, relative positioning, padding and border styles",
+          "descriptionZh": "根元素，设置行内flex布局、相对定位、内边距和边框样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'textarea', desc: t('textarea'), version: '1.0.0' },\n  { name: 'suffix', desc: t('suffix'), version: '1.0.0' },\n  { name: 'popup', desc: t('popup'), version: '1.0.0' },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst options = [\n  { value: 'afc163', label: 'afc163' },\n  { value: 'zombieJ', label: 'zombieJ' },\n  { value: 'thinkasany', label: 'thinkasany' },\n  { value: 'meet-student', label: 'meet-student' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Mentions\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <a-mentions\n          placement=\"bottom\"\n          :style=\"{ width: '100%' }\"\n          value=\"Hi, @\"\n          allow-clear\n          open\n          :get-popup-container=\"() => divRef!\"\n          :options=\"options\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "textarea",
+          "description": "Textarea element, set font, line height, text input and background styles",
+          "descriptionZh": "文本域元素，设置字体、行高、文本输入和背景样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup element, set absolute positioning, z-index, background color, border radius, shadow and dropdown options styles",
+          "descriptionZh": "弹出框元素，设置绝对定位、层级、背景色、圆角、阴影和下拉选项样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with layout and styling for suffix content like clear button, etc.",
+          "descriptionZh": "后缀元素，包含后缀内容的布局和样式，如清除按钮等"
         }
       ]
     },
@@ -13477,14 +14031,68 @@
           "description": "Use the `popupRender` prop to customize submenu popup rendering.",
           "descriptionZh": "使用 `popupRender` 属性自定义弹出菜单的渲染。",
           "code": "<script setup lang=\"ts\">\nimport type { MenuItemType, MenuProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\nimport { computed, h } from 'vue'\n\nconst { token } = theme.useToken()\n\nconst popupStyle = computed(() => ({\n  padding: `${token.value.padding}px`,\n  minWidth: '480px',\n  background: token.value.colorBgElevated,\n  borderRadius: `${token.value.borderRadiusLG}px`,\n  boxShadow: token.value.boxShadowSecondary,\n}))\n\nconst headerStyle = computed(() => ({\n  margin: 0,\n  paddingBottom: `${token.value.paddingXS}px`,\n  borderBottom: `1px solid ${token.value.colorSplit}`,\n}))\n\nconst cardStyle = computed(() => ({\n  padding: `${token.value.paddingSM}px`,\n}))\n\nconst cardItemStyle = computed(() => ({\n  borderRadius: `${token.value.borderRadius}px`,\n  transition: `all ${token.value.motionDurationSlow}`,\n  cursor: 'pointer',\n}))\n\nfunction renderMenuCard(title: string, description: string) {\n  return h('div', { class: 'menu-card', style: cardStyle.value }, [\n    h('div', { class: 'menu-card-title' }, title),\n    h('div', { class: 'menu-card-desc' }, description),\n  ])\n}\n\nconst menuItems = computed<MenuItemType[]>(() => [\n  {\n    key: 'home',\n    label: 'Home',\n  },\n  {\n    key: 'features',\n    label: 'Features',\n    children: [\n      {\n        key: 'getting-started',\n        label: renderMenuCard('Getting Started', 'Quick start guide and learn the basics.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n      {\n        key: 'components',\n        label: renderMenuCard('Components', 'Explore our component library.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n      {\n        key: 'templates',\n        label: renderMenuCard('Templates', 'Ready-to-use template designs.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n    ],\n  },\n  {\n    key: 'resources',\n    label: 'Resources',\n    children: [\n      {\n        key: 'blog',\n        label: renderMenuCard('Blog', 'Latest updates and articles.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n      {\n        key: 'community',\n        label: renderMenuCard('Community', 'Join our developer community.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n    ],\n  },\n])\n\nconst popupRender: MenuProps['popupRender'] = (node, info) => {\n  const title = info.item.title || info.item.key\n  return h('div', { class: 'menu-popup', style: popupStyle.value }, [\n    h('div', { class: 'menu-popup-title', style: headerStyle.value }, title),\n    node,\n  ])\n}\n\nconst themeConfig = {\n  components: {\n    Menu: {\n      popupBg: '#fff',\n      horizontalItemSelectedColor: '#1677ff',\n      horizontalItemHoverColor: '#1677ff',\n    },\n  },\n}\n</script>\n\n<template>\n  <a-config-provider :theme=\"themeConfig\">\n    <a-menu mode=\"horizontal\" :items=\"menuItems\" :popup-render=\"popupRender\" />\n  </a-config-provider>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with basic menu container styles and layout",
+          "descriptionZh": "根元素，包含菜单容器的基础样式和布局"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { MailOutlined } from '@antdv-next/icons'\nimport { computed, h, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst mode = ref<'horizontal' | 'vertical' | 'inline'>('horizontal')\nconst current = ref('mail')\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst semantics = computed(() => {\n  const baseLocale = [\n    { name: 'root', desc: t('root') },\n    { name: 'item', desc: t('item') },\n    { name: 'itemIcon', desc: t('itemIcon') },\n    { name: 'itemContent', desc: t('itemContent') },\n  ]\n  const subMenuLocale = [\n    { name: 'subMenu.itemTitle', desc: t('subMenu.itemTitle') },\n    { name: 'subMenu.list', desc: t('subMenu.list') },\n    { name: 'subMenu.item', desc: t('subMenu.item') },\n    { name: 'subMenu.itemIcon', desc: t('subMenu.itemIcon') },\n    { name: 'subMenu.itemContent', desc: t('subMenu.itemContent') },\n  ]\n  const groupLocale = [\n    { name: 'itemTitle', desc: t('itemTitle') },\n    { name: 'list', desc: t('list') },\n  ]\n\n  const additionalPopupLocale = mode.value !== 'inline' ? [{ name: 'popup', desc: t('popup') }] : []\n  const additionalGroupLocale = mode.value !== 'horizontal' ? groupLocale : []\n\n  return [...baseLocale, ...additionalGroupLocale, ...additionalPopupLocale, ...subMenuLocale]\n})\n\nconst items = [\n  { label: 'Navigation One', key: 'mail', icon: h(MailOutlined) },\n  {\n    key: 'SubMenu',\n    label: 'Navigation One',\n    icon: h(MailOutlined),\n    children: [\n      {\n        key: 'g1',\n        label: 'Item 1',\n        type: 'group',\n        children: [\n          { key: '1', label: 'Option 1', icon: h(MailOutlined) },\n          { key: '2', label: 'Option 2' },\n        ],\n      },\n    ],\n  },\n]\n\nconst groupItem = [\n  {\n    key: 'grp',\n    label: 'Group',\n    type: 'group',\n    children: [\n      { key: '13', label: 'Option 13' },\n      { key: '14', label: 'Option 14' },\n    ],\n  },\n]\n\nconst itemList = computed(() => {\n  return mode.value === 'horizontal' ? items : [...items, ...groupItem]\n})\n\nfunction onClick(e: { key: string }) {\n  current.value = e.key\n}\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Menu\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" vertical gap=\"middle\" align=\"center\">\n        <a-segmented\n          :options=\"['horizontal', 'vertical', 'inline']\"\n          :value=\"mode\"\n          @change=\"(val: 'horizontal' | 'vertical' | 'inline') => mode = val\"\n        />\n        <div :style=\"{ height: '360px' }\">\n          <a-menu\n            :selected-keys=\"[current]\"\n            :mode=\"mode\"\n            :items=\"itemList\"\n            :styles=\"{\n              root: { width: mode === 'horizontal' ? '310px' : '230px' },\n              popup: { root: { zIndex: 1 } },\n            }\"\n            :open-keys=\"['SubMenu']\"\n            :get-popup-container=\"() => divRef!\"\n            :classes=\"classes\"\n            @click=\"onClick\"\n          />\n        </div>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with relative positioning, block display, margins, whitespace handling, cursor styles, transitions and other basic interactive styles for menu items",
+          "descriptionZh": "条目元素，包含相对定位、块级显示、外边距、空白符处理、光标样式、过渡动画等菜单项的基础交互样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Item content element with layout and typography styles for menu item content",
+          "descriptionZh": "条目内容元素，包含菜单项内容的布局和排版样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Icon element with min-width, font-size, transitions, icon reset styles, and spacing control with text",
+          "descriptionZh": "图标元素，包含最小宽度、字体大小、过渡动画、图标重置样式，以及与文本的间距控制"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Item title element (no effect in horizontal mode) with title text styles and layout",
+          "descriptionZh": "菜单标题元素(horizontal 模式不生效)，包含标题文字的样式和布局"
+        },
+        {
+          "key": "list",
+          "description": "Menu list element (no effect in horizontal mode) with menu list layout and container styles",
+          "descriptionZh": "菜单列表元素(horizontal 模式不生效)，包含菜单列表的布局和容器样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup menu element (no effect in inline mode) with popup layer positioning, z-index, background and other styles",
+          "descriptionZh": "弹出菜单(inline 模式不生效)，包含弹出层的定位、层级、背景等样式"
+        },
+        {
+          "key": "subMenu.itemTitle",
+          "description": "Submenu title element with submenu title styles and interactive effects",
+          "descriptionZh": "子菜单标题元素，包含子菜单标题的样式和交互效果"
+        },
+        {
+          "key": "subMenu.list",
+          "description": "Submenu list element with submenu list layout and container styles",
+          "descriptionZh": "子菜单列表元素，包含子菜单列表的布局和容器样式"
+        },
+        {
+          "key": "subMenu.item",
+          "description": "Submenu item element with submenu item styles and interactive effects",
+          "descriptionZh": "子菜单单项元素，包含子菜单项的样式和交互效果"
+        },
+        {
+          "key": "subMenu.itemIcon",
+          "description": "Submenu item icon element with submenu icon size and styles",
+          "descriptionZh": "子菜单条目图标元素，包含子菜单图标的尺寸和样式"
+        },
+        {
+          "key": "subMenu.itemContent",
+          "description": "Submenu item content element with submenu content layout and typography",
+          "descriptionZh": "子菜单条目内容元素，包含子菜单内容的布局和排版"
         }
       ]
     },
@@ -13606,14 +14214,23 @@
           "description": "Static methods cannot consume Context provided by `ConfigProvider`. When enable `layer`, they may also cause style errors. Please use hooks version or `App` provided instance first.",
           "descriptionZh": "静态方法无法消费 Context，不能动态响应 ConfigProvider 提供的各项配置，启用 `layer` 时还可能导致样式异常。请优先使用 hooks 版本或者 App 组件提供的 `message` 实例。",
           "code": "<script setup lang=\"ts\">\nimport { message } from 'antdv-next'\n\nfunction info() {\n  message.info('This is an info message')\n}\n</script>\n\n<template>\n  <a-button type=\"primary\" @click=\"info\">\n    Static Method\n  </a-button>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set fixed positioning, z-index, padding, background color, border radius, shadow and animation styles",
+          "descriptionZh": "根元素，设置固定定位、层级、内边距、背景色、圆角、阴影和动画样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { message } from 'antdv-next'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { _InternalPanelDoNotUseOrYouWillBeFired: InternalPanel } = message\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Message\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <InternalPanel\n        type=\"success\"\n        content=\"Hello, Ant Design!\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element, set font size, right margin and status color styles",
+          "descriptionZh": "图标元素，设置字体大小、右边距和状态颜色样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element, set inline block layout, text color and content display styles",
+          "descriptionZh": "内容元素，设置行内块布局、文字颜色和内容展示样式"
         }
       ]
     },
@@ -14164,14 +14781,48 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Modal by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Modal 组件的 [语义化结构](#semantic-dom) 样式。",
           "code": "<script setup lang=\"ts\">\nimport type { ModalProps } from 'antdv-next'\nimport { computed, ref } from 'vue'\n\nconst modalOpen = ref(false)\nconst modalFnOpen = ref(false)\n\nconst lineStyle = {\n  lineHeight: '28px',\n}\n\nconst classNames = computed(() => ({\n  container: 'custom-modal-container',\n}))\n\nconst styles: ModalProps['styles'] = {\n  mask: {\n    backgroundImage: `linear-gradient(to top, #18181b 0, rgba(21, 21, 22, 0.2) 100%)`,\n  },\n}\n\nconst stylesFn: ModalProps['styles'] = {\n  container: {\n    borderRadius: '14px',\n    border: '1px solid #ccc',\n    padding: '0',\n    overflow: 'hidden',\n  },\n  header: {\n    padding: '16px',\n  },\n  body: {\n    padding: '16px',\n  },\n  footer: {\n    padding: '16px 10px',\n    backgroundColor: '#fafafa',\n  },\n}\n\nconst sharedProps = computed<ModalProps>(() => ({\n  centered: true,\n  classes: classNames.value,\n}))\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-button @click=\"modalOpen = true\">\n      Open Style Modal\n    </a-button>\n    <a-button type=\"primary\" @click=\"modalFnOpen = true\">\n      Open Function Modal\n    </a-button>\n\n    <a-modal\n      v-bind=\"sharedProps\"\n      v-model:open=\"modalOpen\"\n      :footer=\"null\"\n      title=\"Custom Style Modal\"\n      :styles=\"styles\"\n    >\n      <div :style=\"lineStyle\">\n        Following the Ant Design specification, we developed a React UI library antd that contains a\n        set of high quality components and demos for building rich, interactive user interfaces.\n      </div>\n      <div :style=\"lineStyle\">\n        🌈 Enterprise-class UI designed for web applications.\n      </div>\n      <div :style=\"lineStyle\">\n        📦 A set of high-quality React components out of the box.\n      </div>\n      <div :style=\"lineStyle\">\n        🛡 Written in TypeScript with predictable static types.\n      </div>\n      <div :style=\"lineStyle\">\n        ⚙️ Whole package of design resources and development tools.\n      </div>\n      <div :style=\"lineStyle\">\n        🌍 Internationalization support for dozens of languages.\n      </div>\n      <div :style=\"lineStyle\">\n        🎨 Powerful theme customization in every detail.\n      </div>\n    </a-modal>\n\n    <a-modal\n      v-bind=\"sharedProps\"\n      v-model:open=\"modalFnOpen\"\n      title=\"Custom Function Modal\"\n      :styles=\"stylesFn\"\n      :mask=\"{ enabled: true, blur: true }\"\n    >\n      <div :style=\"lineStyle\">\n        Following the Ant Design specification, we developed a React UI library antd that contains a\n        set of high quality components and demos for building rich, interactive user interfaces.\n      </div>\n      <div :style=\"lineStyle\">\n        🌈 Enterprise-class UI designed for web applications.\n      </div>\n      <div :style=\"lineStyle\">\n        📦 A set of high-quality React components out of the box.\n      </div>\n      <div :style=\"lineStyle\">\n        🛡 Written in TypeScript with predictable static types.\n      </div>\n      <div :style=\"lineStyle\">\n        ⚙️ Whole package of design resources and development tools.\n      </div>\n      <div :style=\"lineStyle\">\n        🌍 Internationalization support for dozens of languages.\n      </div>\n      <div :style=\"lineStyle\">\n        🎨 Powerful theme customization in every detail.\n      </div>\n      <template #footer>\n        <a-button\n          :style=\"{ borderColor: '#ccc', color: '#171717', backgroundColor: '#fff' }\"\n          @click=\"modalFnOpen = false\"\n        >\n          Cancel\n        </a-button>\n        <a-button\n          type=\"primary\"\n          :style=\"{ backgroundColor: '#171717' }\"\n          @click=\"modalOpen = true\"\n        >\n          Submit\n        </a-button>\n      </template>\n    </a-modal>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, top position, width, max-width, margins, bottom padding and other basic layout styles for modal container",
+          "descriptionZh": "根元素，包含相对定位、顶部位置、宽度、最大宽度、外边距、底部内边距等模态框容器的基础布局样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'mask', desc: t('mask'), version: '1.0.0' },\n  { name: 'container', desc: t('container'), version: '1.0.0' },\n  { name: 'wrapper', desc: t('wrapper'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Modal\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', inset: 0 }\">\n        <a-modal\n          title=\"Title\"\n          :closable=\"false\"\n          open\n          :get-container=\"() => divRef!\"\n          :width=\"400\"\n          :styles=\"{\n            mask: { position: 'absolute', zIndex: 1 },\n            wrapper: { position: 'absolute', zIndex: 1 },\n          }\"\n          :style=\"{ top: '50%', transform: 'translateY(-50%)', marginBottom: 0, paddingBottom: 0 }\"\n          :classes=\"classes\"\n        >\n          <p>Some contents...</p>\n        </a-modal>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "mask",
+          "description": "Mask element with fixed positioning, z-index, background color, animation transitions and other mask layer styles",
+          "descriptionZh": "遮罩层元素，包含固定定位、层级、背景色、动画过渡等遮罩层的样式"
+        },
+        {
+          "key": "wrapper",
+          "description": "Wrapper element used for motion container with animation and transition effect styles",
+          "descriptionZh": "包裹层元素，一般用于动画容器，包含动画和过渡效果的样式"
+        },
+        {
+          "key": "container",
+          "description": "Modal container element with relative positioning, background, background-clip, border, border-radius, box-shadow, pointer-events, padding and other modal body styles",
+          "descriptionZh": "Modal 容器元素，包含相对定位、背景色、背景裁剪、边框、圆角、阴影、指针事件、内边距等模态框主体样式"
+        },
+        {
+          "key": "header",
+          "description": "Header element with padding, bottom border and other header area styles",
+          "descriptionZh": "头部元素，包含头部内边距、下边框等头部区域样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with margin, color, font-weight, font-size, line-height, word-wrap and other title text styles",
+          "descriptionZh": "标题元素，包含外边距、颜色、字体权重、字体大小、行高、文字换行等标题文字样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with content area background color, padding and other content display styles",
+          "descriptionZh": "内容元素，包含内容区域的背景色、内边距等内容展示样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with footer background color, padding, top border, border-radius and other footer area styles",
+          "descriptionZh": "底部元素，包含底部的背景色、内边距、上边框、圆角等底部区域样式"
         }
       ]
     },
@@ -14353,14 +15004,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Notification by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义通知的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { notification } from 'antdv-next'\n\nconst [api, ContextHolder] = notification.useNotification()\n\nconst classes = {\n  root: 'custom-notification-root',\n}\n\nfunction styleFn(info: any) {\n  if (info.props.type === 'error') {\n    return {\n      root: {\n        backgroundColor: 'rgba(255, 200, 200, 0.3)',\n      },\n    }\n  }\n  return {}\n}\n\nfunction openDefault() {\n  api.info({\n    title: 'Notification Title',\n    description: 'This is a notification description.',\n    duration: false,\n    classes,\n    styles: {\n      root: {\n        borderRadius: '8px',\n      },\n    },\n  })\n}\n\nfunction openError() {\n  api.error({\n    title: 'Notification Title',\n    description: 'This is a notification description.',\n    duration: false,\n    classes,\n    styles: styleFn,\n  })\n}\n</script>\n\n<template>\n  <ContextHolder />\n  <a-space>\n    <a-button type=\"primary\" @click=\"openDefault\">\n      Default Notification\n    </a-button>\n    <a-button @click=\"openError\">\n      Error Notification\n    </a-button>\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set fixed positioning, z-index, padding, background color, border radius, shadow and animation styles",
+          "descriptionZh": "根元素，设置固定定位、层级、内边距、背景色、圆角、阴影和动画样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { notification } from 'antdv-next'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { _InternalPanelDoNotUseOrYouWillBeFired: InternalPanel } = notification\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Notification\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <InternalPanel\n        title=\"Hello World!\"\n        description=\"Hello World?\"\n        type=\"success\"\n        :classes=\"classes\"\n      >\n        <template #actions>\n          <a-button type=\"primary\" size=\"small\">\n            My Button\n          </a-button>\n        </template>\n      </InternalPanel>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element, set absolute positioning, font size, line height and status color styles",
+          "descriptionZh": "图标元素，设置绝对定位、字体大小、行高和状态颜色样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element, set color, font size, line height and margin styles",
+          "descriptionZh": "标题元素，设置颜色、字体大小、行高和外边距样式"
+        },
+        {
+          "key": "description",
+          "description": "Description element, set font size, color and margin styles",
+          "descriptionZh": "描述元素，设置字体大小、颜色和外边距样式"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element, set float right, top margin and action button layout styles",
+          "descriptionZh": "操作组元素，设置右浮动、上边距和操作按钮布局样式"
         }
       ]
     },
@@ -14379,7 +15049,8 @@
       "props": [],
       "tokens": [],
       "faq": [],
-      "demos": []
+      "demos": [],
+      "semanticStructure": []
     },
     {
       "name": "Pagination",
@@ -14802,14 +15473,18 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Pagination by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Pagination 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { PaginationProps } from 'antdv-next'\nimport { useCssModule } from 'vue'\n\nconst moduleStyles = useCssModule()\n\nconst classes: PaginationProps['classes'] = {\n  root: moduleStyles.root,\n}\n\nconst stylesObject: PaginationProps['styles'] = {\n  item: {\n    borderRadius: '999px',\n  },\n}\n\nconst stylesFn: PaginationProps['styles'] = ({ props }) => {\n  if (props.size === 'small') {\n    return {\n      item: {\n        backgroundColor: 'rgba(200, 200, 200, 0.3)',\n        marginInlineEnd: '4px',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-pagination :total=\"500\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-pagination :total=\"500\" size=\"small\" :classes=\"classes\" :styles=\"stylesFn\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set flex layout, alignment, flex wrap and list styles",
+          "descriptionZh": "根元素，设置flex布局、对齐方式、换行和列表样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Pagination\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-pagination :default-current=\"1\" :total=\"50\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element, set size, padding, border, background color, hover state and active state styles",
+          "descriptionZh": "页码元素，设置尺寸、内边距、边框、背景色、悬停态和激活态样式"
         }
       ]
     },
@@ -15021,14 +15696,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Popconfirm by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Popconfirm 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { PopconfirmProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: PopconfirmProps['classes'] = {\n  container: 'demo-popconfirm-container',\n}\n\nconst stylesObject: PopconfirmProps['styles'] = {\n  container: {\n    backgroundColor: '#eee',\n    boxShadow: 'inset 5px 5px 3px #fff, inset -5px -5px 3px #ddd, 0 0 3px rgba(0,0,0,0.2)',\n  },\n  title: {\n    color: '#262626',\n  },\n  content: {\n    color: '#262626',\n  },\n}\n\nconst stylesFn: PopconfirmProps['styles'] = (info) => {\n  if (info?.props?.arrow === false) {\n    return {\n      container: {\n        backgroundColor: 'rgba(53, 71, 125, 0.8)',\n        padding: '12px',\n        borderRadius: '4px',\n      },\n      title: {\n        color: '#fff',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-popconfirm\n      title=\"Object text\"\n      description=\"Object description\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    >\n      <a-button>Object Style</a-button>\n    </a-popconfirm>\n    <a-popconfirm\n      title=\"Function text\"\n      description=\"Function description\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n      :ok-button-props=\"{ styles: { root: { backgroundColor: 'rgba(53, 71, 125, 0.6)', color: '#fff' } } }\"\n      :cancel-button-props=\"{ styles: { root: { borderColor: 'rgba(53, 71, 125, 0.6)', backgroundColor: '#fff', color: 'rgba(53, 71, 125, 0.8)' } } }\"\n    >\n      <a-button type=\"primary\">\n        Function Style\n      </a-button>\n    </a-popconfirm>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set absolute positioning, z-index, transform origin, arrow direction and popover container styles",
+          "descriptionZh": "根元素，设置绝对定位、层级、变换原点、箭头指向和弹层容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'container', desc: t('container') },\n  { name: 'title', desc: t('title') },\n  { name: 'content', desc: t('content') },\n  { name: 'arrow', desc: t('arrow') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Popconfirm\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', marginTop: '60px' }\">\n        <a-popconfirm\n          open\n          placement=\"top\"\n          title=\"Confirm\"\n          description=\"Are you sure you want to perform this action?\"\n          :auto-adjust-overflow=\"false\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "arrow",
+          "description": "Arrow element with width, height, position, color and border styles",
+          "descriptionZh": "箭头元素，设置宽高、位置、颜色和边框样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element, set title text styles and spacing",
+          "descriptionZh": "标题元素，设置标题文本样式和间距"
+        },
+        {
+          "key": "content",
+          "description": "Description element, set content text styles and layout",
+          "descriptionZh": "描述元素，设置描述文本样式和布局"
         }
       ]
     },
@@ -15232,14 +15926,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Popover by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Popover 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { PopoverProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: PopoverProps['classes'] = {\n  container: 'demo-popover-container',\n}\n\nconst stylesObject: PopoverProps['styles'] = {\n  container: {\n    backgroundColor: '#eee',\n    boxShadow: 'inset 5px 5px 3px #fff, inset -5px -5px 3px #ddd, 0 0 3px rgba(0,0,0,0.2)',\n  },\n  title: {\n    color: '#262626',\n  },\n  content: {\n    color: '#262626',\n  },\n}\n\nconst stylesFn: PopoverProps['styles'] = (info) => {\n  if (info?.props?.arrow === false) {\n    return {\n      container: {\n        backgroundColor: 'rgba(53, 71, 125, 0.8)',\n        padding: '12px',\n        borderRadius: '4px',\n      },\n      title: {\n        color: '#fff',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-popover\n      content=\"Object text\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    >\n      <a-button>Object Style</a-button>\n    </a-popover>\n    <a-popover\n      content=\"Function text\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n    >\n      <a-button type=\"primary\">\n        Function Style\n      </a-button>\n    </a-popover>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set absolute positioning, z-index, transform origin, arrow direction and popover container styles",
+          "descriptionZh": "根元素，设置绝对定位、层级、变换原点、箭头指向和弹层容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'container', desc: t('container') },\n  { name: 'title', desc: t('title') },\n  { name: 'content', desc: t('content') },\n  { name: 'arrow', desc: t('arrow') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Popover\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', marginTop: '60px' }\">\n        <a-popover\n          open\n          placement=\"top\"\n          title=\"Hello\"\n          content=\"Ant Design love you!\"\n          :auto-adjust-overflow=\"false\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "arrow",
+          "description": "Arrow element with width, height, position, color and border styles",
+          "descriptionZh": "箭头元素，设置宽高、位置、颜色和边框样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element, set title text styles and spacing",
+          "descriptionZh": "标题元素，设置标题文本样式和间距"
+        },
+        {
+          "key": "content",
+          "description": "Content element, set content text styles and layout",
+          "descriptionZh": "内容元素，设置内容文本样式和布局"
         }
       ]
     },
@@ -15542,14 +16255,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Progress by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Progress 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { ProgressProps } from 'antdv-next'\n\nconst classes: ProgressProps['classes'] = {\n  root: 'demo-progress-root',\n  rail: 'demo-progress-rail',\n  track: 'demo-progress-track',\n}\n\nconst stylesFn: ProgressProps['styles'] = (info) => {\n  const percent = info?.props?.percent ?? 0\n  const hue = 200 - (200 * percent) / 100\n  return {\n    track: {\n      backgroundImage: `\n        linear-gradient(\n          to right,\n          hsla(${hue}, 85%, 65%, 1),\n          hsla(${hue + 30}, 90%, 55%, 0.95)\n        )`,\n      borderRadius: 8,\n      transition: 'all 0.3s ease',\n    },\n    rail: {\n      backgroundColor: 'rgba(0, 0, 0, 0.1)',\n      borderRadius: 8,\n    },\n  } as ProgressProps['styles']\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"10\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"20\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"40\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"60\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"80\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"99\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set relative positioning and basic container styles",
+          "descriptionZh": "根元素，设置相对定位和基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'body', desc: t('body') },\n  { name: 'rail', desc: t('rail') },\n  { name: 'track', desc: t('track') },\n  { name: 'indicator', desc: t('indicator') },\n])\n\nconst gradient = ref(false)\nconst type = ref('line')\n\nconst colorMap = {\n  '0%': '#108ee9',\n  '100%': '#87d068',\n}\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Progress\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical gap=\"middle\" :style=\"{ width: '100%' }\" align=\"center\">\n        <a-flex align=\"center\" gap=\"middle\">\n          <a-segmented\n            :options=\"['line', 'steps', 'circle', 'dashboard']\"\n            :value=\"type\"\n            @change=\"(val: string) => type = val\"\n          />\n          <a-switch\n            :checked=\"gradient\"\n            checked-children=\"Gradient\"\n            un-checked-children=\"Gradient\"\n            @change=\"(val: boolean) => gradient = val\"\n          />\n        </a-flex>\n        <a-flex vertical align=\"center\" :style=\"{ height: '200px', width: '100%' }\">\n          <a-progress\n            :percent=\"80\"\n            :type=\"type === 'steps' ? 'line' : type\"\n            :steps=\"type === 'steps' ? 5 : undefined\"\n            :stroke-color=\"gradient ? colorMap : undefined\"\n            :classes=\"classes\"\n          />\n        </a-flex>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "body",
+          "description": "Body element, set progress bar layout and size styles",
+          "descriptionZh": "主体元素，设置进度条的布局和尺寸样式"
+        },
+        {
+          "key": "rail",
+          "description": "Rail element, set background track color and border radius styles. Not exist in steps mode",
+          "descriptionZh": "导轨元素，设置背景轨道的颜色和圆角样式，steps 模式下没有该元素"
+        },
+        {
+          "key": "track",
+          "description": "Track element, set progress fill color and transition animation styles",
+          "descriptionZh": "轨迹元素，设置进度填充部分的颜色和过渡动画样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element, set percentage text or icon position and font styles",
+          "descriptionZh": "指示器元素，设置百分比文本或图标的位置和字体样式"
         }
       ]
     },
@@ -15770,14 +16502,18 @@
           "description": "With Popover.",
           "descriptionZh": "带气泡卡片的例子。",
           "code": "<script setup lang=\"ts\">\ndefineOptions({ name: 'Popover' })\n</script>\n\n<template>\n  <a-popover>\n    <template #content>\n      <a-qrcode value=\"https://ant.design\" :bordered=\"false\" />\n    </template>\n    <a-button type=\"primary\">\n      Hover me\n    </a-button>\n  </a-popover>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set flex layout, padding, background color, border, border radius and relative positioning styles",
+          "descriptionZh": "根元素，设置flex布局、内边距、背景色、边框、圆角和相对定位样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'cover', desc: t('cover') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"QRCode\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-qrcode value=\"https://ant.design\" status=\"loading\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "cover",
+          "description": "Cover element, set absolute positioning, z-index, background color and loading state overlay styles",
+          "descriptionZh": "遮罩层元素，设置绝对定位、层级、背景色和加载状态覆盖样式"
         }
       ]
     },
@@ -16179,14 +16915,23 @@
           "description": "Solid radio button style.",
           "descriptionZh": "实色填底的单选按钮样式。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst value = shallowRef('a')\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-radio-group v-model:value=\"value\" button-style=\"solid\">\n      <a-radio-button value=\"a\">\n        Hangzhou\n      </a-radio-button>\n      <a-radio-button value=\"b\">\n        Shanghai\n      </a-radio-button>\n      <a-radio-button value=\"c\">\n        Beijing\n      </a-radio-button>\n      <a-radio-button value=\"d\">\n        Chengdu\n      </a-radio-button>\n    </a-radio-group>\n    <a-radio-group v-model:value=\"value\" button-style=\"solid\">\n      <a-radio-button value=\"a\">\n        Hangzhou\n      </a-radio-button>\n      <a-radio-button value=\"b\" disabled>\n        Shanghai\n      </a-radio-button>\n      <a-radio-button value=\"c\">\n        Beijing\n      </a-radio-button>\n      <a-radio-button value=\"d\">\n        Chengdu\n      </a-radio-button>\n    </a-radio-group>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with layout styles, cursor styles, disabled text color and other basic container styles",
+          "descriptionZh": "根元素，包含布局样式、鼠标样式、禁用状态文字颜色等基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Radio\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-radio :classes=\"classes\">\n        Radio\n      </a-radio>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element with border radius, transition animations, border styles, hover states, focus states and other interactive styles",
+          "descriptionZh": "选中框元素，包含圆角样式、过渡动画、边框样式、悬停状态、焦点状态等交互样式"
+        },
+        {
+          "key": "label",
+          "description": "Label element with padding, text color, disabled states, alignment and other text styles",
+          "descriptionZh": "文本元素，包含内边距、文字颜色、禁用状态、对齐方式等文本样式"
         }
       ]
     },
@@ -16462,7 +17207,8 @@
           "descriptionZh": "调试使用。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst value = ref(2.5)\n</script>\n\n<template>\n  <a-config-provider\n    :theme=\"{\n      components: {\n        Rate: {\n          starColor: 'blue',\n          starSize: 40,\n          starHoverScale: 'scale(2)',\n          starBg: 'red',\n        },\n      },\n    }\"\n  >\n    <a-rate v-model:value=\"value\" allow-half />\n  </a-config-provider>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Result",
@@ -16630,14 +17376,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Result by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Result 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { ResultProps } from 'antdv-next'\n\nconst classesObject: ResultProps['classes'] = {\n  root: 'demo-result-root',\n  title: 'demo-result-title',\n  subTitle: 'demo-result-subtitle',\n  icon: 'demo-result-icon',\n  extra: 'demo-result-extra',\n  body: 'demo-result-body',\n}\n\nconst classesFn: ResultProps['classes'] = (info) => {\n  if (info.props.status === 'success') {\n    return {\n      root: 'demo-result-root--success',\n    } satisfies ResultProps['classes']\n  }\n  return {\n    root: 'demo-result-root--default',\n  } satisfies ResultProps['classes']\n}\n\nconst stylesObject: ResultProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed', padding: '16px' },\n  title: { fontStyle: 'italic', color: '#1890ff' },\n  subTitle: { fontWeight: 'bold' },\n  icon: { opacity: 0.8 },\n  extra: { backgroundColor: '#f0f0f0', padding: 'px' },\n  body: { backgroundColor: '#fafafa', padding: '12px' },\n}\n\nconst stylesFn: ResultProps['styles'] = (info) => {\n  if (info.props.status === 'error') {\n    return {\n      root: { backgroundColor: '#fff2f0', borderColor: '#ff4d4f' },\n      title: { color: '#ff4d4f' },\n    } satisfies ResultProps['styles']\n  }\n  else {\n    return {\n      root: { backgroundColor: '#f6ffed', borderColor: '#52c41a' },\n      title: { color: '#52c41a' },\n    } satisfies ResultProps['styles']\n  }\n}\n</script>\n\n<template>\n  <a-result\n    status=\"info\"\n    title=\"classes Object\"\n    sub-title=\"This is a subtitle\"\n    :styles=\"stylesObject\"\n    :classes=\"classesObject\"\n  >\n    <template #extra>\n      <a-button type=\"primary\">\n        Action\n      </a-button>\n    </template>\n    <div>Content area</div>\n  </a-result>\n  <a-result\n    status=\"success\"\n    title=\"classes Function\"\n    sub-title=\"Dynamic class names\"\n    :styles=\"stylesFn\"\n    :classes=\"classesFn\"\n  >\n    <template #extra>\n      <a-button type=\"primary\">\n        Action\n      </a-button>\n    </template>\n  </a-result>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with text alignment, layout styles and other basic container styles",
+          "descriptionZh": "根元素，包含文本对齐、布局样式等基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'subTitle', desc: t('subTitle'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Result\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-result\n        title=\"title\"\n        sub-title=\"subTitle\"\n        :classes=\"classes\"\n      >\n        <template #extra>\n          <a-button type=\"primary\">\n            extra\n          </a-button>\n        </template>\n        <div :style=\"{ textAlign: 'center' }\">\n          The Content of Result\n        </div>\n      </a-result>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "title",
+          "description": "Title element with font size, text color, line height, text alignment and other text styles",
+          "descriptionZh": "标题元素，包含字体大小、文字颜色、行高、对齐方式等文字样式"
+        },
+        {
+          "key": "subTitle",
+          "description": "Subtitle element with font size, text color, line height and other text styles",
+          "descriptionZh": "副标题元素，包含字体大小、文字颜色、行高等文字样式"
+        },
+        {
+          "key": "body",
+          "description": "Content element with margin, padding, background color and other content area styles",
+          "descriptionZh": "内容元素，包含外边距、内边距、背景色等内容区域样式"
+        },
+        {
+          "key": "extra",
+          "description": "Action area element with margin, text alignment, inner element spacing and other layout styles",
+          "descriptionZh": "操作区域元素，包含外边距、文本对齐、内部元素间距等布局样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with margin, text alignment, font size, status colors and other icon styles",
+          "descriptionZh": "图标元素，包含外边距、文本对齐、字体大小、状态颜色等图标样式"
         }
       ]
     },
@@ -16901,14 +17671,28 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Segmented by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Segmented 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { SegmentedProps } from 'antdv-next'\nimport { CloudOutlined, RocketOutlined, ThunderboltOutlined } from '@antdv-next/icons'\nimport { h } from 'vue'\n\nconst classes: SegmentedProps['classes'] = {\n  root: 'custom-segmented-root',\n}\nconst styleFn: SegmentedProps['styles'] = (info) => {\n  if (info.props.vertical) {\n    return {\n      root: {\n        border: '1px solid #77BEF0',\n        padding: '4px',\n        width: '100px',\n      },\n      icon: {\n        color: '#77BEF0',\n      },\n      item: {\n        textAlign: 'start',\n      },\n    } satisfies SegmentedProps['styles']\n  }\n  return {}\n}\n\nconst styles: SegmentedProps['styles'] = {\n  root: {\n    padding: '4px',\n    width: '260px',\n  },\n}\n\nconst options: SegmentedProps['options'] = [\n  {\n    label: 'Boost',\n    value: 'boost',\n    icon: h(RocketOutlined),\n  },\n  {\n    label: 'Stream',\n    value: 'stream',\n    icon: h(ThunderboltOutlined),\n  },\n  {\n    label: 'Cloud',\n    value: 'cloud',\n    icon: h(CloudOutlined),\n  },\n]\nconst segmentedSharedProps: SegmentedProps = {\n  options,\n  classes,\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-segmented v-bind=\"segmentedSharedProps\" :styles=\"styles\" />\n    <a-segmented v-bind=\"segmentedSharedProps\" :styles=\"styleFn\" vertical />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with inline-block layout, padding, background, border radius, transition and container styles",
+          "descriptionZh": "根元素，设置行内块布局、内边距、背景色、圆角、过渡动画和容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AppstoreOutlined, BarsOutlined } from '@antdv-next/icons'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n])\n\nconst options = [\n  { label: 'List', value: 'List', icon: h(BarsOutlined) },\n  { label: 'Kanban', value: 'Kanban', icon: h(AppstoreOutlined) },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Segmented\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-segmented :options=\"options\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Option element with relative positioning, text alignment, cursor style, transition, selected state background and hover styles",
+          "descriptionZh": "选项元素，设置相对定位、文本对齐、光标样式、过渡动画、选中态背景色和悬停态样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with icon size, color and text spacing styles",
+          "descriptionZh": "图标元素，设置图标的尺寸、颜色和与文本的间距样式"
+        },
+        {
+          "key": "label",
+          "description": "Label content element with min height, line height, padding, text ellipsis and content layout styles",
+          "descriptionZh": "标签内容元素，设置最小高度、行高、内边距、文本省略和内容布局样式"
         }
       ]
     },
@@ -17750,14 +18534,73 @@
           "description": "You can customize the semantic dom style of Select by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "您可以通过 `classes` 和 `styles` 传入对象/函数来自定义 Select 的语义化 DOM 样式。",
           "code": "<script setup lang=\"ts\">\nimport { MehOutlined } from '@antdv-next/icons'\n\nconst options = [\n  { value: 'GuangZhou', label: 'GuangZhou' },\n  { value: 'ShenZhen', label: 'ShenZhen' },\n]\n\nconst stylesObject = {\n  prefix: {\n    color: '#1890ff',\n  },\n  suffix: {\n    color: '#1890ff',\n  },\n}\n\nconst stylesFilled = {\n  prefix: {\n    color: '#722ed1',\n  },\n  suffix: {\n    color: '#722ed1',\n  },\n  popup: {\n    root: {\n      border: '1px solid #722ed1',\n    },\n  },\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-select\n      :options=\"options\"\n      :classes=\"{ root: 'custom-select' }\"\n      :styles=\"stylesObject\"\n      placeholder=\"Object\"\n    >\n      <template #prefix>\n        <MehOutlined />\n      </template>\n    </a-select>\n    <a-select\n      :options=\"options\"\n      :classes=\"{ root: 'custom-select' }\"\n      :styles=\"stylesFilled\"\n      placeholder=\"Function\"\n      variant=\"filled\"\n    >\n      <template #prefix>\n        <MehOutlined />\n      </template>\n    </a-select>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, cursor styles, transitions, border and other basic selector container styles",
+          "descriptionZh": "根元素，包含相对定位、行内 flex 布局、光标样式、过渡动画、边框等选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst mode = ref<'single' | 'multiple'>('single')\n\nconst options = [\n  { value: 'aojunhao123', label: 'aojunhao123' },\n  { value: 'thinkasany', label: 'thinkasany' },\n  { value: 'meet-student', label: 'meet-student' },\n]\n\nconst value = computed(() => {\n  if (mode.value !== 'multiple')\n    return []\n\n  return options.length > 0\n    ? [options[0]!.value]\n    : []\n})\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => {\n  const base = [\n    { name: 'root', desc: t('root') },\n    { name: 'prefix', desc: t('prefix') },\n    { name: 'content', desc: t('content') },\n    { name: 'placeholder', desc: t('placeholder') },\n    { name: 'clear', desc: t('clear') },\n    { name: 'input', desc: t('input') },\n    { name: 'suffix', desc: t('suffix') },\n    { name: 'popup.root', desc: t('popup.root') },\n    { name: 'popup.list', desc: t('popup.list') },\n    { name: 'popup.listItem', desc: t('popup.listItem') },\n  ]\n\n  if (mode.value === 'multiple') {\n    return [\n      ...base,\n      { name: 'item', desc: t('item') },\n      { name: 'itemContent', desc: t('itemContent') },\n      { name: 'itemRemove', desc: t('itemRemove') },\n    ]\n  }\n\n  return base\n})\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Select\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <div :style=\"{ display: 'flex', justifyContent: 'center', marginBottom: '12px' }\">\n          <a-segmented v-model:value=\"mode\" :options=\"['single', 'multiple']\" />\n        </div>\n        <div :style=\"{ display: 'flex', flexDirection: 'column', gap: '12px' }\">\n          <a-select\n            prefix=\"prefix\"\n            :style=\"{ width: '300px' }\"\n            :options=\"options\"\n            :value=\"value\"\n            :mode=\"mode === 'multiple' ? 'multiple' : undefined\"\n            open\n            :get-popup-container=\"() => divRef!\"\n            :classes=\"classes\"\n          />\n        </div>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with layout and styling for prefix content",
+          "descriptionZh": "前缀元素，包含前缀内容的布局和样式"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "clear",
+          "description": "Clear button element with layout, styling and interactive effects for clear button",
+          "descriptionZh": "清除按钮元素，包含清除按钮的布局、样式和交互效果"
+        },
+        {
+          "key": "input",
+          "description": "Input element with search input styling, cursor control, font inheritance and other search-related styles. Remove border styles",
+          "descriptionZh": "输入框元素，包含搜索输入框的样式、光标控制、字体继承等搜索相关样式，去除了边框样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with layout and styling for suffix content like clear button, arrow icon, etc.",
+          "descriptionZh": "后缀元素，包含后缀内容的布局和样式，如清除按钮、箭头图标等"
+        },
+        {
+          "key": "item",
+          "description": "Multiple selection item element with border, background, padding, and margin styles",
+          "descriptionZh": "多选项元素，包含边框、背景、内边距、外边距样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Multiple selection item content area with text ellipsis styles",
+          "descriptionZh": "多选项内容区域，包含文字的省略样式"
+        },
+        {
+          "key": "itemRemove",
+          "description": "Multiple selection item remove button with font-related styless",
+          "descriptionZh": "多选项移除按钮，包含字体相关样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with popup layer positioning, z-index, background, border, box-shadow and other popup container styles",
+          "descriptionZh": "弹出菜单元素，包含弹出层的定位、层级、背景、边框、阴影等弹出容器样式"
+        },
+        {
+          "key": "popup.list",
+          "description": "Popup list element with option list layout, scrolling, max-height and other list container styles",
+          "descriptionZh": "弹出菜单列表元素，包含选项列表的布局、滚动、最大高度等列表容器样式"
+        },
+        {
+          "key": "popup.listItem",
+          "description": "Popup item element with option item padding, hover effects, selected states, disabled states and other option interactive styles",
+          "descriptionZh": "弹出菜单条目元素，包含选项项的内边距、悬浮效果、选中状态、禁用状态等选项交互样式"
         }
       ]
     },
@@ -18212,14 +19055,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Skeleton by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Skeleton 组件的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nconst classes = {\n  root: 'skeleton-root',\n  header: 'skeleton-header',\n}\n\nconst styles = {\n  avatar: {\n    border: '1px solid #aaa',\n  },\n  title: {\n    border: '1px solid #aaa',\n  },\n}\n\nfunction stylesFn(info: { props: { active?: boolean } }) {\n  if (info.props?.active) {\n    return {\n      root: {\n        border: '1px solid rgba(229, 243, 254, 0.3)',\n      },\n      title: {\n        backgroundColor: 'rgba(229, 243, 254, 0.5)',\n        height: '20px',\n        borderRadius: '20px',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-skeleton\n      :classes=\"classes\"\n      :styles=\"styles\"\n      avatar\n      :paragraph=\"false\"\n    />\n    <a-skeleton\n      :classes=\"{ ...classes, paragraph: 'skeleton-paragraph' }\"\n      :styles=\"stylesFn\"\n      active\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with table display, width, animation effects, border radius and other skeleton container basic styles",
+          "descriptionZh": "根元素，包含表格显示、宽度、动画效果、圆角等骨架屏容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'avatar', desc: t('avatar'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'paragraph', desc: t('paragraph'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Skeleton\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-skeleton avatar :paragraph=\"{ rows: 4 }\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with table cell, padding, vertical alignment and other avatar placeholder area layout styles",
+          "descriptionZh": "头部元素，包含表格单元格、内边距、垂直对齐等头像占位区域的布局样式"
+        },
+        {
+          "key": "section",
+          "description": "Section element with skeleton content area layout styles",
+          "descriptionZh": "区块元素，包含骨架屏内容区域的布局样式"
+        },
+        {
+          "key": "avatar",
+          "description": "Avatar element with inline-block display, vertical alignment, background color, size, border radius and other avatar placeholder styles",
+          "descriptionZh": "头像元素，包含行内块显示、垂直对齐、背景色、尺寸、圆角等头像占位的样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with width, height, background color, border radius and other title placeholder styles",
+          "descriptionZh": "标题元素，包含宽度、高度、背景色、圆角等标题占位的样式"
+        },
+        {
+          "key": "paragraph",
+          "description": "Paragraph element with padding, list item styles, background color, border radius and other paragraph placeholder styles",
+          "descriptionZh": "段落元素，包含内边距、列表项样式、背景色、圆角等段落占位的样式"
         }
       ]
     },
@@ -18617,14 +19484,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Sliders by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Sliders 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst value = ref(30)\nconst valueVertical = ref(30)\n\nconst stylesObject = {\n  track: { backgroundImage: 'linear-gradient(180deg, #91caff, #1677ff)' },\n  handle: { borderColor: '#1677ff', boxShadow: '0 2px 8px #1677ff' },\n}\n\nfunction stylesFn(info: any) {\n  if (info.props.orientation === 'vertical') {\n    return {\n      root: { height: '300px' },\n      track: { backgroundImage: 'linear-gradient(180deg, #722cc0, #722ed1)' },\n      handle: { borderColor: '#722ed1', boxShadow: '0 2px 8px #722ed1' },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-slider v-model:value=\"value\" class=\"custom-slider\" :styles=\"stylesObject\" />\n    <a-slider\n      v-model:value=\"valueVertical\"\n      class=\"custom-slider-vertical\"\n      orientation=\"vertical\"\n      reverse\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, height, margin, padding, cursor style and touch action control",
+          "descriptionZh": "根元素，设置相对定位、高度、边距、内边距、光标样式和触摸事件控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'track', desc: t('track'), version: '1.0.0' },\n  { name: 'tracks', desc: t('tracks'), version: '1.0.0' },\n  { name: 'rail', desc: t('rail'), version: '1.0.0' },\n  { name: 'handle', desc: t('handle'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Slider\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-slider\n        range\n        :default-value=\"[20, 30, 50]\"\n        :style=\"{ width: '100%' }\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "track",
+          "description": "Track selection bar element with absolute positioning, background color, border radius and transition animation styles",
+          "descriptionZh": "轨道选取条元素，设置绝对定位、背景色、圆角和过渡动画样式"
+        },
+        {
+          "key": "tracks",
+          "description": "Multi-segment track container element with absolute positioning and transition animation styles",
+          "descriptionZh": "多段轨道容器元素，设置绝对定位和过渡动画样式"
+        },
+        {
+          "key": "rail",
+          "description": "Background rail element with absolute positioning, background color, border radius and transition animation styles",
+          "descriptionZh": "背景轨道元素，设置绝对定位、背景色、圆角和过渡动画样式"
+        },
+        {
+          "key": "handle",
+          "description": "Slider handle control element with absolute positioning, size, outline, user selection, background color, border shadow, border radius, cursor style and transition animation",
+          "descriptionZh": "滑块控制点元素，设置绝对定位、尺寸、轮廓线、用户选择、背景色、边框阴影、圆角、光标样式和过渡动画"
         }
       ]
     },
@@ -18832,14 +19718,23 @@
           "description": "Customize semantic structure styles and class names. Supports both object and function forms.",
           "descriptionZh": "自定义语义化结构的样式和类名。支持对象和函数两种形式。",
           "code": "<script setup lang=\"ts\">\nimport type { SpaceProps } from 'antdv-next'\n\nconst classNamesObject: SpaceProps['classes'] = {\n  root: 'demo-space-root',\n  item: 'demo-space-item',\n  separator: 'demo-space-separator',\n}\n\nconst classNamesFn: SpaceProps['classes'] = (info) => {\n  if (info.props.orientation === 'vertical') {\n    return {\n      root: 'demo-space-root--vertical',\n    } satisfies SpaceProps['classes']\n  }\n  else {\n    return {\n      root: 'demo-space-root--horizontal',\n    } satisfies SpaceProps['classes']\n  }\n}\n\nconst stylesObject: SpaceProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed', padding: '8px', marginBottom: '10px' },\n  item: { backgroundColor: '#f0f0f0', padding: '4px' },\n  separator: { color: 'red', fontWeight: 'bold' },\n}\n\nconst stylesFn: SpaceProps['styles'] = (info) => {\n  if (info.props.size === 'large') {\n    return {\n      root: {\n        backgroundColor: '#e6f7ff',\n        borderColor: '#1890ff',\n        padding: '8px',\n      },\n    } satisfies SpaceProps['styles']\n  }\n  else {\n    return {\n      root: {\n        backgroundColor: '#fff7e6',\n        borderColor: '#fa8c16',\n      },\n    } satisfies SpaceProps['styles']\n  }\n}\n</script>\n\n<template>\n  <div>\n    <a-space :styles=\"stylesObject\" :classes=\"classNamesObject\" separator=\"•\">\n      <a-button>Styled Button 1</a-button>\n      <a-button>Styled Button 2</a-button>\n      <a-button>Styled Button 3</a-button>\n    </a-space>\n    <a-space size=\"large\" :styles=\"stylesFn\" :classes=\"classNamesFn\">\n      <a-button>Large Space Button 1</a-button>\n      <a-button>Large Space Button 2</a-button>\n      <a-button>Large Space Button 3</a-button>\n    </a-space>\n  </div>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, gap settings, alignment, wrap and other spacing container basic styles",
+          "descriptionZh": "根元素，包含 flex 布局、间隙设置、对齐方式、换行等间距容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n  { name: 'separator', desc: t('separator') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Space\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-space :classes=\"classes\">\n        <template #separator>\n          <a-divider vertical />\n        </template>\n        <a-button type=\"primary\">\n          Primary\n        </a-button>\n        <a-button>Default</a-button>\n        <a-button type=\"dashed\">\n          Dashed\n        </a-button>\n      </a-space>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Wrapped item element with spacing item layout and styles, providing wrapper for each child element for inline alignment",
+          "descriptionZh": "包裹的子组件，包含间距项的布局和样式，为每个子元素提供包装用于内联对齐"
+        },
+        {
+          "key": "separator",
+          "description": "Separator element with divider styling",
+          "descriptionZh": "分隔符，包含分隔元素的样式"
         }
       ]
     },
@@ -19037,14 +19932,18 @@
           "description": "The `fullscreen` mode is perfect for creating page loaders. It adds a dimmed overlay with a centered spinner.",
           "descriptionZh": "`fullscreen` 属性非常适合创建流畅的页面加载器。它添加了半透明覆盖层，并在其中心放置了一个旋转加载符号。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst spinning = ref(false)\nconst percent = ref(0)\n\nfunction showLoader() {\n  spinning.value = true\n  let ptg = -10\n\n  const interval = setInterval(() => {\n    ptg += 5\n    percent.value = ptg\n\n    if (ptg > 120) {\n      clearInterval(interval)\n      spinning.value = false\n      percent.value = 0\n    }\n  }, 100)\n}\n</script>\n\n<template>\n  <div>\n    <a-button @click=\"showLoader\">\n      Show fullscreen\n    </a-button>\n    <a-spin :spinning=\"spinning\" :percent=\"percent\" fullscreen />\n  </div>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with absolute positioning, display control, color, font size, text alignment, vertical alignment, opacity and transition animation (effective when fullscreen is false)",
+          "descriptionZh": "根元素，设置绝对定位、显示控制、颜色、字体大小、文本对齐、垂直对齐、透明度和过渡动画(fullscreen 为 false 时才有效)"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Spin\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div\n        :style=\"{\n          position: 'relative',\n          width: '500px',\n          height: '100px',\n          display: 'flex',\n          alignItems: 'center',\n          justifyContent: 'center',\n        }\"\n      >\n        <a-spin :percent=\"0\" :classes=\"classes\" />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "indicator",
+          "description": "Indicator element with width, height, font size, inline-block display, transition animation, transform origin, line height and color",
+          "descriptionZh": "指示器元素，设置宽度、高度、字体大小、行内块显示、过渡动画、变换原点、行高和颜色"
         }
       ]
     },
@@ -19327,14 +20226,23 @@
           "description": "Customize semantic structure styles and class names. Supports both object and function forms.",
           "descriptionZh": "自定义语义化结构的样式和类名。支持对象和函数两种形式。",
           "code": "<script setup lang=\"ts\">\nimport type { SplitterProps } from 'antdv-next'\n\nconst stylesObject: SplitterProps['styles'] = {\n  root: { backgroundColor: '#fffbe6' },\n  dragger: { backgroundColor: 'rgba(194,223,252,0.4)' },\n}\n\nconst stylesFn: SplitterProps['styles'] = ({ props }) => {\n  if (props.orientation === 'horizontal') {\n    return {\n      root: {\n        borderWidth: '2px',\n        borderStyle: 'dashed',\n        marginBottom: '10px',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-splitter\n      style=\"height: 200px\"\n      root-class=\"shadow-secondary\"\n      :styles=\"stylesObject\"\n    >\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\" style=\"color: #000\">\n            First\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\" style=\"color: #000\">\n            Second\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n    </a-splitter>\n    <a-splitter\n      style=\"height: 200px\"\n      root-class=\"shadow-secondary\"\n      :styles=\"stylesFn\"\n    >\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\">\n            First\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\">\n            Second\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n    </a-splitter>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, width and height, alignment and stretch styles",
+          "descriptionZh": "根元素，设置flex布局、宽度高度、对齐方式和拉伸样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'panel', desc: t('panel'), version: '1.0.0' },\n  { name: 'dragger', desc: t('dragger'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Splitter\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-splitter\n        :style=\"{ height: '200px', boxShadow: '0 0 10px rgba(0, 0, 0, 0.1)' }\"\n        :classes=\"classes\"\n      >\n        <a-splitter-panel>\n          <div :style=\"{ display: 'flex', height: '100%', alignItems: 'center', justifyContent: 'center' }\">\n            First\n          </div>\n        </a-splitter-panel>\n        <a-splitter-panel>\n          <div :style=\"{ display: 'flex', height: '100%', alignItems: 'center', justifyContent: 'center' }\">\n            Second\n          </div>\n        </a-splitter-panel>\n      </a-splitter>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "panel",
+          "description": "Panel element with flex basis, grow ratio and panel container styles",
+          "descriptionZh": "面板元素，设置flex基础值、增长比例和面板容器样式"
+        },
+        {
+          "key": "dragger",
+          "description": "Drag control element with absolute positioning, user selection, z-index, center alignment, background color, hover and active states styles",
+          "descriptionZh": "拖拽控制元素，设置绝对定位、用户选择、层级、居中对齐、背景色、悬停态和激活态样式"
         }
       ]
     },
@@ -19535,14 +20443,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of the Statistic by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Statistic 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { StatisticProps } from 'antdv-next'\nimport { ArrowDownOutlined, ArrowUpOutlined } from '@antdv-next/icons'\n\nconst classes = {\n  root: 'custom-statistic-root',\n}\nconst styleFn: StatisticProps['styles'] = ({ props }) => {\n  const numValue = Number(props.value ?? 0)\n  const isNegative = Number.isFinite(numValue) && numValue < 0\n  if (isNegative) {\n    return {\n      title: {\n        color: '#ff4d4f',\n      },\n      content: {\n        color: '#ff7875',\n      },\n    } satisfies StatisticProps['styles']\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-statistic\n      :value=\"93241\"\n      title=\"Monthly Active Users\"\n      :classes=\"classes\"\n      :styles=\"{ title: { color: '#1890ff', fontWeight: '600px' }, content: { fontSize: '24px' } }\"\n      suffix=\"users\"\n    >\n      <template #prefix>\n        <ArrowUpOutlined />\n      </template>\n    </a-statistic>\n\n    <a-statistic\n      :value=\"-18.7\"\n      title=\"Yearly Loss\"\n      :precision=\"1\"\n      :classes=\"classes\"\n      :styles=\"styleFn\"\n      suffix=\"%\"\n    >\n      <template #prefix>\n        <ArrowDownOutlined />\n      </template>\n    </a-statistic>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with reset styles and overall container styles for statistic component",
+          "descriptionZh": "根元素，包含统计数值组件的重置样式和整体容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { ArrowUpOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'prefix', desc: t('prefix'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'suffix', desc: t('suffix'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Statistic\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ position: 'absolute' }\">\n        <a-statistic\n          title=\"Active\"\n          :value=\"11.28\"\n          :precision=\"2\"\n          :styles=\"{ content: { color: '#3f8600' } }\"\n          suffix=\"%\"\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <ArrowUpOutlined />\n          </template>\n        </a-statistic>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with bottom padding and title area layout styles",
+          "descriptionZh": "头部元素，包含下内边距和标题区域的布局样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text color, font size and other title text display styles",
+          "descriptionZh": "标题元素，包含文字颜色、字体大小等标题文字的显示样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with text color, font size, font family and other numeric content display styles",
+          "descriptionZh": "内容元素，包含文字颜色、字体大小、字体族等数值内容的展示样式"
+        },
+        {
+          "key": "prefix",
+          "description": "Prefix element with inline-block display, right margin and other prefix content layout styles",
+          "descriptionZh": "前缀元素，包含行内块显示、右外边距等前缀内容的布局样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with inline-block display, left margin and other suffix content layout styles",
+          "descriptionZh": "后缀元素，包含行内块显示、左外边距等后缀内容的布局样式"
         }
       ]
     },
@@ -19848,14 +20780,58 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Steps by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Steps 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { StepsProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: StepsProps['classes'] = {\n  root: 'steps-demo-root',\n}\n\nconst stylesObject: StepsProps['styles'] = {\n  itemIcon: {\n    borderRadius: '30%',\n  },\n  itemContent: {\n    fontStyle: 'italic',\n  },\n}\n\nconst stylesFn: StepsProps['styles'] = (info) => {\n  if (info?.props?.type === 'navigation') {\n    return {\n      root: {\n        borderColor: '#1890ff',\n      },\n    }\n  }\n  return {}\n}\n\nconst items: StepsProps['items'] = [\n  { title: 'Finished', content: 'This is a content.' },\n  { title: 'In Progress', content: 'This is a content.' },\n  { title: 'Waiting', content: 'This is a content.' },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-steps :items=\"items\" :current=\"1\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-steps\n      :items=\"items\"\n      :current=\"1\"\n      type=\"navigation\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, nowrap, alignment, CSS variables and other basic step container styles",
+          "descriptionZh": "根元素，包含 flex 布局、禁止换行、对齐方式、CSS 变量等步骤条容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemWrapper', desc: t('itemWrapper') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n  { name: 'itemHeader', desc: t('itemHeader') },\n  { name: 'itemTitle', desc: t('itemTitle') },\n  { name: 'itemSubtitle', desc: t('itemSubtitle') },\n  { name: 'itemSection', desc: t('itemSection') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'itemRail', desc: t('itemRail') },\n])\n\nconst items = [\n  { title: 'Step 1', subTitle: '00:01', content: 'This is a content.' },\n  { title: 'Step 2', subTitle: '00:02', content: 'This is a content.' },\n  { title: 'Step 3', subTitle: '00:03', content: 'This is a content.' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Steps\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical gap=\"large\" :style=\"{ width: '100%' }\">\n        <a-steps\n          :current=\"1\"\n          :style=\"{ width: '100%' }\"\n          title-placement=\"vertical\"\n          :items=\"items\"\n          :classes=\"classes\"\n        />\n        <a-steps\n          :current=\"1\"\n          :style=\"{ width: '100%' }\"\n          type=\"panel\"\n          size=\"small\"\n          title-placement=\"horizontal\"\n          :items=\"items\"\n          :classes=\"classes\"\n        />\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Step item element with flex layout, relative positioning and other basic step item container styles",
+          "descriptionZh": "步骤项元素，包含 flex 布局、相对定位等单个步骤项的基础容器样式"
+        },
+        {
+          "key": "itemWrapper",
+          "description": "Step item wrapper element with flex layout, nowrap, top padding and other step content wrapping styles",
+          "descriptionZh": "步骤项内裹元素，包含 flex 布局、禁止换行、顶部内边距等步骤项内容的包装样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Step item icon element with icon size, positioning, font-size and other icon display related styles",
+          "descriptionZh": "步骤项图标元素，包含图标的尺寸、定位、字体大小等图标显示相关样式"
+        },
+        {
+          "key": "itemHeader",
+          "description": "Step item header element with flex layout, nowrap, alignment and other header area layout styles",
+          "descriptionZh": "步骤项头部元素，包含 flex 布局、禁止换行、对齐方式等头部区域的布局样式"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Step item title element with color, font-size, line-height, word-break, transitions and other title text styles",
+          "descriptionZh": "步骤项标题元素，包含颜色、字体大小、行高、文字换行、过渡动画等标题文字样式"
+        },
+        {
+          "key": "itemSubtitle",
+          "description": "Step item subtitle element with color, font-weight, font-size, line-height, margin, word-break and other subtitle styles",
+          "descriptionZh": "步骤项副标题元素，包含颜色、字体权重、字体大小、行高、外边距、文字换行等副标题样式"
+        },
+        {
+          "key": "itemSection",
+          "description": "Step item section element with step content area layout and styling",
+          "descriptionZh": "步骤项区域元素，包含步骤项内容区域的布局和样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Step item content element with color, font-size, line-height, word-break, transitions and other content text styles",
+          "descriptionZh": "步骤项内容元素，包含颜色、字体大小、行高、文字换行、过渡动画等内容文字样式"
+        },
+        {
+          "key": "itemRail",
+          "description": "Step item rail element with border-style, border-width, transitions and other connecting line styles",
+          "descriptionZh": "步骤项连接线元素，包含边框样式、边框宽度、过渡动画等连接线的样式"
         }
       ]
     },
@@ -20154,14 +21130,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Switch by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Switch 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes = {\n  root: 'custom-switch-root',\n}\n\nconst stylesObject = {\n  root: {\n    backgroundColor: '#F5D2D2',\n  },\n}\n\nfunction stylesFn(info: any) {\n  if (info.props.size === 'default') {\n    return {\n      root: {\n        backgroundColor: '#BDE3C3',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-switch\n      size=\"small\"\n      checked-children=\"on\"\n      un-checked-children=\"off\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n    />\n    <a-switch :classes=\"classes\" size=\"default\" :styles=\"stylesFn\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with min-width, height, line-height, vertical alignment, background color, border, border radius, cursor style, transition animations, user selection and other basic switch container styles",
+          "descriptionZh": "根元素，包含最小宽度、高度、行高、垂直对齐、背景色、边框、圆角、光标样式、过渡动画、用户选择等开关容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.3' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Switch\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-switch\n        checked-children=\"on\"\n        un-checked-children=\"off\"\n        default-checked\n        disabled\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "content",
+          "description": "Content element with block display, overflow hidden, border radius, height, padding, transition animations and other switch content area layout and styles",
+          "descriptionZh": "内容元素，包含块级显示、溢出隐藏、圆角、高度、内边距、过渡动画等开关内容区域的布局和样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element with absolute positioning, width, height, background color, border radius, shadow, transition animations and other switch handle styles and interactive effects",
+          "descriptionZh": "指示器元素,包含绝对定位、宽度、高度、背景色、圆角、阴影、过渡动画等开关把手的样式和交互效果"
         }
       ]
     },
@@ -20910,14 +21895,73 @@
           "description": "Customize header and body cells via the headerCell and bodyCell slots.",
           "descriptionZh": "通过 headerCell 与 bodyCell 插槽自定义表头和单元格内容。",
           "code": "<script setup lang=\"ts\">\nimport type { TableProps } from 'antdv-next'\n\ninterface DataItem {\n  key: string\n  name: string\n  age: number\n  address: string\n}\n\nconst columns: TableProps['columns'] = [\n  {\n    title: 'Name',\n    dataIndex: 'name',\n    key: 'name',\n  },\n  {\n    title: 'Age',\n    dataIndex: 'age',\n    key: 'age',\n  },\n  {\n    title: 'Address',\n    dataIndex: 'address',\n    key: 'address',\n  },\n  {\n    title: 'Action',\n    key: 'action',\n  },\n]\n\nconst dataSource: DataItem[] = [\n  {\n    key: '1',\n    name: 'John Brown',\n    age: 32,\n    address: 'New York No. 1 Lake Park',\n  },\n  {\n    key: '2',\n    name: 'Jim Green',\n    age: 42,\n    address: 'London No. 1 Lake Park',\n  },\n  {\n    key: '3',\n    name: 'Joe Black',\n    age: 32,\n    address: 'Sydney No. 1 Lake Park',\n  },\n]\n\nfunction handleAction(record: Record<string, any>) {\n  console.log('Action:', record.name)\n}\n</script>\n\n<template>\n  <a-table :columns=\"columns\" :data-source=\"dataSource\">\n    <template #headerCell=\"{ column }\">\n      <template v-if=\"column.key === 'name'\">\n        <span class=\"table-header-strong\">{{ column.title }}</span>\n      </template>\n    </template>\n    <template #bodyCell=\"{ column, text, record }\">\n      <template v-if=\"column.key === 'name'\">\n        <a class=\"table-name\" @click.prevent=\"handleAction(record)\">{{ text }}</a>\n      </template>\n      <template v-else-if=\"column.key === 'action'\">\n        <a @click.prevent=\"handleAction(record)\">Action</a>\n      </template>\n    </template>\n  </a-table>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with font-size, background, border-radius, scrollbar-color and other basic table container styles",
+          "descriptionZh": "根元素，包含字体大小、背景色、圆角、滚动条颜色等表格容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'title', desc: t('title') },\n  { name: 'content', desc: t('content') },\n  { name: 'header.wrapper', desc: t('header.wrapper') },\n  { name: 'header.row', desc: t('header.row') },\n  { name: 'header.cell', desc: t('header.cell') },\n  { name: 'section', desc: t('section') },\n  { name: 'body.wrapper', desc: t('body.wrapper') },\n  { name: 'body.row', desc: t('body.row') },\n  { name: 'body.cell', desc: t('body.cell') },\n  { name: 'footer', desc: t('footer') },\n  { name: 'pagination.root', desc: t('pagination.root') },\n  { name: 'pagination.item', desc: t('pagination.item') },\n])\n\nconst columns = [\n  {\n    title: 'Personal Info',\n    children: [\n      { title: 'Name', dataIndex: 'name', key: 'name' },\n      { title: 'Age', dataIndex: 'age', key: 'age' },\n    ],\n  },\n  { title: 'Address', dataIndex: 'address' },\n]\n\nconst data = [\n  { key: '1', name: 'thinkasany', age: 24, address: 'New York No. 1 Lake Park' },\n  { key: '2', name: 'Jim Green', age: 42, address: 'London No. 1 Lake Park' },\n  { key: '3', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n  { key: '4', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n  { key: '5', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n  { key: '6', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Table\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-table\n        bordered\n        :style=\"{ width: '100%' }\"\n        :columns=\"columns\"\n        :data-source=\"data\"\n        size=\"middle\"\n        :pagination=\"{ pageSize: 3 }\"\n        :classes=\"classes\"\n      >\n        <template #title>\n          table title\n        </template>\n        <template #footer>\n          table footer\n        </template>\n      </a-table>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Container element with clear-fix, max-width, scrollbar background and other table wrapper styles",
+          "descriptionZh": "容器元素，包含清除浮动、最大宽度、滚动条背景等表格包装容器样式"
+        },
+        {
+          "key": "header.wrapper",
+          "description": "Header wrapper element with table header layout and container styles",
+          "descriptionZh": "头部容器元素，包含表头的布局和容器样式"
+        },
+        {
+          "key": "header.row",
+          "description": "Header row element with table header row layout and styling",
+          "descriptionZh": "头部行元素，包含表头行的布局和样式"
+        },
+        {
+          "key": "header.cell",
+          "description": "Header cell element with relative positioning, padding, word-wrap, background, text color, font-weight and other header cell styles",
+          "descriptionZh": "头部单元格元素，包含相对定位、内边距、文字换行、背景色、文字颜色、字体权重等表头单元格样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with table title styling and layout",
+          "descriptionZh": "标题元素，包含表格标题的样式和布局"
+        },
+        {
+          "key": "body.wrapper",
+          "description": "Body wrapper element with table body layout and container styles",
+          "descriptionZh": "主体容器元素，包含表格主体的布局和容器样式"
+        },
+        {
+          "key": "body.row",
+          "description": "Body row element with hover effects, selected states, expanded states and other interactive row styles",
+          "descriptionZh": "主体行元素，包含数据行的悬浮效果、选中状态、展开状态等交互样式"
+        },
+        {
+          "key": "body.cell",
+          "description": "Body cell element with relative positioning, padding, word-wrap and other basic data cell styles",
+          "descriptionZh": "主体单元格元素，包含相对定位、内边距、文字换行等数据单元格的基础样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with table footer background color, text color and other footer styles",
+          "descriptionZh": "底部元素，包含表格底部的背景色、文字颜色等样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with table content area styling and layout",
+          "descriptionZh": "内容元素，包含表格内容区域的样式和布局"
+        },
+        {
+          "key": "pagination.root",
+          "description": "Pagination root element with pagination component basic styles and layout",
+          "descriptionZh": "分页根元素，包含分页组件的基础样式和布局"
+        },
+        {
+          "key": "pagination.item",
+          "description": "Pagination item element with pagination item styling and interactive effects",
+          "descriptionZh": "分页单项元素，包含分页项的样式和交互效果"
         }
       ]
     },
@@ -21422,14 +22466,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tabs by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tabs 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TabsProps } from 'antdv-next'\n\nconst items: TabsProps['items'] = [\n  { key: '1', label: 'Tab 1', content: 'Content of Tab Pane 1' },\n  { key: '2', label: 'Tab 2', content: 'Content of Tab Pane 2' },\n  { key: '3', label: 'Tab 3', content: 'Content of Tab Pane 3' },\n]\n\nconst classes: TabsProps['classes'] = {\n  root: 'custom-tabs-root',\n}\n\nconst stylesObject: TabsProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed', padding: '16px', marginBottom: '10px' },\n  header: { backgroundColor: 'rgba(245,245,245,0.5)' },\n  item: { fontWeight: 'bold', color: '#1890ff', padding: `6px 10px` },\n  indicator: { backgroundColor: 'rgba(255,77,79, 0.3)', height: '4px' },\n  content: { backgroundColor: 'rgba(230,247,255,0.8)', padding: '16px' },\n}\n\nconst stylesFn: TabsProps['styles'] = (info) => {\n  if (info.props.type === 'card') {\n    return {\n      root: { backgroundColor: 'rgba(250,250,250, 0.8)', borderColor: '#d9d9d9' },\n      header: { textAlign: 'start' },\n    } satisfies TabsProps['styles']\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-tabs :items=\"items\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-tabs type=\"card\" :items=\"items\" :classes=\"classes\" :styles=\"stylesFn\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with basic tab container styles, layout and direction control",
+          "descriptionZh": "根元素，包含标签页容器的基础样式、布局和方向控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'header', desc: t('header') },\n  { name: 'item', desc: t('item') },\n  { name: 'indicator', desc: t('indicator') },\n  { name: 'content', desc: t('content') },\n  { name: 'popup.root', desc: t('popup.root') },\n])\n\nconst items = computed(() =>\n  Array.from({ length: 30 }, (_, i) => {\n    const id = String(i)\n    return {\n      label: `Tab-${id}`,\n      key: id,\n      disabled: i === 28,\n      children: `Content of tab ${id}`,\n    }\n  }),\n)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tabs\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-tabs\n        default-active-key=\"1\"\n        :style=\"{ height: '220px', width: '100%' }\"\n        :styles=\"{\n          popup: {\n            root: { background: '#fff' },\n          },\n        }\"\n        :items=\"items\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with relative positioning, padding, colors, text ellipsis, border-radius, transitions and other tab item styles and interactive effects",
+          "descriptionZh": "Item 元素，包含相对定位、内边距、颜色、文本省略、圆角、过渡动画等标签项的样式和交互效果"
+        },
+        {
+          "key": "header",
+          "description": "Header element with tab navigation header layout, background, borders and other styles",
+          "descriptionZh": "头部元素，包含标签页头部导航的布局、背景、边框等样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element with indicator bar color, position, dimensions, transitions and other active state indication styles",
+          "descriptionZh": "指示器元素，包含指示条的颜色、位置、尺寸、过渡动画等活跃状态指示样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with tab content panel layout, padding and other content display styles",
+          "descriptionZh": "内容元素，包含标签页内容面板的布局、内边距等内容展示样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup menu element with dropdown absolute positioning, z-index, display control, max-height, scrolling and other styles",
+          "descriptionZh": "弹出菜单元素，包含下拉菜单的绝对定位、层级、显示控制、最大高度、滚动等样式"
         }
       ]
     },
@@ -21741,14 +22809,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tag by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tag 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { CheckCircleOutlined, CloseCircleOutlined } from '@antdv-next/icons'\n\nconst tagStyles = {\n  root: {\n    backgroundColor: '#e6f7ff',\n  },\n  icon: {\n    color: '#52c41a',\n  },\n  content: {\n    color: '#262626',\n  },\n}\n\nconst filledTagStyles = {\n  root: {\n    backgroundColor: '#F5EFFF',\n  },\n  icon: {\n    color: '#8F87F1',\n  },\n  content: {\n    color: '#8F87F1',\n  },\n}\n\nconst groupStyles = {\n  root: {\n    gap: '12px',\n    padding: '8px 12px',\n    backgroundColor: 'rgba(82, 196, 26, 0.08)',\n    borderRadius: '8px',\n  },\n  item: {\n    backgroundColor: 'rgba(82, 196, 26, 0.1)',\n    borderColor: 'rgba(82, 196, 26, 0.3)',\n    color: '#52c41a',\n  },\n}\n\nconst multipleGroupStyles = {\n  root: {\n    gap: '16px',\n    padding: '8px 12px',\n    backgroundColor: 'rgba(143, 135, 241, 0.08)',\n    borderRadius: '8px',\n  },\n  item: {\n    backgroundColor: 'rgba(143, 135, 241, 0.1)',\n    borderColor: 'rgba(143, 135, 241, 0.3)',\n    color: '#8F87F1',\n    fontWeight: 500,\n  },\n}\n\nconst options1 = ['React', 'Vue', 'Angular']\nconst options2 = ['meet-student', 'thinkasany']\n</script>\n\n<template>\n  <a-space size=\"large\" vertical>\n    <a-flex gap=\"middle\">\n      <a-tag :classes=\"{ root: 'custom-tag-root' }\" :styles=\"tagStyles\">\n        <template #icon>\n          <CheckCircleOutlined />\n        </template>\n        Object\n      </a-tag>\n      <a-tag\n        variant=\"filled\"\n        :classes=\"{ root: 'custom-tag-root' }\"\n        :styles=\"filledTagStyles\"\n      >\n        <template #icon>\n          <CloseCircleOutlined />\n        </template>\n        Function\n      </a-tag>\n    </a-flex>\n    <a-flex vertical gap=\"middle\">\n      <a-checkable-tag-group\n        :classes=\"{ root: 'custom-tag-root' }\"\n        :styles=\"groupStyles\"\n        :options=\"options1\"\n      />\n      <a-checkable-tag-group\n        :classes=\"{ root: 'custom-tag-root' }\"\n        :styles=\"multipleGroupStyles\"\n        :options=\"options2\"\n        multiple\n      />\n    </a-flex>\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with inline-block display, auto height, padding, font size, line height, nowrap, background color, border, border radius, opacity, transition animations, text alignment, relative positioning and other basic tag styles",
+          "descriptionZh": "根元素，包含行内块布局、自动高度、内边距、字体大小、行高、禁止换行、背景色、边框、圆角、透明度、过渡动画、文本对齐、相对定位等标签的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AntDesignOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tag\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-tag :classes=\"classes\">\n        <template #icon>\n          <AntDesignOutlined />\n        </template>\n        Ant Design\n      </a-tag>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element with font size, color, cursor style, transition animations and other icon display styles",
+          "descriptionZh": "图标元素，包含字体大小、颜色、光标样式、过渡动画等图标的显示样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with text content color, font styles and other content area styles",
+          "descriptionZh": "内容元素，包含文本内容的颜色、字体样式等内容区域的样式"
         }
       ]
     },
@@ -21895,14 +22972,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of TimePicker by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 TimePicker 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TimePickerProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { useToken } = theme\nconst { token } = useToken()\n\nconst customClasses = {\n  root: 'custom-timepicker-root',\n}\n\nconst stylesObject: TimePickerProps['styles'] = {\n  root: {\n    borderColor: '#d9d9d9',\n  },\n}\n\nconst stylesFn: TimePickerProps['styles'] = (info) => {\n  if (info.props.size === 'large') {\n    return {\n      root: {\n        borderColor: '#722ed1',\n      },\n      suffix: {\n        color: '#722ed1',\n      },\n      popup: {\n        container: { border: '1px solid #722ed1', borderRadius: '8px' },\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-time-picker :classes=\"customClasses\" :styles=\"stylesObject\" placeholder=\"Object\" />\n    <a-time-picker :classes=\"customClasses\" :styles=\"stylesFn\" placeholder=\"Function\" size=\"large\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, padding, border-radius, transition animations and other basic styles for time picker container",
+          "descriptionZh": "根元素，包含相对定位、行内flex布局、内边距、边框圆角、过渡动画等时间选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { SmileOutlined } from '@antdv-next/icons'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'popup.root', desc: t('popup') },\n  { name: 'popup.container', desc: t('popup.container') },\n  { name: 'popup.content', desc: t('popup.content') },\n  { name: 'popup.item', desc: t('popup.item') },\n  { name: 'popup.footer', desc: t('popup.footer') },\n])\n\nconst type = ref<'Single' | 'Multiple'>('Single')\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    :component-name=\"type === 'Single' ? 'TimePicker' : 'TimePicker.RangePicker'\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" vertical :style=\"{ alignSelf: 'flex-start' }\" gap=\"middle\" align=\"center\">\n        <a-segmented\n          :options=\"['Single', 'Multiple']\"\n          :value=\"type\"\n          @change=\"(val: 'Single' | 'Multiple') => type = val\"\n        />\n        <a-time-picker\n          v-if=\"type === 'Single'\"\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-time-picker>\n        <a-time-range-picker\n          v-else\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-time-range-picker>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with flex layout and margin styles for prefix content layout",
+          "descriptionZh": "前缀元素，包含flex布局、右外边距等前缀内容的布局样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with relative positioning, width, color, font, line-height, transition animations and other core interactive styles for input field",
+          "descriptionZh": "输入框元素，包含相对定位、宽度、颜色、字体、行高、过渡动画等输入框的核心交互样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with flex layout, color, line-height, pointer events, transition animations and other styles for suffix content",
+          "descriptionZh": "后缀元素，包含flex布局、颜色、行高、指针事件、过渡动画等后缀内容的样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup element",
+          "descriptionZh": "弹出框元素"
+        },
+        {
+          "key": "popup.container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "popup.content",
+          "description": "Popup content element with width, border, cell and other content display styles for time list",
+          "descriptionZh": "弹出框内容元素，包含时间列表的宽度、边框、单元格等内容展示样式"
+        },
+        {
+          "key": "popup.item",
+          "description": "Popup item element with size, background, border-radius, hover state, selected state and other interactive styles for time cells",
+          "descriptionZh": "弹出框单项元素，包含时间单元格的尺寸、背景色、边框圆角、悬停态、选中态等交互样式"
+        },
+        {
+          "key": "popup.footer",
+          "description": "Popup footer element with layout styles for bottom operation area including confirm/cancel buttons",
+          "descriptionZh": "弹出框底部元素，包含确认取消按钮等底部操作区域的布局样式"
         }
       ]
     },
@@ -22123,14 +23239,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Timeline by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Timeline 的[语义化结构](#semantic-dom)样式。",
           "code": "<script lang=\"ts\" setup>\nconst classes = {\n  root: 'custom-timeline-root',\n}\n\nconst styles = {\n  itemIcon: {\n    borderColor: '#1890ff',\n  },\n}\n\nfunction stylesFn(info: any) {\n  if (info.props.orientation === 'vertical') {\n    return {\n      root: {\n        padding: '10px 6px',\n        border: '1px solid #A294F9',\n      },\n      itemIcon: {\n        borderColor: '#A294F9',\n      },\n    }\n  }\n  return {}\n}\n\nconst items = [\n  {\n    title: '2015-09-01',\n    content: 'Create a services site',\n  },\n  {\n    title: '2015-09-01 09:12:11',\n    content: 'Solve initial network problems',\n  },\n  {\n    content: 'Technical testing',\n  },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-timeline :items=\"items\" orientation=\"horizontal\" :styles=\"styles\" :classes=\"classes\" />\n    <a-timeline :items=\"items\" orientation=\"vertical\" :styles=\"stylesFn\" :classes=\"classes\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with timeline container list style reset, vertical layout, dot icon, outlined style, alternate layout and other basic container styles",
+          "descriptionZh": "根元素，设置时间轴容器的列表样式重置、垂直布局、点状图标、轮廓样式、交替布局等基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemWrapper', desc: t('itemWrapper') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n  { name: 'itemSection', desc: t('itemSection') },\n  { name: 'itemHeader', desc: t('itemHeader') },\n  { name: 'itemTitle', desc: t('itemTitle') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'itemRail', desc: t('itemRail') },\n])\n\nconst items = [\n  { title: '2015-09-01', content: 'Create a services' },\n  { title: '2015-09-01 09:12:11', content: 'Solve initial network problems' },\n  { content: 'Technical testing' },\n  { title: '2015-09-01 09:12:11', content: 'Network problems being solved' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Timeline\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-timeline :items=\"items\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with single timeline node relative positioning, margin, padding, font size, finish state, color theme, layout direction and other node basic styles",
+          "descriptionZh": "节点元素，设置单个时间节点的相对定位、外边距、内边距、字体大小、完成状态、颜色主题、布局方向等节点基础样式"
+        },
+        {
+          "key": "itemWrapper",
+          "description": "Item wrapper element with timeline node content wrapping container styles",
+          "descriptionZh": "节点包装元素，设置时间节点内容的包装容器样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Item icon element with node head icon absolute positioning, width/height size, background color, border, border radius, wave animation and other icon styles",
+          "descriptionZh": "节点图标元素，设置节点头部图标的绝对定位、宽高尺寸、背景色、边框、圆角、波纹动画等图标样式"
+        },
+        {
+          "key": "itemHeader",
+          "description": "Item header element with header area layout containing title and rail, alignment, text direction and other styles",
+          "descriptionZh": "节点头部元素，设置包含标题和连接线的头部区域布局、对齐方式、文本方向等样式"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Item title element with node title text font size, line height, color and other text styles",
+          "descriptionZh": "节点标题元素，设置节点标题文字的字体大小、行高、颜色等文本样式"
+        },
+        {
+          "key": "itemSection",
+          "description": "Item section element with section container containing header and content flex layout, wrap, gap and other layout styles",
+          "descriptionZh": "节点区域元素，设置包含头部和内容的区域容器的Flex布局、换行、间距等布局样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Item content element with node detail content relative positioning, top offset, left margin, text color, word break and other content styles",
+          "descriptionZh": "节点内容元素，设置节点详细内容的相对定位、顶部偏移、左侧外边距、文字颜色、词汇换行等内容样式"
+        },
+        {
+          "key": "itemRail",
+          "description": "Item rail element with timeline node connection track line absolute positioning, top offset, left offset, height, border color, width, style and other connection line styles",
+          "descriptionZh": "节点连接线元素，设置连接时间节点的轨道线条的绝对定位、顶部偏移、左侧偏移、高度、边框颜色、宽度、样式等连接线样式"
         }
       ]
     },
@@ -22499,14 +23654,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tooltip by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tooltip 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TooltipProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: TooltipProps['classes'] = {\n  container: 'demo-tooltip-container',\n}\n\nconst stylesObject: TooltipProps['styles'] = {\n  container: {\n    borderRadius: '12px',\n    boxShadow: 'inset 0 0 8px #ccc',\n  },\n}\n\nconst stylesFn: TooltipProps['styles'] = (info) => {\n  if (info?.props?.arrow === false) {\n    return {\n      container: {\n        backgroundColor: 'rgba(53, 71, 125, 0.8)',\n        padding: '12px',\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-tooltip title=\"Object text\" :classes=\"classes\" :styles=\"stylesObject\" :arrow=\"false\">\n      <a-button>Object Style</a-button>\n    </a-tooltip>\n    <a-tooltip title=\"Function text\" :classes=\"classes\" :styles=\"stylesFn\" :arrow=\"false\">\n      <a-button type=\"primary\">\n        Function Style\n      </a-button>\n    </a-tooltip>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element (including arrows, content elements) with absolute positioning, z-index, block display, max width, visibility, transform origin and arrow background color",
+          "descriptionZh": "根元素 (包含箭头、内容元素)，设置绝对定位、层级、块级显示、最大宽度、可见性、变换原点和箭头背景色"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'container', desc: t('container') },\n  { name: 'arrow', desc: t('arrow') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tooltip\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', marginTop: '60px' }\">\n        <a-tooltip\n          open\n          placement=\"top\"\n          title=\"tooltip prompt text\"\n          :auto-adjust-overflow=\"false\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "container",
+          "description": "Content element with min width and height, padding, color, text alignment, background color, border radius, shadow and border styles",
+          "descriptionZh": "内容元素，设置最小宽度高度、内边距、颜色、文本对齐、背景色、圆角、阴影和边框样式"
+        },
+        {
+          "key": "arrow",
+          "description": "Arrow element with width, height, position, color and border styles",
+          "descriptionZh": "箭头元素，设置宽高、位置、颜色和边框样式"
         }
       ]
     },
@@ -22808,14 +23972,63 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tour by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tour 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TourProps, TourStepItem } from 'antdv-next'\nimport { computed, h, shallowRef } from 'vue'\n\nconst ref1 = shallowRef()\nconst ref2 = shallowRef()\nconst ref3 = shallowRef()\nconst open = shallowRef(false)\nconst openFn = shallowRef(false)\n\nconst btnProps = {\n  nextButtonProps: {\n    style: {\n      border: '1px solid #CDC1FF',\n      color: '#CDC1FF',\n    },\n  },\n  prevButtonProps: {\n    style: {\n      backgroundColor: '#CDC1FF',\n      color: '#fff',\n    },\n  },\n}\n\nconst coverNode = h('img', {\n  alt: 'tour.png',\n  src: 'https://user-images.githubusercontent.com/5378891/197385811-55df8480-7ff4-44bd-9d43-a7dade598d70.png',\n})\n\nconst steps: TourStepItem[] = [\n  {\n    title: 'Upload File',\n    description: 'Put your files here.',\n    cover: coverNode,\n    target: ref1,\n    prevButtonProps: {},\n  },\n  {\n    title: 'Save',\n    description: 'Save your changes.',\n    target: ref2,\n  },\n  {\n    title: 'Other Actions',\n    description: 'Click to see other actions.',\n    target: ref3,\n  },\n]\n\nconst stepsWithButtonProps = computed(() => steps.map(step => ({ ...step, ...btnProps })))\n\nconst classes: TourProps['classes'] = {\n  root: 'custom-tour-root',\n  section: 'custom-tour-section',\n}\n\nconst stylesObject: TourProps['styles'] = {\n  mask: {\n    backgroundColor: 'rgba(0, 0, 0, 0.3)',\n  },\n  section: {\n    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',\n    border: '2px solid #4096ff',\n  },\n  cover: {\n    borderRadius: '12px 12px 0 0',\n  },\n}\n\nconst stylesFn: TourProps['styles'] = (info) => {\n  if (info.props.type === 'primary') {\n    return {\n      mask: {\n        backgroundColor: 'rgba(0, 0, 0, 0.3)',\n      },\n      section: {\n        backgroundColor: 'rgba(205, 193, 255, 0.8)',\n        boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',\n      },\n      cover: {\n        borderRadius: '12px 12px 0 0',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-flex gap=\"middle\">\n      <a-button type=\"primary\" @click=\"open = true\">\n        Begin Tour Object\n      </a-button>\n      <a-button type=\"primary\" @click=\"openFn = true\">\n        Begin Tour Function\n      </a-button>\n    </a-flex>\n    <a-divider />\n    <a-tour\n      v-model:open=\"open\"\n      :steps=\"steps\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    />\n    <a-tour\n      v-model:open=\"openFn\"\n      :steps=\"stepsWithButtonProps\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n      type=\"primary\"\n    />\n    <a-space>\n      <a-button ref=\"ref1\" type=\"primary\">\n        Upload\n      </a-button>\n      <a-button ref=\"ref2\">\n        Save\n      </a-button>\n      <a-button ref=\"ref3\" type=\"dashed\">\n        Other Actions\n      </a-button>\n    </a-space>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Tour root container with absolute positioning, z-index control, max width, visibility, arrow background color variable, theme styles and other container styles",
+          "descriptionZh": "引导根容器，设置绝对定位、层级控制、最大宽度、可见性、箭头背景色变量、主题样式等容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'mask', desc: t('mask'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'cover', desc: t('cover'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n  { name: 'indicators', desc: t('indicators'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n])\n\nconst open = ref(true)\nconst createBtnRef = ref<HTMLButtonElement | null>(null)\n\nconst steps = [\n  {\n    title: 'Hello World!',\n    description: 'Hello World?!',\n    target: () => createBtnRef.value!,\n    mask: true,\n  },\n  {\n    title: 'Save',\n    description: 'Save your changes.',\n    target: () => createBtnRef.value!,\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tour\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div\n        :style=\"{\n          width: '100%',\n          height: '825px',\n          display: 'flex',\n          alignItems: 'center',\n          justifyContent: 'center',\n          position: 'relative',\n          overflow: 'hidden',\n        }\"\n      >\n        <a-button ref=\"createBtnRef\" @click=\"open = true\">\n          Show\n        </a-button>\n        <a-tour\n          v-model:open=\"open\"\n          :z-index=\"1\"\n          :default-current=\"0\"\n          :get-popup-container=\"false\"\n          :steps=\"steps\"\n          :classes=\"classes\"\n        >\n          <template #coverRender=\"{ index }\">\n            <template v-if=\"index === 0\">\n              <img src=\"https://user-images.githubusercontent.com/5378891/197385811-55df8480-7ff4-44bd-9d43-a7dade598d70.png\" alt=\"img\">\n            </template>\n          </template>\n        </a-tour>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "cover",
+          "description": "Card cover area with text center alignment, padding, image width and other image display styles",
+          "descriptionZh": "卡片封面区域，设置文本居中对齐、内边距、图片宽度等图片展示样式"
+        },
+        {
+          "key": "section",
+          "description": "Card main content area with text alignment, border radius, box shadow, relative positioning, background color, border, background clip and other card styles",
+          "descriptionZh": "卡片主要内容区域，设置文本对齐、边框圆角、盒阴影、相对定位、背景色、边框、背景裁剪等卡片样式"
+        },
+        {
+          "key": "footer",
+          "description": "Card bottom action area with padding, text right alignment, border radius, flex layout and other bottom container styles",
+          "descriptionZh": "卡片底部操作区域，设置内边距、文本右对齐、边框圆角、Flex布局等底部容器样式"
+        },
+        {
+          "key": "actions",
+          "description": "Action button group container with left auto margin, button spacing and other button group layout styles",
+          "descriptionZh": "操作按钮组容器，设置左侧自动外边距、按钮间距等按钮组布局样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Single indicator element with width/height size, inline-block display, border radius, background color, right margin, active state and other dot styles",
+          "descriptionZh": "单个指示器元素，设置宽高尺寸、行内块显示、圆角、背景色、右外边距、激活状态等圆点样式"
+        },
+        {
+          "key": "indicators",
+          "description": "Indicator group container with inline-block display and other indicator container styles",
+          "descriptionZh": "指示器组容器，设置行内块显示等指示器容器样式"
+        },
+        {
+          "key": "header",
+          "description": "Card header area with padding, width calculation, word break and other header container styles",
+          "descriptionZh": "卡片头部区域，设置内边距、宽度计算、词汇换行等头部容器样式"
+        },
+        {
+          "key": "title",
+          "description": "Guide title text with font weight and other title text styles",
+          "descriptionZh": "引导标题文字，设置字体粗细等标题文本样式"
+        },
+        {
+          "key": "description",
+          "description": "Guide description text with padding, word wrap and other description text styles",
+          "descriptionZh": "引导描述文字，设置内边距、词汇换行等描述文本样式"
+        },
+        {
+          "key": "mask",
+          "description": "Mask layer element with fixed positioning, full screen coverage, z-index, pointer events, transition animation and other mask styles",
+          "descriptionZh": "遮罩层元素，设置固定定位、全屏覆盖、层级、指针事件、过渡动画等遮罩样式"
         }
       ]
     },
@@ -23139,14 +24352,63 @@
           "description": "Custom the labels for select all checkboxes.",
           "descriptionZh": "自定义穿梭框全选按钮的文字。",
           "code": "<script setup lang=\"ts\">\nimport type { TransferEmits, TransferProps } from 'antdv-next'\nimport { ref } from 'vue'\n\ninterface RecordType {\n  key: string\n  title: string\n  description: string\n}\n\nconst mockData = Array.from({ length: 10 }).map<RecordType>((_, i) => ({\n  key: i.toString(),\n  title: `content${i + 1}`,\n  description: `description of content${i + 1}`,\n}))\n\nconst oriTargetKeys = mockData.filter(item => Number(item.key) % 3 > 1).map(item => item.key)\n\nconst selectAllLabels: TransferProps['selectAllLabels'] = [\n  'Select All',\n  ({ selectedCount, totalCount }) => `${selectedCount}/${totalCount}`,\n]\n\nconst targetKeys = ref(oriTargetKeys)\n\nconst handleChange: TransferEmits['change'] = (newTargetKeys) => {\n  targetKeys.value = newTargetKeys\n}\n</script>\n\n<template>\n  <a-transfer\n    v-model:target-keys=\"targetKeys\"\n    :data-source=\"mockData\"\n    :render=\"(item: RecordType) => item.title\"\n    :select-all-labels=\"selectAllLabels\"\n    @change=\"handleChange\"\n  />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, transfer container base styles and layout control",
+          "descriptionZh": "根元素，设置flex布局、穿梭框容器的基础样式和布局控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'section', desc: t('section') },\n  { name: 'header', desc: t('header') },\n  { name: 'title', desc: t('title') },\n  { name: 'body', desc: t('body') },\n  { name: 'list', desc: t('list') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'footer', desc: t('footer') },\n  { name: 'actions', desc: t('actions') },\n])\n\nconst mockData = Array.from({ length: 20 }).map((_, i) => ({\n  key: i,\n  title: `content ${i + 1}`,\n}))\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Transfer\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-transfer\n        show-search\n        :titles=\"['Source', 'Target']\"\n        :data-source=\"mockData\"\n        :selected-keys=\"[]\"\n        :target-keys=\"[3, 9]\"\n        :render=\"(item: any) => item.title\"\n        :styles=\"{\n          section: { height: '250px', width: '200px' },\n        }\"\n        :classes=\"classes\"\n      >\n        <template #footer>\n          <div :style=\"{ padding: '8px' }\">\n            Custom Footer\n          </div>\n        </template>\n      </a-transfer>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Section element with flex layout, width, height, min height, border, border radius and other single-side transfer container styles",
+          "descriptionZh": "区域元素，设置flex布局、宽度、高度、最小高度、边框、圆角等单侧穿梭框的容器样式"
+        },
+        {
+          "key": "header",
+          "description": "Header element with flex layout, alignment, height, padding, color, background color, bottom border, border radius and other header area styles",
+          "descriptionZh": "头部元素，设置flex布局、对齐方式、高度、内边距、颜色、背景色、下边框、圆角等头部区域的样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text ellipsis, flex ratio, text alignment, auto left margin and other title text layout and styles",
+          "descriptionZh": "标题元素，设置文本省略、flex占比、文本对齐、自动左边距等标题文字的布局和样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with list main area container styles and layout control",
+          "descriptionZh": "内容元素，设置列表主体区域的容器样式和布局控制"
+        },
+        {
+          "key": "list",
+          "description": "List element with list content styles, layout and scroll control",
+          "descriptionZh": "列表元素，设置列表内容的样式、布局和滚动控制"
+        },
+        {
+          "key": "item",
+          "description": "List item element with relative positioning, padding, border, hover state, selected state, disabled state and other list item interaction styles",
+          "descriptionZh": "列表项元素，设置相对定位、内边距、边框、悬停态、选中态、禁用态等列表项的交互样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "List item icon element with checkbox and other icon styles and interaction states",
+          "descriptionZh": "列表项图标元素，设置复选框等图标的样式和交互状态"
+        },
+        {
+          "key": "itemContent",
+          "description": "List item content element with text ellipsis, padding and other list item text content display styles",
+          "descriptionZh": "列表项内容元素，设置文本省略、内边距等列表项文本内容的展示样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with bottom operation area styles and layout",
+          "descriptionZh": "页脚元素，设置底部操作区域的样式和布局"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element with transfer button group styles, layout and interaction states",
+          "descriptionZh": "操作元素，设置穿梭按钮组的样式、布局和交互状态"
         }
       ]
     },
@@ -23834,14 +25096,28 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tree by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tree 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TreeDataNode, TreeProps } from 'antdv-next'\nimport { ref } from 'vue'\n\nconst treeData: TreeDataNode[] = [\n  {\n    title: 'parent 1',\n    key: '0-0',\n    children: [\n      {\n        title: 'parent 1-0',\n        key: '0-0-0',\n        children: [\n          {\n            title: 'leaf',\n            key: '0-0-0-0',\n          },\n          {\n            title: 'leaf',\n            key: '0-0-0-1',\n          },\n        ],\n      },\n      {\n        title: 'parent 1-1',\n        key: '0-0-1',\n        children: [\n          {\n            title: 'leaf',\n            key: '0-0-1-0',\n          },\n        ],\n      },\n    ],\n  },\n]\n\nconst styles: TreeProps['styles'] = {\n  root: { border: '2px solid #d9d9d9' },\n  item: { margin: '2px 0' },\n}\n\nconst stylesFn: TreeProps['styles'] = (info) => {\n  if (!info.props.checkable) {\n    return {\n      root: {\n        border: `2px solid #E5D9F2`,\n        borderRadius: '4px',\n      },\n    }\n  }\n  return {}\n}\n\nconst expandedKeys = ref(['0-0-0', '0-0-1'])\nconst selectedKeys = ref(['0-0-1'])\nconst checkedKeys = ref(['0-0-0', '0-0-1'])\nconst classes = {\n  root: 'root',\n  item: 'item',\n  itemTitle: 'itemTitle',\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-tree\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      auto-expand-parent\n      checkable\n      :styles=\"styles\"\n    />\n    <a-tree\n      v-model:expanded-keys=\"expandedKeys\"\n      v-model:selected-keys=\"selectedKeys\"\n      v-model:checked-keys=\"checkedKeys\"\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      auto-expand-parent\n      :checkable=\"false\"\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with tree control base styles, layout and container control",
+          "descriptionZh": "根元素，设置树形控件的基础样式、布局和容器控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { DownOutlined, FrownFilled, FrownOutlined, MehOutlined, SmileOutlined } from '@antdv-next/icons'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'itemIcon', desc: t('itemIcon'), version: '1.0.0' },\n  { name: 'itemTitle', desc: t('itemTitle'), version: '1.0.0' },\n])\n\nconst treeData = [\n  {\n    title: 'parent 1',\n    key: '0-0',\n    icon: h(SmileOutlined),\n    children: [\n      { title: 'leaf', key: '0-0-0', icon: h(MehOutlined) },\n      { title: 'leaf', key: '0-0-1', icon: ({ selected }: { selected: boolean }) => selected ? h(FrownFilled) : h(FrownOutlined) },\n    ],\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tree\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-tree\n        show-icon\n        default-expand-all\n        :default-selected-keys=\"['0-0-0']\"\n        :tree-data=\"treeData\"\n        :classes=\"classes\"\n      >\n        <template #switcherIcon>\n          <DownOutlined />\n        </template>\n      </a-tree>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with tree node base styles, drag state, role attributes, indentation, switcher, content wrapper and other node structure",
+          "descriptionZh": "条目元素，设置树节点的基础样式、拖拽状态、角色属性、缩进、切换器、内容包装器等节点结构"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Title element with tree node title text display styles and text content",
+          "descriptionZh": "标题元素，设置树节点标题文字的显示样式和文本内容"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Icon element with tree node icon styles, size and state display",
+          "descriptionZh": "图标元素，设置树节点图标的样式、尺寸和状态显示"
         }
       ]
     },
@@ -24417,14 +25693,68 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of TreeSelect by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 TreeSelect 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TreeSelectProps } from 'antdv-next'\n\nconst classes: TreeSelectProps['classes'] = {\n  root: 'custom-tree-select',\n}\n\nconst stylesObject: TreeSelectProps['styles'] = {\n  input: {\n    fontSize: 16,\n  },\n  suffix: {\n    color: '#1890ff',\n  },\n  popup: {\n    root: {\n      border: '1px solid #1890ff',\n    },\n  },\n}\n\nconst stylesFn: TreeSelectProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      suffix: {\n        color: '#722ed1',\n      },\n      popup: {\n        item: {\n          color: '#722ed1',\n        },\n      },\n    }\n  }\n  return {}\n}\n\nconst treeData: TreeSelectProps['treeData'] = [\n  {\n    value: 'parent 1',\n    title: 'parent 1',\n    children: [\n      {\n        value: 'parent 1-0',\n        title: 'parent 1-0',\n        children: [\n          {\n            value: 'leaf1',\n            title: 'leaf1',\n          },\n          {\n            value: 'leaf2',\n            title: 'leaf2',\n          },\n        ],\n      },\n      {\n        value: 'parent 1-1',\n        title: 'parent 1-1',\n        children: [\n          {\n            value: 'leaf3',\n            title: 'leaf3',\n          },\n        ],\n      },\n    ],\n  },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-tree-select\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      placeholder=\"Object\"\n    />\n    <a-tree-select\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      placeholder=\"Function\"\n      size=\"middle\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with tree selector base styles, border, border radius container styles",
+          "descriptionZh": "根元素，设置树选择器的基础样式、边框、圆角容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst mode = ref<'single' | 'multiple'>('single')\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => {\n  const base = [\n    { name: 'root', desc: t('root') },\n    { name: 'prefix', desc: t('prefix') },\n    { name: 'placeholder', desc: t('placeholder') },\n  ]\n\n  if (mode.value === 'multiple') {\n    base.push(\n      ...[\n        { name: 'content', desc: t('content') },\n        { name: 'item', desc: t('item') },\n        { name: 'itemContent', desc: t('itemContent') },\n        { name: 'itemRemove', desc: t('itemRemove') },\n      ],\n    )\n  }\n\n  base.push(\n    ...[\n      { name: 'input', desc: t('input') },\n      { name: 'suffix', desc: t('suffix') },\n      { name: 'popup.root', desc: t('popup.root') },\n      { name: 'popup.item', desc: t('popup.item') },\n      { name: 'popup.itemTitle', desc: t('popup.itemTitle') },\n    ],\n  )\n\n  return base\n})\n\nconst treeValue = ref<string[]>([])\nconsole.log(treeValue)\nfunction handleResetValue(newMode: string | number) {\n  if (newMode === 'multiple') {\n    treeValue.value = ['aojunhao123']\n  }\n  else {\n    treeValue.value = []\n  }\n}\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst treeData = [\n  {\n    value: 'contributors',\n    title: 'contributors',\n    children: [\n      { value: 'aojunhao123', title: 'aojunhao123' },\n      { value: 'thinkasany', title: 'thinkasany' },\n      { value: 'meet-student', title: 'meet-student' },\n    ],\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"TreeSelect\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <div :style=\"{ display: 'flex', justifyContent: 'center', marginBottom: '12px' }\">\n          <a-segmented v-model:value=\"mode\" :options=\"['single', 'multiple']\" @change=\"handleResetValue\" />\n        </div>\n\n        <a-tree-select\n          v-model:value=\"treeValue\"\n          prefix=\"prefix\"\n          :style=\"{ width: '300px' }\"\n          :tree-data=\"treeData\"\n          tree-default-expand-all\n          :multiple=\"mode === 'multiple'\"\n          show-search\n          max-tag-count=\"responsive\"\n          placeholder=\"Please select\"\n          allow-clear\n          open\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with prefix content layout and styles",
+          "descriptionZh": "前缀元素，设置前缀内容的布局和样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "input",
+          "description": "Input element with text input, search, selected value display and other input core interaction styles",
+          "descriptionZh": "输入框元素，设置文本输入、搜索、选择值显示等输入框的核心交互样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with suffix content, clear button, dropdown arrow and other suffix area styles",
+          "descriptionZh": "后缀元素，设置后缀内容、清除按钮、下拉箭头等后缀区域的样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with dropdown tree selection panel positioning, z-index, background, border, shadow and other popup layer styles",
+          "descriptionZh": "弹出菜单元素，设置下拉树形选择面板的定位、层级、背景、边框、阴影等弹层样式"
+        },
+        {
+          "key": "popup.item",
+          "description": "Popup item element with tree node option styles, hover state, selected state and other interaction states",
+          "descriptionZh": "弹出菜单条目元素，设置树节点选项的样式、悬停态、选中态等交互状态"
+        },
+        {
+          "key": "popup.itemTitle",
+          "description": "Popup title element with tree node title text display styles",
+          "descriptionZh": "弹出菜单标题元素，设置树节点标题文字的显示样式"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "item",
+          "description": "Multiple selection item element with border, background, padding, and margin styles",
+          "descriptionZh": "多选项元素，包含边框、背景、内边距、外边距样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Multiple selection item content area with text ellipsis styles",
+          "descriptionZh": "多选项内容区域，包含文字的省略样式"
+        },
+        {
+          "key": "itemRemove",
+          "description": "Multiple selection item remove button with font-related styles",
+          "descriptionZh": "多选项移除按钮，包含字体相关样式"
         }
       ]
     },
@@ -24937,7 +26267,8 @@
           "descriptionZh": "添加后缀的省略。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst rows = ref(1)\n\nconst article = `To be, or not to be, that is the question: Whether it is nobler in the mind to suffer. The slings and arrows of outrageous fortune Or to take arms against a sea of troubles, And by opposing end them? To die: to sleep; No more; and by a sleep to say we end The heart-ache and the thousand natural shocks That flesh is heir to, 'tis a consummation Devoutly to be wish'd. To die, to sleep To sleep- perchance to dream: ay, there's the rub! For in that sleep of death what dreams may come When we have shuffled off this mortal coil, Must give us pause. There 's the respect That makes calamity of so long life`\n\nfunction onEllipsis(ellipsis: boolean) {\n  console.log('Ellipsis changed:', ellipsis)\n}\n</script>\n\n<template>\n  <div>\n    <a-slider v-model:value=\"rows\" :min=\"1\" :max=\"10\" />\n    <a-typography-paragraph\n      :ellipsis=\"{\n        rows,\n        expandable: true,\n        suffix: '--William Shakespeare',\n        onEllipsis,\n      }\"\n      :title=\"`${article}--William Shakespeare`\"\n    >\n      {{ article }}\n    </a-typography-paragraph>\n  </div>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Upload",
@@ -25393,14 +26724,23 @@
           "description": "Component Token Debug.",
           "descriptionZh": "Component Token Debug.",
           "code": "<script setup lang=\"ts\">\nimport type { UploadEmits, UploadFile } from 'antdv-next'\nimport { UploadOutlined } from '@antdv-next/icons'\n\nconst defaultFileList: UploadFile[] = [\n  {\n    uid: '1',\n    name: 'xxx.png',\n    status: 'uploading',\n    url: 'http://www.baidu.com/xxx.png',\n    percent: 33,\n  },\n  {\n    uid: '2',\n    name: 'yyy.png',\n    status: 'done',\n    url: 'http://www.baidu.com/yyy.png',\n  },\n  {\n    uid: '3',\n    name: 'zzz.png',\n    status: 'error',\n    response: 'Server Error 500',\n    url: 'http://www.baidu.com/zzz.png',\n  },\n]\n\nconst handleChange: UploadEmits['change'] = ({ file, fileList }) => {\n  if (file.status !== 'uploading') {\n    console.log(file, fileList)\n  }\n}\n</script>\n\n<template>\n  <a-config-provider\n    :theme=\"{\n      components: {\n        Upload: {\n          actionsColor: 'yellow',\n        },\n      },\n    }\"\n  >\n    <a-upload\n      action=\"https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload\"\n      :default-file-list=\"defaultFileList\"\n      @change=\"handleChange\"\n    >\n      <a-button>\n        <template #icon>\n          <UploadOutlined />\n        </template>\n        Upload\n      </a-button>\n    </a-upload>\n  </a-config-provider>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root container element with layout styles, disabled text color, user-select control, cursor styles and other basic styles",
+          "descriptionZh": "根元素容器，包含布局样式、禁用状态文字颜色、用户选择控制、鼠标样式等基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { UploadOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'list', desc: t('list'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n])\n\nconst defaultFileList = [\n  { uid: '1', name: 'xxx.png', status: 'uploading', url: 'http://www.baidu.com/xxx.png', percent: 33 },\n  { uid: '2', name: 'yyy.png', status: 'done', url: 'http://www.baidu.com/yyy.png' },\n  { uid: '3', name: 'zzz.png', status: 'error', response: 'Server Error 500', url: 'http://www.baidu.com/zzz.png' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Upload\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-upload\n        action=\"https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload\"\n        :default-file-list=\"defaultFileList\"\n        :classes=\"classes\"\n      >\n        <a-button>\n          <template #icon>\n            <UploadOutlined />\n          </template>\n          Upload\n        </a-button>\n      </a-upload>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "list",
+          "description": "File list container with layout arrangement, transition animations, spacing control and other styles",
+          "descriptionZh": "文件列表容器，包含布局排列、过渡动画、间距控制等样式"
+        },
+        {
+          "key": "item",
+          "description": "File item element with padding, background color, border styles, hover effects, status colors, transition animations and other styles",
+          "descriptionZh": "文件项元素，包含内边距、背景色、边框样式、悬停效果、状态颜色、过渡动画等样式"
         }
       ]
     },
@@ -25547,7 +26887,8 @@
           "descriptionZh": "在 Modal 与 Drawer 中使用。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst showModal = shallowRef(false)\nconst showDrawer = shallowRef(false)\nconst showDrawer2 = shallowRef(false)\n\nconst placeholderStyle = {\n  height: '300px',\n  display: 'flex',\n  justifyContent: 'center',\n  alignItems: 'center',\n  backgroundColor: 'rgba(150, 150, 150, 0.2)',\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-button type=\"primary\" @click=\"showModal = true\">\n      Show in Modal\n    </a-button>\n    <a-button type=\"primary\" @click=\"showDrawer = true\">\n      Show in Drawer\n    </a-button>\n    <a-button type=\"primary\" @click=\"showDrawer2 = true\">\n      Not Show in Drawer\n    </a-button>\n  </a-flex>\n  <a-watermark content=\"Antdv Next\">\n    <a-modal\n      v-model:open=\"showModal\"\n      destroy-on-hidden\n      title=\"Modal\"\n      @ok=\"showModal = false\"\n      @cancel=\"showModal = false\"\n    >\n      <div :style=\"placeholderStyle\">\n        A mock height\n      </div>\n    </a-modal>\n    <a-drawer\n      v-model:open=\"showDrawer\"\n      destroy-on-hidden\n      title=\"Drawer\"\n      @close=\"showDrawer = false\"\n    >\n      <div :style=\"placeholderStyle\">\n        A mock height\n      </div>\n    </a-drawer>\n  </a-watermark>\n  <a-watermark content=\"Antdv Next\" :inherit=\"false\">\n    <a-drawer\n      v-model:open=\"showDrawer2\"\n      destroy-on-hidden\n      title=\"Drawer\"\n      @close=\"showDrawer2 = false\"\n    >\n      <div :style=\"placeholderStyle\">\n        A mock height\n      </div>\n    </a-drawer>\n  </a-watermark>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     }
   ],
   "changelog": [

--- a/data/v1.1.9.json
+++ b/data/v1.1.9.json
@@ -1805,7 +1805,8 @@
           "descriptionZh": "用 `target` 设置 `Affix` 需要监听其滚动事件的元素，默认为 `window`。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst container = shallowRef()\n</script>\n\n<template>\n  <div ref=\"container\" style=\"width: 100%;height: 100px;overflow: auto;box-shadow: 0 0 0 1px #1677ff;scrollbar-width: thin;scrollbar-gutter: stable\">\n    <div style=\"width: 100%;height: 1000px\">\n      <a-affix :target=\"() => container\">\n        <a-button type=\"primary\">\n          Fixed at the top of container\n        </a-button>\n      </a-affix>\n    </div>\n  </div>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Alert",
@@ -2074,14 +2075,43 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Alert by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Alert 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { AlertProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: AlertProps['classes'] = {\n  root: 'demo-alert-root',\n}\n\nconst stylesObject: AlertProps['styles'] = {\n  icon: {\n    fontSize: '18px',\n  },\n  section: {\n    fontWeight: 500,\n  },\n}\n\nconst stylesFn: AlertProps['styles'] = (info) => {\n  if (info?.props?.type === 'success') {\n    return {\n      root: {\n        backgroundColor: 'rgba(82, 196, 26, 0.1)',\n        borderColor: '#b7eb8f',\n      },\n      icon: {\n        color: '#52c41a',\n      },\n    }\n  }\n  if (info?.props?.type === 'warning') {\n    return {\n      root: {\n        backgroundColor: 'rgba(250, 173, 20, 0.1)',\n        borderColor: '#ffe58f',\n      },\n      icon: {\n        color: '#faad14',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"small\">\n    <a-alert\n      title=\"Object styles\"\n      type=\"info\"\n      show-icon\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n    >\n      <template #action>\n        <a-button size=\"small\">\n          Action\n        </a-button>\n      </template>\n    </a-alert>\n    <a-alert\n      title=\"Function styles\"\n      type=\"success\"\n      show-icon\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with border, background, padding, border-radius, and positioning styles for the alert container",
+          "descriptionZh": "根元素，包含边框、背景色、内边距、圆角、位置布局等警告提示框的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Alert\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-alert\n        closable\n        title=\"Info Text\"\n        show-icon\n        description=\"Info Description Info Description Info Description Info Description\"\n        type=\"info\"\n        :classes=\"classes\"\n      >\n        <template #action>\n          <a-space direction=\"vertical\">\n            <a-button size=\"small\" type=\"primary\">\n              Accept\n            </a-button>\n            <a-button size=\"small\" danger ghost>\n              Decline\n            </a-button>\n          </a-space>\n        </template>\n      </a-alert>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Content element with flex layout controlling content area typography and minimum width",
+          "descriptionZh": "内容元素，采用 flex 布局控制内容区域的排版和最小宽度"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with color, line-height, and margin styles, supporting different status icon types",
+          "descriptionZh": "图标元素，包含图标的颜色、行高、外边距等样式，支持不同类型的状态图标"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text color and font styling for the alert title",
+          "descriptionZh": "标题元素，包含标题文字的颜色、字体等样式"
+        },
+        {
+          "key": "description",
+          "description": "Description element with font-size and line-height styles for additional content",
+          "descriptionZh": "描述元素，包含描述文字的字体大小、行高等排版样式"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element with layout and spacing styles for action buttons",
+          "descriptionZh": "操作组元素，包含操作按钮的布局和间距样式"
+        },
+        {
+          "key": "close",
+          "description": "Close button element with basic button styling",
+          "descriptionZh": "关闭按钮元素，包含按钮的基础样式"
         }
       ]
     },
@@ -2319,14 +2349,28 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Anchor by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "您可以通过 `classes` 和 `styles` 传入对象/函数可以自定义 Anchor 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { AnchorProps } from 'antdv-next'\n\nconst classesObject: AnchorProps['classes'] = {\n  root: 'demo-anchor-root',\n  item: 'demo-anchor-item',\n  itemTitle: 'demo-anchor-title',\n  indicator: 'demo-anchor-indicator',\n}\n\nconst stylesFn: AnchorProps['styles'] = (info) => {\n  if (info.props.direction === 'vertical') {\n    return {\n      root: {\n        backgroundColor: 'rgba(255,251,230,0.5)',\n        height: '100vh',\n      },\n    }\n  }\n  return {}\n}\n\nconst items: NonNullable<AnchorProps['items']> = [\n  {\n    key: 'part-1',\n    href: '#part-1',\n    title: 'Part 1',\n  },\n  {\n    key: 'part-2',\n    href: '#part-2',\n    title: 'Part 2',\n  },\n  {\n    key: 'part-3',\n    href: '#part-3',\n    title: 'Part 3',\n  },\n]\n</script>\n\n<template>\n  <a-row>\n    <a-col :span=\"16\">\n      <div id=\"part-1\" style=\"height: 100vh; background: rgba(255, 0, 0, 0.08)\" />\n      <div id=\"part-2\" style=\"height: 100vh; background: rgba(0, 255, 0, 0.08)\" />\n      <div id=\"part-3\" style=\"height: 100vh; background: rgba(0, 0, 255, 0.08)\" />\n    </a-col>\n    <a-col :span=\"8\">\n      <a-anchor replace :items=\"items\" :styles=\"stylesFn\" :classes=\"classesObject\" />\n    </a-col>\n  </a-row>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with layout positioning, padding, margin, background color and other basic styles",
+          "descriptionZh": "根元素，包含布局定位、内边距、边距、背景色等基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'itemTitle', desc: t('itemTitle'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n])\n\nconst items = [\n  {\n    key: 'api',\n    href: '#api',\n    title: 'API',\n    children: [\n      { key: '4', href: '#anchor-props', title: 'Anchor Props' },\n      { key: '5', href: '#link-props', title: 'Link Props' },\n    ],\n  },\n  { key: '1', href: '#anchor-demo-basic', title: 'Basic demo' },\n  { key: '2', href: '#anchor-demo-static', title: 'Static demo' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Anchor\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-anchor :affix=\"false\" :items=\"items\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Link item element with padding, text color, hover states, transition animations and other styles",
+          "descriptionZh": "链接项元素，包含内边距、文字颜色、悬停状态、过渡动画等样式"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Title text element with font styles, color changes, text decoration, transition effects and other styles",
+          "descriptionZh": "标题文字元素，包含字体样式、颜色变化、文本装饰、过渡效果等样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element with width, height, background color, position changes, transition animations and other styles",
+          "descriptionZh": "指示器元素，包含宽度、高度、背景色、位置变化、过渡动画等样式"
         }
       ]
     },
@@ -2389,7 +2433,8 @@
           "descriptionZh": "对 `message`、`notification` 进行配置。。",
           "code": "<script setup lang=\"ts\">\nimport MyPage2 from './myPage2.vue'\n</script>\n\n<template>\n  <a-app :message=\"{ maxCount: 1 }\" :notification=\"{ placement: 'bottomLeft' }\">\n    <MyPage2 />\n  </a-app>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "AutoComplete",
@@ -2692,14 +2737,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of AutoComplete by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 AutoComplete 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst stylesObject = {\n  popup: {\n    root: {\n      borderWidth: '1px',\n      borderStyle: 'solid',\n      borderColor: '#1890ff',\n    },\n    list: {\n      backgroundColor: 'rgba(240, 240, 240, 0.85)',\n    },\n    listItem: {\n      color: '#272727',\n    },\n  },\n}\n\nfunction stylesFn({ props }: { props: { variant?: string } }) {\n  if (props.variant === 'filled') {\n    return {\n      popup: {\n        root: {\n          borderWidth: '1px',\n          borderStyle: 'solid',\n          borderColor: '#ccc',\n        },\n        list: {\n          backgroundColor: 'rgba(240, 240, 240, 0.85)',\n        },\n        listItem: {\n          color: '#272727',\n        },\n      },\n    }\n  }\n  return {}\n}\n\nconst options = [\n  { value: 'Burnaby' },\n  { value: 'Seattle' },\n  { value: 'Los Angeles' },\n  { value: 'San Francisco' },\n  { value: 'Meet student' },\n]\n\nconst sharedProps = {\n  options,\n  classes: {\n    root: 'auto-complete-style-root',\n  },\n  style: { width: '200px' },\n}\n\nconst value = ref('')\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-auto-complete v-model:value=\"value\" v-bind=\"sharedProps\" placeholder=\"object styles\" :styles=\"stylesObject\" />\n    <a-auto-complete\n      v-model:value=\"value\"\n      v-bind=\"sharedProps\"\n      placeholder=\"function styles\"\n      :styles=\"stylesFn\"\n      variant=\"filled\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, cursor styles, transitions, border and other basic selector container styles",
+          "descriptionZh": "根元素，包含相对定位、行内 flex 布局、光标样式、过渡动画、边框等选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'placeholder', desc: t('placeholder') },\n  { name: 'content', desc: t('content') },\n  { name: 'clear', desc: t('clear') },\n  { name: 'popup.root', desc: t('popup.root') },\n  { name: 'popup.list', desc: t('popup.list') },\n  { name: 'popup.listItem', desc: t('popup.listItem') },\n])\n\nconst options = ref([\n  { value: 'aojunhao123', label: 'aojunhao123' },\n  { value: 'thinkasany', label: 'thinkasany' },\n  { value: 'meet-student', label: 'meet-student' },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"AutoComplete\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <a-auto-complete\n          prefix=\"prefix\"\n          :style=\"{ width: '200px' }\"\n          :options=\"options\"\n          placeholder=\"input here\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with layout and styling for prefix content",
+          "descriptionZh": "前缀元素，包含前缀内容的布局和样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with search input styling, cursor control, font inheritance and other search-related styles. Remove border styles",
+          "descriptionZh": "输入框元素，包含搜索输入框的样式、光标控制、字体继承等搜索相关样式，去除了边框样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "clear",
+          "description": "Clear button element with layout, styling and interactive effects for clear button",
+          "descriptionZh": "清除按钮元素，包含清除按钮的布局、样式和交互效果"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with popup layer positioning, z-index, background, border, box-shadow and other popup container styles",
+          "descriptionZh": "弹出菜单元素，包含弹出层的定位、层级、背景、边框、阴影等弹出容器样式"
+        },
+        {
+          "key": "popup.list",
+          "description": "Popup list element with option list layout, scrolling, max-height and other list container styles",
+          "descriptionZh": "弹出菜单列表元素，包含选项列表的布局、滚动、最大高度等列表容器样式"
+        },
+        {
+          "key": "popup.listItem",
+          "description": "Popup item element with option item padding, hover effects, selected states, disabled states and other option interactive styles",
+          "descriptionZh": "弹出菜单条目元素，包含选项项的内边距、悬浮效果、选中状态、禁用状态等选项交互样式"
         }
       ]
     },
@@ -2988,7 +3072,8 @@
           "descriptionZh": "头像大小可以根据屏幕大小自动调整。",
           "code": "<script setup lang=\"ts\">\nimport { AntDesignOutlined } from '@antdv-next/icons'\n</script>\n\n<template>\n  <a-avatar\n    :size=\"{ xs: 24, sm: 32, md: 40, lg: 64, xl: 80, xxl: 100 }\"\n  >\n    <template #icon>\n      <AntDesignOutlined />\n    </template>\n  </a-avatar>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Badge",
@@ -3258,22 +3343,33 @@
           "description": "The badge will display `title` when hovered over, instead of `count`.",
           "descriptionZh": "设置鼠标放在状态点上时显示的文字。",
           "code": "<script setup lang=\"ts\">\n</script>\n\n<template>\n  <a-space size=\"large\">\n    <a-badge :count=\"5\" title=\"Custom hover text\">\n      <a-avatar shape=\"square\" size=\"large\" />\n    </a-badge>\n    <a-badge :count=\"-5\" title=\"Negative\">\n      <a-avatar shape=\"square\" size=\"large\" />\n    </a-badge>\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-block display, and fit-content width for basic layout",
+          "descriptionZh": "根元素，包含相对定位、行内块布局、适应内容宽度等基础布局样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Badge\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-badge :count=\"5\" :classes=\"classes\">\n        <a-avatar shape=\"square\" size=\"large\" />\n      </a-badge>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "indicator",
+          "description": "Indicator element with positioning, z-index, dimensions, colors, fonts, text alignment, background, border-radius, box-shadow, and transition animations for complete badge styling",
+          "descriptionZh": "指示器元素，包含定位、层级、尺寸、颜色、字体、文本对齐、背景、圆角、阴影、过渡动画等完整的徽标样式"
         },
         {
-          "name": "_semantic_ribbon",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('ribbonRoot'), version: '1.0.0' },\n  { name: 'indicator', desc: t('ribbonIndicator'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <div style=\"display: flex; flex-direction: column; gap: 24px;\">\n    <SemanticPreview\n      component-name=\"Badge\"\n      :semantics=\"semantics\"\n    >\n      <template #default=\"{ classes }\">\n        <div style=\"width: 100%;\">\n          <a-badge-ribbon text=\"Hippies\" color=\"magenta\" :classes=\"classes\">\n            <a-card title=\"Pushes open the window\" size=\"small\">\n              and raises the spyglass.\n            </a-card>\n          </a-badge-ribbon>\n        </div>\n      </template>\n    </SemanticPreview>\n  </div>\n</template>"
+          "key": "ribbonRoot",
+          "description": "Root element, set relative positioning and wrapper container styles",
+          "descriptionZh": "根元素，设置相对定位和包装容器样式"
+        },
+        {
+          "key": "ribbonIndicator",
+          "description": "Indicator element, set absolute positioning, padding, background color, border radius and ribbon styles",
+          "descriptionZh": "指示器元素，设置绝对定位、内边距、背景色、圆角和缎带样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element, set text color and ribbon content display styles",
+          "descriptionZh": "文本元素，设置文本颜色和缎带内容显示样式"
         }
       ]
     },
@@ -3463,14 +3559,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Breadcrumb by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Breadcrumb 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { BreadcrumbProps } from 'antdv-next'\n\nconst classesObject = {\n  root: 'demo-breadcrumb-root',\n  item: 'demo-breadcrumb-item',\n  separator: 'demo-breadcrumb-separator',\n}\n\nconst stylesObject: BreadcrumbProps['styles'] = {\n  root: { border: '1px solid #f0f0f0', padding: '8px', borderRadius: '4px' },\n  item: { color: '#1890ff' },\n  separator: { color: 'rgba(0, 0, 0, 0.45)' },\n}\n\nconst stylesFn: BreadcrumbProps['styles'] = (info) => {\n  const items = info.props.items || []\n  if (items.length > 2) {\n    return {\n      root: { border: '1px solid #F5EFFF', padding: '8px', borderRadius: '4px' },\n      item: { color: '#8F87F1' },\n    }\n  }\n  return {}\n}\n\nconst items = [\n  { title: 'Antdv Next' },\n  { title: 'Component' },\n  { title: 'Breadcrumb' },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-breadcrumb\n      :classes=\"classesObject\"\n      :items=\"items.slice(0, 2)\"\n      :styles=\"stylesObject\"\n      aria-label=\"Breadcrumb with Object\"\n    />\n    <a-breadcrumb\n      :classes=\"classesObject\"\n      :items=\"items\"\n      :styles=\"stylesFn\"\n      aria-label=\"Breadcrumb with Function\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with text color, font size, icon size and other basic styles, using flex layout with ordered list",
+          "descriptionZh": "根元素，包含文字颜色、字体大小、图标尺寸等基础样式，内部使用 flex 布局的有序列表"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { HomeOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'separator', desc: t('separator'), version: '1.0.0' },\n])\n\nconst items = [\n  { href: '', title: h(HomeOutlined) },\n  { href: '', title: [h(UserOutlined), h('span', 'Application List')] },\n  { title: 'Application' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Breadcrumb\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-breadcrumb :items=\"items\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with text color, link color transitions, hover effects, padding, border-radius, height, and margin styles",
+          "descriptionZh": "Item 元素，包含文字颜色、链接的颜色变化、悬浮效果、内边距、圆角、高度、外边距等样式"
+        },
+        {
+          "key": "separator",
+          "description": "Separator element with margin and color styles for the divider",
+          "descriptionZh": "分隔符元素，包含分隔符的外边距和颜色样式"
         }
       ]
     },
@@ -3984,20 +4089,29 @@
           "code": "<script setup lang=\"ts\">\nimport type { ButtonProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: ButtonProps['classes'] = {\n  root: 'demo-button-root',\n  content: 'demo-button-content',\n}\n\nconst stylesObject: ButtonProps['styles'] = {\n  root: {\n    boxShadow: '0 1px 2px 0 rgba(0,0,0,0.05)',\n  },\n}\n\nconst stylesFn: ButtonProps['styles'] = (info) => {\n  if (info?.props?.type === 'primary') {\n    return {\n      root: {\n        backgroundColor: '#171717',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"small\">\n    <a-button type=\"default\" :classes=\"classes\" :styles=\"stylesObject\">\n      Object\n    </a-button>\n    <a-button type=\"primary\" :classes=\"classes\" :styles=\"stylesFn\">\n      Function\n    </a-button>\n  </a-flex>\n</template>"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AntDesignOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Button\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-button type=\"primary\" :classes=\"classes\">\n        <template #icon>\n          <AntDesignOutlined />\n        </template>\n        Antdv Next\n      </a-button>\n    </template>\n  </SemanticPreview>\n</template>"
-        },
-        {
           "name": "chinese-space",
           "title": "",
           "titleZh": "移除两个汉字之间的空格",
           "description": "We add a space between two Chinese characters by default, which can be removed by setting `autoInsertSpace` to `false`.",
           "descriptionZh": "我们默认在两个汉字之间添加空格，可以通过设置 `autoInsertSpace` 为 `false` 关闭。",
           "code": "<template>\n  <a-flex gap=\"small\" wrap>\n    <a-button type=\"primary\" :auto-insert-space=\"false\">\n      确定\n    </a-button>\n    <a-button type=\"primary\" auto-insert-space>\n      确定\n    </a-button>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with comprehensive button styling including border, background, padding, border-radius, box-shadow, transitions, cursor, font-weight, alignment, and layout properties",
+          "descriptionZh": "根元素，包含边框样式、背景色、内边距、圆角、阴影效果、过渡动画、光标样式、文字权重、对齐方式等完整的按钮外观样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element that wraps button text with typography styles including nowrap, text-align center, and Chinese character spacing optimization",
+          "descriptionZh": "内容元素，包装按钮文本内容，控制文本的不换行显示、居中对齐、中文字符间距优化等文本排版样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with font-size, color inheritance, and SVG style reset for proper icon display",
+          "descriptionZh": "图标元素，包含图标的字体大小、颜色继承、SVG 样式重置等图标显示相关样式"
         }
       ]
     },
@@ -4285,14 +4399,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Calendar by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Calendar 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CalendarProps } from 'antdv-next'\nimport type { Dayjs } from 'dayjs'\n\nconst classes = {\n  root: 'custom-calendar-root',\n}\n\nconst stylesObject: CalendarProps<Dayjs>['styles'] = {\n  root: {\n    borderRadius: '8px',\n    width: '600px',\n  },\n}\n\nconst stylesFunction: CalendarProps<Dayjs>['styles'] = (info) => {\n  if (info.props.fullscreen) {\n    return {\n      root: {\n        border: '2px solid #BDE3C3',\n        borderRadius: '10px',\n        backgroundColor: 'rgba(189,227,195, 0.3)',\n      },\n    } satisfies CalendarProps<Dayjs>['styles']\n  }\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-calendar :fullscreen=\"false\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-calendar :classes=\"classes\" :styles=\"stylesFunction\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element containing background, border, border-radius and overall layout structure of the calendar component",
+          "descriptionZh": "根元素，包含日历组件的背景色、边框、圆角等基础样式和整体布局结构"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Calendar\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-calendar :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with layout and style control for year selector, month selector and mode switcher",
+          "descriptionZh": "头部元素，包含年份选择器、月份选择器、模式切换器的布局和样式控制"
+        },
+        {
+          "key": "body",
+          "description": "Body element with padding and layout control for the calendar table that contains the calendar grid",
+          "descriptionZh": "主体元素，包含日历表格的内边距、布局控制等样式，用于容纳日历网格"
+        },
+        {
+          "key": "content",
+          "description": "Content element with width, height and table styling control for the calendar table",
+          "descriptionZh": "内容元素，包含日历表格的宽度、高度等尺寸控制和表格样式"
+        },
+        {
+          "key": "item",
+          "description": "Item element with background, border, hover state, selected state and other interactive styles for calendar cells",
+          "descriptionZh": "条目元素，包含日历单元格的背景色、边框、悬停态、选中态等交互样式"
         }
       ]
     },
@@ -4762,14 +4895,43 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Card by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Card 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CardProps } from 'antdv-next'\nimport { EditOutlined, HeartOutlined, ShareAltOutlined } from '@antdv-next/icons'\nimport { theme } from 'antdv-next'\nimport { computed } from 'vue'\n\nconst { token } = theme.useToken()\n\nconst classes = computed(() => ({\n  root: 'custom-card-root',\n  header: 'custom-card-header',\n  body: 'custom-card-body',\n}))\n\nconst stylesCard = computed(() => ({\n  root: {\n    boxShadow: '0 2px 8px rgba(0,0,0,0.06)',\n    borderRadius: '8px',\n  },\n  title: {\n    fontSize: '16px',\n    fontWeight: 500,\n  },\n}))\n\nconst stylesCardFn = computed(() => {\n  return (info: { props: CardProps }) => {\n    if (info.props.variant === 'outlined') {\n      return {\n        root: {\n          borderColor: '#696FC7',\n          boxShadow: '0 2px 8px #A7AAE1',\n          borderRadius: '8px',\n        },\n        extra: {\n          color: '#696FC7',\n        },\n        title: {\n          fontSize: '16px',\n          fontWeight: 500,\n          color: '#A7AAE1',\n        },\n      }\n    }\n    return {}\n  }\n})\n\nconst stylesCardMeta = {\n  title: {\n    color: '#A7AAE1',\n  },\n  description: {\n    color: '#A7AAE1',\n  },\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-card\n      title=\"Object Card\"\n      :classes=\"classes\"\n      :styles=\"stylesCard\"\n      variant=\"borderless\"\n    >\n      <template #extra>\n        <a-button type=\"link\">\n          More\n        </a-button>\n      </template>\n      <template #actions>\n        <HeartOutlined key=\"heart\" style=\"color: #ff6b6b\" />\n        <ShareAltOutlined key=\"share\" style=\"color: #4ecdc4\" />\n        <EditOutlined key=\"edit\" style=\"color: #45b7d1\" />\n      </template>\n      <a-card-meta title=\"Object Card Meta title\" description=\"This is the description\">\n        <template #avatar>\n          <a-avatar src=\"https://api.dicebear.com/7.x/miniavs/svg?seed=1\" />\n        </template>\n      </a-card-meta>\n    </a-card>\n    <a-card\n      title=\"Function Card\"\n      :classes=\"classes\"\n      :styles=\"stylesCardFn\"\n    >\n      <template #extra>\n        <a-button type=\"link\" :styles=\"{ root: { color: '#A7AAE1' } }\">\n          More\n        </a-button>\n      </template>\n      <template #actions>\n        <HeartOutlined key=\"heart\" style=\"color: #ff6b6b\" />\n        <ShareAltOutlined key=\"share\" style=\"color: #4ecdc4\" />\n        <EditOutlined key=\"edit\" style=\"color: #45b7d1\" />\n      </template>\n      <a-card-meta\n        title=\"Function Card Meta title\"\n        description=\"This is the description\"\n        :styles=\"stylesCardMeta\"\n      >\n        <template #avatar>\n          <a-avatar src=\"https://api.dicebear.com/7.x/miniavs/svg?seed=1\" />\n        </template>\n      </a-card-meta>\n    </a-card>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Card root element with positioning, background, border, border-radius, box-shadow, padding and other container styles",
+          "descriptionZh": "卡片根元素，包含位置定位、背景色、边框、圆角、阴影、内边距等卡片容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, EllipsisOutlined, SettingOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'cover', desc: t('cover'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Card\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ position: 'absolute' }\">\n        <a-card\n          title=\"Card title\"\n          extra=\"More\"\n          :style=\"{ width: '300px' }\"\n          :classes=\"classes\"\n        >\n          <template #cover>\n            <img\n              draggable=\"false\"\n              alt=\"example\"\n              src=\"https://gw.alipayobjects.com/zos/rmsportal/JiqGstEfoWAOHiTxclqi.png\"\n            >\n          </template>\n          <template #actions>\n            <SettingOutlined key=\"setting\" />\n            <EditOutlined key=\"edit\" />\n            <EllipsisOutlined key=\"ellipsis\" />\n          </template>\n          <a-card-meta\n            title=\"Card Meta title\"\n            description=\"This is the description\"\n          >\n            <template #avatar>\n              <a-avatar src=\"https://api.dicebear.com/7.x/miniavs/svg?seed=8\" />\n            </template>\n          </a-card-meta>\n        </a-card>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Card header area with flex layout, min-height, padding, text color, font-weight, font-size, background, bottom border and top border-radius",
+          "descriptionZh": "卡片头部区域，包含 flex 布局、最小高度、内边距、文字颜色、字体权重、字体大小、背景色、下边框、顶部圆角等样式"
+        },
+        {
+          "key": "body",
+          "description": "Card content area with padding, font-size and other content display styles",
+          "descriptionZh": "卡片内容区域，包含内边距、字体大小等内容展示的基础样式"
+        },
+        {
+          "key": "extra",
+          "description": "Card extra operation area in top-right corner with text color and layout styles for additional content",
+          "descriptionZh": "卡片右上角的操作区域，包含额外内容的文字颜色和布局样式"
+        },
+        {
+          "key": "title",
+          "description": "Card title with inline-block display, flex-grow, text ellipsis and other title display styles",
+          "descriptionZh": "卡片标题，包含行内块布局、flex 占比、文本省略等标题显示样式"
+        },
+        {
+          "key": "actions",
+          "description": "Card bottom action group with flex layout, list-style reset, background, top border and bottom border-radius for action buttons container",
+          "descriptionZh": "卡片底部操作组，包含 flex 布局、列表样式重置、背景色、上边框、底部圆角等操作按钮容器样式"
+        },
+        {
+          "key": "cover",
+          "description": "Title cover with styles for cover image display and layout",
+          "descriptionZh": "标题封面，包含封面图片的显示和布局样式"
         }
       ]
     },
@@ -5035,7 +5197,8 @@
           "descriptionZh": "展示指示点的进度。",
           "code": "<template>\n  <a-carousel :autoplay=\"{ dotDuration: true }\" :autoplay-speed=\"5000\">\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        1\n      </h3>\n    </div>\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        2\n      </h3>\n    </div>\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        3\n      </h3>\n    </div>\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        4\n      </h3>\n    </div>\n  </a-carousel>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Cascader",
@@ -5427,14 +5590,6 @@
           "code": "<script setup lang=\"ts\">\nimport type { CascaderEmits } from 'antdv-next'\nimport { ref } from 'vue'\n\ninterface Option {\n  value: string | number\n  label: string\n  children?: Option[]\n}\n\nconst options: Option[] = [\n  {\n    value: 'zhejiang',\n    label: 'Zhejiang',\n    children: [\n      {\n        value: 'hangzhou',\n        label: 'Hangzhou',\n        children: [\n          {\n            value: 'xihu',\n            label: 'West Lake',\n          },\n        ],\n      },\n    ],\n  },\n  {\n    value: 'jiangsu',\n    label: 'Jiangsu',\n    children: [\n      {\n        value: 'nanjing',\n        label: 'Nanjing',\n        children: [\n          {\n            value: 'zhonghuamen',\n            label: 'Zhong Hua Men',\n          },\n        ],\n      },\n    ],\n  },\n]\n\nconst disabled = ref(false)\n\nconst onChange: CascaderEmits['change'] = (value) => {\n  console.log(value)\n}\n\nconst onMultipleChange: CascaderEmits['change'] = (value) => {\n  console.log(value)\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"small\" align=\"flex-start\">\n    <a-switch\n      v-model:checked=\"disabled\"\n      checked-children=\"Enabled\"\n      un-checked-children=\"Disabled\"\n      aria-label=\"disabled switch\"\n    />\n    <a-cascader-panel :options=\"options\" :disabled=\"disabled\" @change=\"onChange\" />\n    <a-cascader-panel multiple :options=\"options\" :disabled=\"disabled\" @change=\"onMultipleChange\" />\n    <a-cascader-panel />\n  </a-flex>\n</template>"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst mode = ref<'single' | 'multiple'>('single')\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => {\n  const base = [\n    { name: 'root', desc: t('root') },\n    { name: 'prefix', desc: t('prefix') },\n    { name: 'content', desc: t('content') },\n    { name: 'placeholder', desc: t('placeholder') },\n    { name: 'clear', desc: t('clear') },\n    { name: 'input', desc: t('input') },\n    { name: 'suffix', desc: t('suffix') },\n    { name: 'popup.root', desc: t('popup.root') },\n    { name: 'popup.list', desc: t('popup.list') },\n    { name: 'popup.listItem', desc: t('popup.listItem') },\n  ]\n\n  if (mode.value === 'multiple') {\n    return [\n      ...base,\n      { name: 'item', desc: t('item') },\n      { name: 'itemContent', desc: t('itemContent') },\n      { name: 'itemRemove', desc: t('itemRemove') },\n    ]\n  }\n\n  return base\n})\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst options = [\n  {\n    value: 'contributors',\n    label: 'contributors',\n    children: [\n      { value: 'aojunhao123', label: 'aojunhao123' },\n      { value: 'thinkasany', label: 'thinkasany' },\n      { value: 'meet-student', label: 'meet-student' },\n    ],\n  },\n]\n\nconst value = computed(() => {\n  if (mode.value !== 'multiple')\n    return ['contributors', 'thinkasany']\n\n  return [['contributors', 'aojunhao123']]\n})\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Cascader\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <div :style=\"{ display: 'flex', justifyContent: 'center', marginBottom: '12px' }\">\n          <a-segmented v-model:value=\"mode\" :options=\"['single', 'multiple']\" />\n        </div>\n        <div :style=\"{ display: 'flex', flexDirection: 'column', gap: '12px' }\">\n          <a-cascader\n            prefix=\"prefix\"\n            :style=\"{ width: '300px' }\"\n            :options=\"options\"\n            :value=\"value\"\n            :multiple=\"mode === 'multiple'\"\n            open\n            :get-popup-container=\"() => divRef!\"\n            :classes=\"classes\"\n          />\n        </div>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
-        },
-        {
           "name": "basic",
           "title": "",
           "titleZh": "基本",
@@ -5481,6 +5636,73 @@
           "description": "Allows the selection of only parent options.",
           "descriptionZh": "这种交互允许只选中父级选项。",
           "code": "<script setup lang=\"ts\">\nimport type { CascaderEmits } from 'antdv-next'\nimport { shallowRef } from 'vue'\n\ninterface Option {\n  value: string\n  label: string\n  children?: Option[]\n}\n\nconst options: Option[] = [\n  {\n    value: 'zhejiang',\n    label: 'Zhejiang',\n    children: [\n      {\n        value: 'hangzhou',\n        label: 'Hanzhou',\n        children: [\n          {\n            value: 'xihu',\n            label: 'West Lake',\n          },\n        ],\n      },\n    ],\n  },\n  {\n    value: 'jiangsu',\n    label: 'Jiangsu',\n    children: [\n      {\n        value: 'nanjing',\n        label: 'Nanjing',\n        children: [\n          {\n            value: 'zhonghuamen',\n            label: 'Zhong Hua Men',\n          },\n        ],\n      },\n    ],\n  },\n]\n\nconst onChange: CascaderEmits['change'] = (value) => {\n  console.log(value)\n}\nconst value = shallowRef()\n</script>\n\n<template>\n  <a-cascader v-model:value=\"value\" :options=\"options\" change-on-select @change=\"onChange\" />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, cursor styles, transitions, border and other basic selector container styles",
+          "descriptionZh": "根元素，包含相对定位、行内 flex 布局、光标样式、过渡动画、边框等选择器容器的基础样式"
+        },
+        {
+          "key": "prefix",
+          "description": "Prefix element with layout and styling for prefix content",
+          "descriptionZh": "前缀元素，包含前缀内容的布局和样式"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "clear",
+          "description": "Clear button element with layout, styling and interactive effects for clear button式",
+          "descriptionZh": "清除按钮元素，包含清除按钮的布局、样式和交互效果"
+        },
+        {
+          "key": "item",
+          "description": "Multiple selection item element with border, background, padding, and margin styles",
+          "descriptionZh": "多选项元素，包含边框、背景、内边距、外边距样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Multiple selection item content area with text ellipsis styles",
+          "descriptionZh": "多选项内容区域，包含文字的省略样式"
+        },
+        {
+          "key": "itemRemove",
+          "description": "Multiple selection item remove button with font-related styles式",
+          "descriptionZh": "多选项移除按钮，包含字体相关样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with search input styling, cursor control, font inheritance and other search-related styles. Remove border styles",
+          "descriptionZh": "输入框元素，包含搜索输入框的样式、光标控制、字体继承等搜索相关样式，去除了边框样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with layout and styling for suffix content like clear button, arrow icon, etc.",
+          "descriptionZh": "后缀元素，包含后缀内容的布局和样式，如清除按钮、箭头图标等"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with popup layer positioning, z-index, background, border, box-shadow and other popup container styles",
+          "descriptionZh": "弹出菜单元素，包含弹出层的定位、层级、背景、边框、阴影等弹出容器样式"
+        },
+        {
+          "key": "popup.list",
+          "description": "Popup list element with option list layout, scrolling, max-height and other list container styles",
+          "descriptionZh": "弹出菜单列表元素，包含选项列表的布局、滚动、最大高度等列表容器样式"
+        },
+        {
+          "key": "popup.listItem",
+          "description": "Popup item element with option item padding, hover effects, selected states, disabled states and other option interactive styles",
+          "descriptionZh": "弹出菜单条目元素，包含选项项的内边距、悬浮效果、选中状态、禁用状态等选项交互样式式"
         }
       ]
     },
@@ -5709,14 +5931,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Checkbox by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Checkbox 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CheckboxProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\nimport { ref } from 'vue'\n\nconst checked = ref(true)\nconst { token } = theme.useToken()\n\n// Object styles — 静态样式对象\nconst stylesObject: CheckboxProps['styles'] = {\n  icon: {\n    borderRadius: '6px',\n  },\n  label: {\n    color: 'blue',\n  },\n}\n\n// Function classes — 根据 checked 状态动态返回类名\nconst classesFn: CheckboxProps['classes'] = (info) => {\n  const base: Record<string, string> = {\n    root: 'checkbox-demo-root',\n    icon: 'checkbox-demo-icon',\n    label: 'checkbox-demo-label',\n  }\n  if (info.props.checked) {\n    return {\n      root: base.root,\n      icon: `${base.icon} checkbox-demo-icon-checked`,\n      label: `${base.label} checkbox-demo-label-checked`,\n    }\n  }\n  return base\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-checkbox :styles=\"stylesObject\">\n      Object styles\n    </a-checkbox>\n    <a-checkbox\n      v-model:checked=\"checked\"\n      :classes=\"classesFn\"\n    >\n      Function classes\n    </a-checkbox>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with inline-flex layout, baseline alignment, cursor style, reset styles and other basic checkbox container styles",
+          "descriptionZh": "根元素，包含行内 flex 布局、基线对齐、光标样式、重置样式等复选框容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Checkbox\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-checkbox :classes=\"classes\">\n        Checkbox\n      </a-checkbox>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Checkbox icon element with size, direction, background, border, border-radius, transitions, and checked state checkmark styles",
+          "descriptionZh": "选中框元素，包含尺寸、方向、背景色、边框、圆角、过渡动画，以及选中状态的勾选标记样式"
+        },
+        {
+          "key": "label",
+          "description": "Label text element with padding and spacing styles relative to the checkbox",
+          "descriptionZh": "文本元素，包含文本的内边距和与复选框的间距样式"
         }
       ]
     },
@@ -6064,14 +6295,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Collapse by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Collapse 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CollapseProps } from 'antdv-next'\nimport { h } from 'vue'\n\nconst text\n  = 'A dog is a type of domesticated animal. Known for its loyalty and faithfulness, it can be found as a welcome guest in many households across the world.'\n\nconst element = h('p', text)\n\nconst items = [\n  {\n    key: '1',\n    label: 'This is panel header 1',\n    content: element,\n  },\n  {\n    key: '2',\n    label: 'This is panel header 2',\n    content: element,\n  },\n  {\n    key: '3',\n    label: 'This is panel header 3',\n    content: element,\n  },\n]\n\nconst classes: CollapseProps['classes'] = {\n  root: 'demo-collapse-root',\n}\n\nconst stylesObject: CollapseProps['styles'] = {\n  root: {\n    backgroundColor: '#fafafa',\n    border: '1px solid #e0e0e0',\n    borderRadius: '8px',\n  },\n  header: {\n    backgroundColor: '#f0f0f0',\n    padding: '12px 16px',\n    color: '#141414',\n  },\n}\n\nconst stylesFn: CollapseProps['styles'] = (info) => {\n  if (info?.props?.size === 'large') {\n    return {\n      root: {\n        backgroundColor: '#fff',\n        border: '1px solid #696FC7',\n        borderRadius: '8px',\n      },\n      header: {\n        backgroundColor: '#F5EFFF',\n        padding: '12px 16px',\n        color: '#141414',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-collapse :items=\"items\" :classes=\"classes\" :styles=\"stylesObject\" :default-active-key=\"['1']\" />\n    <a-collapse :items=\"items\" :classes=\"classes\" :styles=\"stylesFn\" size=\"large\" :default-active-key=\"['2']\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with border, border-radius, background color and container styles that control the overall layout and appearance of collapse panels",
+          "descriptionZh": "根元素，包含折叠面板的边框、圆角、背景色等容器样式，控制面板的整体布局和外观"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { theme } from 'antdv-next'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n])\n\nconst { token } = theme.useToken()\n\nconst items = computed(() => [\n  {\n    key: '1',\n    label: 'This is panel header',\n    children: 'This is panel body',\n  },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Collapse\"\n    items-a-p-i=\"items\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ position: 'absolute', inset: 0, margin: `${token.marginXL}px` }\">\n        <a-collapse\n          :items=\"items\"\n          :default-active-key=\"['1']\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with flex layout, padding, color, line-height, cursor style, transition animations and other interactive styles for panel headers",
+          "descriptionZh": "头部元素，包含flex布局、内边距、颜色、行高、光标样式、过渡动画等面板头部的交互和样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with flex auto layout and margin styles for title text layout and typography",
+          "descriptionZh": "标题元素，包含flex自适应布局、右边距等标题文字的布局和排版样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with padding, color, background color and other styles for panel content area display",
+          "descriptionZh": "内容元素，包含内边距、颜色、背景色等面板内容区域的展示样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with font size, transition animations, rotation transforms and other styles and animations for expand/collapse arrows",
+          "descriptionZh": "图标元素，包含字体大小、过渡动画、旋转变换等展开收起箭头的样式和动效"
         }
       ]
     },
@@ -6419,14 +6669,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of ColorPicker by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或函数可以自定义 ColorPicker 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst classes = { root: 'custom-color-picker' }\n\nconst color = shallowRef('#1677ff')\nconst colorLarge = shallowRef('#722ed1')\n\nconst stylesObject = {\n  popup: {\n    root: {\n      border: '1px solid #fff',\n    },\n  },\n}\n\nfunction stylesFn(info: any) {\n  if (info?.props?.size === 'large') {\n    return {\n      popup: {\n        root: {\n          border: '1px solid #722ed1',\n        },\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-space size=\"middle\" wrap>\n    <a-color-picker\n      v-model:value=\"color\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    />\n    <a-color-picker\n      v-model:value=\"colorLarge\"\n      size=\"large\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n    />\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Trigger container with border styles, transition animations, size controls, displaying color block and text content",
+          "descriptionZh": "触发器容器，包含边框样式、过渡动画、尺寸控制等样式，显示颜色块和文本内容"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'body', desc: t('body') },\n  { name: 'content', desc: t('content') },\n  { name: 'description', desc: t('description') },\n  { name: 'popup.root', desc: t('popup.root') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\nconst body = document?.body\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"ColorPicker\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" :style=\"{ height: '300px' }\" align=\"flex-start\" gap=\"small\">\n        <a-color-picker\n          default-value=\"#1677ff\"\n          open\n          show-text\n          :get-popup-container=\"() => divRef || body\"\n          :styles=\"{ popup: { root: { zIndex: 1 } } }\"\n          :classes=\"classes\"\n        />\n        <a-color-picker :open=\"false\" allow-clear :classes=\"classes\" />\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "popup.root",
+          "description": "Popup panel root container with background color, shadow effects, color selection panel, slider controls and preset colors",
+          "descriptionZh": "弹出面板根容器，包含背景色、阴影效果、色彩选择面板、滑块控制和预设颜色等样式"
+        },
+        {
+          "key": "body",
+          "description": "Color block container with background color, border styles",
+          "descriptionZh": "色块容器，包含底色、边框等样式"
+        },
+        {
+          "key": "content",
+          "description": "Color block element with actual selected color styles",
+          "descriptionZh": "色块颜色元素，包含实际选择的颜色样式"
+        },
+        {
+          "key": "description",
+          "description": "Description text content with font styles and color",
+          "descriptionZh": "描述文本内容，包含字体样式、颜色等样式"
         }
       ]
     },
@@ -6640,7 +6909,8 @@
           "descriptionZh": "获取父级 `Provider` 的值。如 `DisabledContextProvider`、`SizeContextProvider`。",
           "code": "<script setup lang=\"ts\">\nimport type { ConfigProviderProps } from 'antdv-next'\nimport { ref } from 'vue'\nimport ConfigDisplay from './use-config-display.vue'\n\ntype SizeType = ConfigProviderProps['componentSize']\n\nconst componentSize = ref<SizeType>('small')\nconst disabled = ref(true)\n</script>\n\n<template>\n  <div>\n    <a-space>\n      <a-radio-group v-model:value=\"componentSize\">\n        <a-radio-button value=\"small\">\n          Small\n        </a-radio-button>\n        <a-radio-button value=\"middle\">\n          Middle\n        </a-radio-button>\n        <a-radio-button value=\"large\">\n          Large\n        </a-radio-button>\n      </a-radio-group>\n      <a-checkbox v-model:checked=\"disabled\">\n        Form disabled\n      </a-checkbox>\n    </a-space>\n    <a-divider />\n    <a-config-provider :component-size=\"componentSize\">\n      <div class=\"example\">\n        <a-form :disabled=\"disabled\">\n          <ConfigDisplay />\n        </a-form>\n      </div>\n    </a-config-provider>\n  </div>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "DatePicker",
@@ -7267,14 +7537,63 @@
           "description": "Custom `prefix` and `suffixIcon`.",
           "descriptionZh": "自定义前缀 `prefix` 和后缀图标 `suffixIcon`。",
           "code": "<script setup lang=\"ts\">\nimport type { Dayjs } from 'dayjs'\nimport { SmileOutlined } from '@antdv-next/icons'\nimport { h } from 'vue'\n\nconst smileIcon = h(SmileOutlined)\n\nfunction handleChange(date: Dayjs | (Dayjs | null)[] | null, dateString: string | string[] | null) {\n  console.log(date, dateString)\n}\n</script>\n\n<template>\n  <a-space vertical :size=\"12\">\n    <a-date-picker :suffix-icon=\"smileIcon\" @change=\"handleChange\" />\n    <a-date-picker :suffix-icon=\"smileIcon\" picker=\"month\" @change=\"handleChange\" />\n    <a-range-picker :suffix-icon=\"smileIcon\" @change=\"handleChange\" />\n    <a-date-picker :suffix-icon=\"smileIcon\" picker=\"week\" @change=\"handleChange\" />\n    <a-date-picker suffix-icon=\"ab\" @change=\"handleChange\" />\n    <a-date-picker suffix-icon=\"ab\" picker=\"month\" @change=\"handleChange\" />\n    <a-range-picker suffix-icon=\"ab\" @change=\"handleChange\" />\n    <a-date-picker suffix-icon=\"ab\" picker=\"week\" @change=\"handleChange\" />\n    <a-date-picker :prefix=\"smileIcon\" picker=\"week\" @change=\"handleChange\" />\n    <a-date-picker prefix=\"Event Period\" picker=\"week\" @change=\"handleChange\" />\n    <a-range-picker :prefix=\"smileIcon\" picker=\"week\" @change=\"handleChange\" />\n    <a-range-picker prefix=\"Event Period\" picker=\"week\" @change=\"handleChange\" />\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, padding, border-radius, transition animations and other basic styles for date picker container",
+          "descriptionZh": "根元素，包含相对定位、行内flex布局、内边距、边框圆角、过渡动画等日期选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { SmileOutlined } from '@antdv-next/icons'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'popup.root', desc: t('popup') },\n  { name: 'popup.container', desc: t('popup.container') },\n  { name: 'popup.header', desc: t('popup.header') },\n  { name: 'popup.body', desc: t('popup.body') },\n  { name: 'popup.content', desc: t('popup.content') },\n  { name: 'popup.item', desc: t('popup.item') },\n  { name: 'popup.footer', desc: t('popup.footer') },\n])\n\nconst type = ref<'Single' | 'Multiple'>('Single')\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    :component-name=\"type === 'Single' ? 'DatePicker' : 'DatePicker.RangePicker'\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" vertical :style=\"{ alignSelf: 'flex-start' }\" gap=\"middle\" align=\"center\">\n        <a-segmented\n          :options=\"['Single', 'Multiple']\"\n          :value=\"type\"\n          @change=\"(val: 'Single' | 'Multiple') => type = val\"\n        />\n        <a-date-picker\n          v-if=\"type === 'Single'\"\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-date-picker>\n        <a-range-picker\n          v-else\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-range-picker>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with flex layout and margin styles for prefix content layout",
+          "descriptionZh": "前缀元素，包含flex布局、右外边距等前缀内容的布局样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with relative positioning, width, color, font, line-height, transition animations and other core interactive styles for input field",
+          "descriptionZh": "输入框元素，包含相对定位、宽度、颜色、字体、行高、过渡动画等输入框的核心交互样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with flex layout, color, line-height, pointer events, transition animations and other styles for suffix content",
+          "descriptionZh": "后缀元素，包含flex布局、颜色、行高、指针事件、过渡动画等后缀内容的样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup element",
+          "descriptionZh": "弹出框元素"
+        },
+        {
+          "key": "popup.container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "popup.header",
+          "description": "Popup header element with navigation buttons, month/year selectors and other header control area layout and styles",
+          "descriptionZh": "弹出框头部元素，包含导航按钮、月份年份选择器等头部控制区域的布局和样式"
+        },
+        {
+          "key": "popup.body",
+          "description": "Popup body element with container layout and styles for date panel table",
+          "descriptionZh": "弹出框主体元素，包含日期面板表格的容器布局和样式"
+        },
+        {
+          "key": "popup.content",
+          "description": "Popup content element with width, border, cell and other content display styles for date table",
+          "descriptionZh": "弹出框内容元素，包含日期表格的宽度、边框、单元格等内容展示样式"
+        },
+        {
+          "key": "popup.item",
+          "description": "Popup item element with size, background, border-radius, hover state, selected state and other interactive styles for date cells",
+          "descriptionZh": "弹出框单项元素，包含日期单元格的尺寸、背景色、边框圆角、悬停态、选中态等交互样式"
+        },
+        {
+          "key": "popup.footer",
+          "description": "Popup footer element with layout styles for bottom operation area including confirm/cancel buttons and shortcuts",
+          "descriptionZh": "弹出框底部元素，包含确认取消按钮、快捷选择等底部操作区域的布局样式"
         }
       ]
     },
@@ -7528,14 +7847,38 @@
           "description": "Display of the entire line.",
           "descriptionZh": "整行的展示。",
           "code": "<script setup lang=\"ts\">\nimport type { DescriptionsItemType } from 'antdv-next'\n\nconst items: DescriptionsItemType[] = [\n  {\n    label: 'UserName',\n    content: 'Zhou Maomao',\n  },\n  {\n    label: 'Live',\n    span: 'filled', // span = 2\n    content: 'Hangzhou, Zhejiang',\n  },\n  {\n    label: 'Remark',\n    span: 'filled', // span = 3\n    content: 'empty',\n  },\n  {\n    label: 'Address',\n    span: 1, // span will be 3 and warning for span is not align to the end\n    content: 'No. 18, Wantang Road, Xihu District, Hangzhou, Zhejiang, China',\n  },\n]\n</script>\n\n<template>\n  <a-descriptions title=\"User Info\" :items=\"items\" bordered />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with basic styles, reset styles, border styles, layout direction and other overall styles for description list container",
+          "descriptionZh": "根元素，包含描述列表容器的基础样式、重置样式、边框样式、布局方向等整体样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n\nconst bordered = ref(false)\n\nconst items = [\n  { key: '1', label: 'Telephone', children: '1810000000' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Descriptions\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ width: '100%', height: '100%' }\">\n        <a-switch v-model:checked=\"bordered\" />\n        Toggle Border\n        <a-divider />\n        <a-descriptions\n          title=\"User Info\"\n          :items=\"items\"\n          :bordered=\"bordered\"\n          :classes=\"classes\"\n        >\n          <template #extra>\n            <a-button type=\"primary\">\n              Edit\n            </a-button>\n          </template>\n        </a-descriptions>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with flex layout, alignment, bottom margin and other layout and style controls for header area",
+          "descriptionZh": "头部元素，包含flex布局、对齐方式、下边距等头部区域的布局和样式控制"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text ellipsis, flex ratio, color, font weight, font size, line height and other title text styles",
+          "descriptionZh": "标题元素，包含文本省略、flex占比、颜色、字体权重、字体大小、行高等标题文字样式"
+        },
+        {
+          "key": "extra",
+          "description": "Extra content element with left margin, color, font size and other styles for additional operation area",
+          "descriptionZh": "额外内容元素，包含左边距、颜色、字体大小等额外操作区域的样式"
+        },
+        {
+          "key": "label",
+          "description": "Label element with color, font weight, font size, line height, text align, colon styles and other label text styles",
+          "descriptionZh": "标签元素，包含颜色、字体权重、字体大小、行高、文本对齐、冒号样式等标签文字的样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with table cell layout, color, font size, line height, word break and other content display styles",
+          "descriptionZh": "内容元素，包含表格单元格布局、颜色、字体大小、行高、文字换行等内容展示样式"
         }
       ]
     },
@@ -7704,14 +8047,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of divider by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义分割线的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { DividerProps } from 'antdv-next'\n\nconst classesObject: DividerProps['classes'] = {\n  root: 'demo-divider-root',\n  content: 'demo-divider-content',\n  rail: 'demo-divider-rail',\n}\n\nconst classesFn: DividerProps['classes'] = (info) => {\n  if (info?.props?.titlePlacement === 'start') {\n    return {\n      root: 'demo-divider-root--start',\n    }\n  }\n  return {\n    root: 'demo-divider-root--default',\n  }\n}\n\nconst stylesObject: DividerProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed' },\n  content: { fontStyle: 'italic' },\n  rail: { opacity: 0.85 },\n}\n\nconst stylesFn: DividerProps['styles'] = (info) => {\n  if (info?.props?.size === 'small') {\n    return {\n      root: { opacity: 0.6, cursor: 'default' },\n    }\n  }\n  return {\n    root: { backgroundColor: '#fafafa', borderColor: '#d9d9d9' },\n  }\n}\n</script>\n\n<template>\n  <div>\n    <a-divider :classes=\"classesObject\">\n      classes Object\n    </a-divider>\n    <a-divider title-placement=\"start\" :classes=\"classesFn\">\n      classes Function\n    </a-divider>\n    <a-divider :styles=\"stylesObject\">\n      styles Object\n    </a-divider>\n    <a-divider size=\"small\" :styles=\"stylesFn\">\n      styles Function\n    </a-divider>\n  </div>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with border-top style, divider styling and other basic divider container styles",
+          "descriptionZh": "根元素，包含边框顶部样式、分隔线样式等分割线容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'rail', desc: t('rail') },\n  { name: 'content', desc: t('content') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Divider\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div>\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider :classes=\"classes\" />\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider :classes=\"classes\">\n          Solid\n        </a-divider>\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider title-placement=\"left\" variant=\"dotted\" :classes=\"classes\">\n          Dotted\n        </a-divider>\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider title-placement=\"right\" variant=\"dashed\" :classes=\"classes\">\n          Dashed\n        </a-divider>\n        These\n        <a-divider orientation=\"vertical\" :classes=\"classes\" />\n        are\n        <a-divider orientation=\"vertical\" :classes=\"classes\" />\n        vertical\n        <a-divider orientation=\"vertical\" :classes=\"classes\" />\n        Dividers\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "content",
+          "description": "Content element with inline-block display, padding and other divider text content styles",
+          "descriptionZh": "内容元素，包含行内块显示、内边距等分割线文本内容的样式"
+        },
+        {
+          "key": "rail",
+          "description": "Background rail element with border-top style and other divider connection line styles",
+          "descriptionZh": "背景条元素，包含边框顶部样式等分割线连接条的样式"
         }
       ]
     },
@@ -8088,14 +8440,58 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Drawer by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Drawer 组件的 [语义化结构](#semantic-dom) 样式。",
           "code": "<script setup lang=\"ts\">\nimport type { DrawerProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\nimport { ref } from 'vue'\n\nconst { token } = theme.useToken()\nconst open = ref(false)\nconst openFn = ref(false)\n\nconst classes: DrawerProps['classes'] = {\n  header: 'demo-drawer-header',\n  body: 'demo-drawer-body',\n}\n\nconst stylesObject: DrawerProps['styles'] = {\n  body: {\n    backgroundColor: '#f5f5f5',\n  },\n  footer: {\n    backgroundColor: '#fafafa',\n  },\n}\n\nconst stylesFn: DrawerProps['styles'] = (info) => {\n  if (info?.props?.placement === 'right') {\n    return {\n      mask: {\n        backgroundColor: 'rgba(0, 0, 0, 0.2)',\n      },\n      wrapper: {\n        boxShadow: '0 8px 24px rgba(0, 0, 0, 0.15)',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-button @click=\"open = true\">\n      Object Style\n    </a-button>\n    <a-button type=\"primary\" @click=\"openFn = true\">\n      Function Style\n    </a-button>\n  </a-flex>\n\n  <a-drawer\n    v-model:open=\"open\"\n    title=\"Custom Style Drawer\"\n    :classes=\"classes\"\n    :styles=\"stylesObject\"\n    @close=\"open = false\"\n  >\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n  </a-drawer>\n\n  <a-drawer\n    v-model:open=\"openFn\"\n    title=\"Custom Function Drawer\"\n    :classes=\"classes\"\n    :styles=\"stylesFn\"\n    @close=\"openFn = false\"\n  >\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n  </a-drawer>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with fixed positioning, z-index control, pointer events, color and other basic styles and layout control for drawer container",
+          "descriptionZh": "根元素，包含固定定位、层级控制、指针事件、颜色等抽屉容器的基础样式和布局控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'mask', desc: t('mask'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n  { name: 'dragger', desc: t('dragger'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Drawer\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-drawer\n        title=\"Title\"\n        placement=\"right\"\n        open\n        :get-container=\"false\"\n        :size=\"300\"\n        :resizable=\"{}\"\n        :classes=\"classes\"\n      >\n        <template #footer>\n          <a-typography-link>Footer</a-typography-link>\n        </template>\n        <template #extra>\n          <a-button>Cancel</a-button>\n        </template>\n        <p>Some contents...</p>\n      </a-drawer>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "mask",
+          "description": "Mask element with absolute positioning, z-index, background color, pointer events and other mask layer styles and interaction controls",
+          "descriptionZh": "遮罩层元素，包含绝对定位、层级、背景色、指针事件等遮罩层的样式和交互控制"
+        },
+        {
+          "key": "section",
+          "description": "Drawer container element with flex layout, width/height, overflow control, background color, pointer events and other drawer body styles",
+          "descriptionZh": "Drawer 容器元素，包含flex布局、宽高、溢出控制、背景色、指针事件等抽屉主体的样式"
+        },
+        {
+          "key": "header",
+          "description": "Header element with flex layout, alignment, padding, font size, line height, bottom border and other header area styles",
+          "descriptionZh": "头部元素，包含flex布局、对齐方式、内边距、字体大小、行高、下边框等头部区域的样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with flex ratio, minimum size, padding, overflow scroll and other content area display and layout styles",
+          "descriptionZh": "内容元素，包含flex占比、最小尺寸、内边距、溢出滚动等内容区域的展示和布局样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with flex shrink, padding, top border and other bottom operation area styles",
+          "descriptionZh": "底部元素，包含flex收缩、内边距、上边框等底部操作区域的样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with flex ratio, margin, font weight, font size, line height and other title text styles",
+          "descriptionZh": "标题元素，包含flex占比、外边距、字体权重、字体大小、行高等标题文字的样式"
+        },
+        {
+          "key": "extra",
+          "description": "Extra element with flex fixed layout and other additional operation content style controls",
+          "descriptionZh": "额外元素，包含flex固定布局等额外操作内容的样式控制"
+        },
+        {
+          "key": "dragger",
+          "description": "Dragger element used to resize the drawer, with absolute positioning, transparent background, pointer events control, hover state styles, and dragging state styles",
+          "descriptionZh": "拖拽元素，用于调整抽屉大小的拖拽手柄，包含绝对定位、背景透明、指针事件控制、hover状态样式、拖拽状态样式等"
+        },
+        {
+          "key": "close",
+          "description": "Close button element with basic button styling",
+          "descriptionZh": "关闭按钮元素，包含按钮的基础样式"
         }
       ]
     },
@@ -8452,14 +8848,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of the Dropdown by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Dropdown 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { DropdownProps, MenuItemType } from 'antdv-next'\nimport { DownOutlined, LogoutOutlined, SettingOutlined } from '@antdv-next/icons'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst items: MenuItemType[] = [\n  {\n    key: '1',\n    label: 'Profile',\n  },\n  {\n    key: '2',\n    label: 'Settings',\n    icon: SettingOutlined,\n  },\n  {\n    type: 'divider',\n  },\n  {\n    key: '3',\n    label: 'Logout',\n    icon: LogoutOutlined,\n    danger: true,\n  },\n]\n\nconst classes: DropdownProps['classes'] = {\n  root: 'demo-dropdown-root',\n}\n\nconst objectStyles: DropdownProps['styles'] = {\n  root: {\n    backgroundColor: '#ffffff',\n    border: '1px solid #d9d9d9',\n    borderRadius: '4px',\n  },\n  item: {\n    padding: '8px 12px',\n    fontSize: '14px',\n  },\n  itemTitle: {\n    fontWeight: '500',\n  },\n  itemIcon: {\n    color: '#1890ff',\n    marginRight: '8px',\n  },\n  itemContent: {\n    backgroundColor: 'transparent',\n  },\n}\n\nconst functionStyles: DropdownProps['styles'] = (info) => {\n  const isClick = info.props.trigger?.includes('click')\n  if (isClick) {\n    return {\n      root: {\n        borderColor: '#1890ff',\n        borderRadius: '8px',\n      },\n    }\n  }\n  return {}\n}\n\nconst sharedProps: DropdownProps = {\n  menu: { items },\n  placement: 'bottomLeft',\n  classes,\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\" wrap=\"wrap\">\n    <a-space direction=\"vertical\" size=\"large\">\n      <a-dropdown v-bind=\"sharedProps\" :styles=\"objectStyles\">\n        <a-button>\n          <a-space>\n            Object Style\n            <DownOutlined />\n          </a-space>\n        </a-button>\n      </a-dropdown>\n\n      <a-dropdown v-bind=\"sharedProps\" :styles=\"functionStyles\" :trigger=\"['click']\">\n        <a-button type=\"primary\">\n          <a-space>\n            Function Style\n            <DownOutlined />\n          </a-space>\n        </a-button>\n      </a-dropdown>\n    </a-space>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element of dropdown, sets positioning, z-index and container styles",
+          "descriptionZh": "dropdown 的根元素，设置定位、层级和容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { DeleteOutlined, DownOutlined, EditOutlined, SaveOutlined } from '@antdv-next/icons'\nimport { computed, h, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'itemTitle', desc: t('itemTitle') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst items: any[] = [\n  {\n    key: '1',\n    type: 'group',\n    label: 'Group title',\n    children: [\n      { key: '1-1', label: '1st menu item', icon: h(SaveOutlined) },\n      { key: '1-2', label: '2nd menu item', icon: h(EditOutlined) },\n    ],\n  },\n  {\n    key: 'SubMenu',\n    label: 'SubMenu',\n    children: [\n      {\n        key: 'g1',\n        label: 'Item 1',\n        type: 'group',\n        children: [\n          { key: '1', label: 'Option 1' },\n          { key: '2', label: 'Option 2' },\n        ],\n      },\n    ],\n  },\n  { key: '3', type: 'divider' },\n  { key: '4', label: 'Delete', icon: h(DeleteOutlined), danger: true },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Dropdown\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ height: '120px', position: 'absolute', top: '50px' }\">\n        <a-dropdown\n          open\n          :menu=\"{ items }\"\n          :styles=\"{ root: { width: '200px', zIndex: 1 } }\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        >\n          <a @click.prevent>\n            <a-space>\n              Hover me\n              <DownOutlined />\n            </a-space>\n          </a>\n        </a-dropdown>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "itemTitle",
+          "description": "Title content area of dropdown option, sets layout and text styles",
+          "descriptionZh": "dropdown 选项的标题内容区域，设置布局和文字样式"
+        },
+        {
+          "key": "item",
+          "description": "Individual dropdown option element, sets interaction states and background styles",
+          "descriptionZh": "dropdown 的单个选项元素，设置选项的交互状态和背景样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Main content area of dropdown option, sets content layout and link styles",
+          "descriptionZh": "dropdown 选项的主要内容区域，设置内容布局和链接样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Icon area of dropdown option, sets icon size and spacing styles",
+          "descriptionZh": "dropdown 选项的图标区域，设置图标的尺寸和间距样式"
         }
       ]
     },
@@ -8569,14 +8984,28 @@
           "description": "Hide default description.",
           "descriptionZh": "隐藏默认描述。",
           "code": "<template>\n  <a-empty :description=\"false\" />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets text alignment, font and line height styles",
+          "descriptionZh": "根元素，设置文本对齐、字体和行高样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'image', desc: t('image'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Empty\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-empty\n        :image=\"1\"\n        :styles=\"{ image: { height: '60px' } }\"\n        :classes=\"classes\"\n      >\n        <template #description>\n          <a-typography-text>\n            Customize <a href=\"#API\">Description</a>\n          </a-typography-text>\n        </template>\n        <a-button type=\"primary\">\n          Create Now\n        </a-button>\n      </a-empty>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "image",
+          "description": "Image element, sets height, opacity, margin and image styles",
+          "descriptionZh": "图标元素，设置高度、透明度、边距和图片样式"
+        },
+        {
+          "key": "description",
+          "description": "Description element, sets text color styles",
+          "descriptionZh": "描述元素，设置文本颜色样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element, sets top margin and action button styles",
+          "descriptionZh": "底部元素，设置顶部边距和操作按钮样式"
         }
       ]
     },
@@ -8686,7 +9115,8 @@
           "descriptionZh": "嵌套使用，可以实现更复杂的布局。",
           "code": "<script setup lang=\"ts\">\nimport type { CSSProperties } from 'vue'\n\nconst cardStyle: CSSProperties = {\n  width: '620px',\n}\nconst imgStyle: CSSProperties = {\n  display: 'block',\n  width: '273px',\n}\n</script>\n\n<template>\n  <a-card :style=\"cardStyle\" :styles=\"{ body: { padding: 0, overflow: 'hidden' } }\">\n    <a-flex justify=\"space-between\">\n      <img\n        alt=\"avatar\"\n        src=\"https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png\"\n        :style=\"imgStyle\"\n      >\n      <a-flex vertical align=\"flex-end\" justify=\"space-between\" :style=\"{ padding: '32px' }\">\n        <a-typography>\n          <a-typography-title :level=\"3\">\n            “antd is an enterprise-class UI design language and Vue UI library.”\n          </a-typography-title>\n        </a-typography>\n        <a-button type=\"primary\" href=\"https://antdv.com\" target=\"_blank\">\n          Get Start\n        </a-button>\n      </a-flex>\n    </a-flex>\n  </a-card>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "FloatButton",
@@ -9095,22 +9525,63 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of FloatButton by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 FloatButton 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { FloatButtonProps } from 'antdv-next'\nimport { QuestionCircleOutlined } from '@antdv-next/icons'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: FloatButtonProps['classes'] = {\n  root: 'demo-float-button-root',\n  content: 'demo-float-button-content',\n}\n\nconst stylesObject: FloatButtonProps['styles'] = {\n  root: {\n    boxShadow: '0 1px 2px 0 rgba(0,0,0,0.05)',\n  },\n}\n\nconst stylesFn: FloatButtonProps['styles'] = (info) => {\n  if (info?.props?.type === 'primary') {\n    return {\n      root: {\n        backgroundColor: '#171717',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-float-button-group shape=\"circle\" style=\"inset-inline-end: 94px;\">\n    <a-float-button\n      type=\"primary\"\n      :classes=\"classes\"\n      href=\"https://ant.design/index-cn\"\n      :styles=\"stylesFn\"\n    >\n      <template #tooltip>\n        <div>custom style class</div>\n      </template>\n    </a-float-button>\n    <a-float-button\n      type=\"default\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n    >\n      <template #icon>\n        <QuestionCircleOutlined />\n      </template>\n    </a-float-button>\n  </a-float-button-group>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with float button base styles, shape size, type theme, fixed positioning, z-index, shadow, spacing and other container styles",
+          "descriptionZh": "根元素，设置悬浮按钮的基础样式、形状尺寸、类型主题、固定定位、层级、阴影、间距等容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { QuestionCircleOutlined } from '@antdv-next/icons'\nimport { FloatButton } from 'antdv-next'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst PurePanel = (FloatButton as any)._InternalPanelDoNotUseOrYouWillBeFired\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'icon', desc: t('icon') },\n  { name: 'content', desc: t('content') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"FloatButton\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <PurePanel\n        type=\"primary\"\n        shape=\"square\"\n        content=\"HELP\"\n        :classes=\"classes\"\n      >\n        <template #icon>\n          <QuestionCircleOutlined />\n        </template>\n      </PurePanel>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "content",
+          "description": "Content element with button text content font size, color, alignment, line wrap and other text display styles",
+          "descriptionZh": "内容元素，设置按钮内文字内容的字体大小、颜色、对齐、换行等文本显示样式"
         },
         {
-          "name": "_semantic_group",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AlertOutlined, BugOutlined, BulbOutlined } from '@antdv-next/icons'\nimport { FloatButton } from 'antdv-next'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst PurePanel = (FloatButton as any)._InternalPanelDoNotUseOrYouWillBeFired\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('group.root') },\n  { name: 'list', desc: t('group.list') },\n  { name: 'item', desc: t('group.item') },\n  { name: 'itemIcon', desc: t('group.itemIcon') },\n  { name: 'itemContent', desc: t('group.itemContent') },\n  { name: 'trigger', desc: t('group.trigger') },\n  { name: 'triggerIcon', desc: t('group.triggerIcon') },\n  { name: 'triggerContent', desc: t('group.triggerContent') },\n])\n\nconst items = [\n  {\n    icon: h(AlertOutlined),\n    content: 'warn',\n  },\n  {\n    icon: h(BugOutlined),\n    content: 'bug',\n  },\n  {\n    icon: h(BulbOutlined),\n    content: 'idea',\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"FloatButton\"\n    :semantics=\"semantics\"\n    :style=\"{ paddingTop: '100px' }\"\n  >\n    <template #default=\"{ classes }\">\n      <PurePanel\n        type=\"primary\"\n        shape=\"square\"\n        :items=\"items\"\n        trigger=\"hover\"\n        :open=\"true\"\n        content=\"back\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element with button icon size, color, line height, alignment and other icon display styles",
+          "descriptionZh": "图标元素，设置按钮内图标的尺寸、颜色、行高、对齐等图标显示样式"
+        },
+        {
+          "key": "group.root",
+          "description": "Root element with float button group container styles, fixed positioning, z-index, padding, gap, direction mode and other combined layout styles",
+          "descriptionZh": "根元素，设置悬浮按钮组的容器样式、固定定位、层级、内边距、间距、方向模式等组合布局样式"
+        },
+        {
+          "key": "group.list",
+          "description": "List element with button group list flex layout, border radius, shadow, animation transition, vertical alignment and other list container styles",
+          "descriptionZh": "列表元素，设置按钮组列表的Flex布局、圆角、阴影、动画过渡、垂直对齐等列表容器样式"
+        },
+        {
+          "key": "group.item",
+          "description": "Item element with individual float button styles, size, shape, type, state, icon content and other button base styles",
+          "descriptionZh": "列表项元素，设置单个悬浮按钮的样式、尺寸、形状、类型、状态、图标内容等按钮基础样式"
+        },
+        {
+          "key": "group.itemIcon",
+          "description": "Item icon element with float button icon size, color, alignment and other icon display styles",
+          "descriptionZh": "列表项图标元素，设置悬浮按钮内图标的尺寸、颜色、对齐等图标显示样式"
+        },
+        {
+          "key": "group.itemContent",
+          "description": "Item content element with float button text content, badge, description and other content area styles",
+          "descriptionZh": "列表项内容元素，设置悬浮按钮内文字内容、徽标、描述等内容区域样式"
+        },
+        {
+          "key": "group.trigger",
+          "description": "Trigger element with menu mode trigger button styles, shape, icon, hover state, expand/collapse state and other interaction styles",
+          "descriptionZh": "触发元素，设置菜单模式下触发按钮的样式、形状、图标、悬停态、展开收起状态等交互样式"
+        },
+        {
+          "key": "group.triggerIcon",
+          "description": "Trigger icon element with trigger button icon styles, rotation animation, toggle state and other icon interaction styles",
+          "descriptionZh": "触发图标元素，设置触发按钮内图标的样式、旋转动画、切换状态等图标交互样式"
+        },
+        {
+          "key": "group.triggerContent",
+          "description": "Trigger content element with trigger button content area text, identifier, state indicator and other content styles",
+          "descriptionZh": "触发内容元素，设置触发按钮内容区域的文字、标识、状态指示等内容样式"
         }
       ]
     },
@@ -10061,14 +10532,23 @@
           "description": "Custom semantic dom styling.",
           "descriptionZh": "自定义语义化结构的样式和类。",
           "code": "<script setup lang=\"ts\">\nimport { reactive } from 'vue'\n\nconst model = reactive({\n  name: '',\n  email: '',\n})\n\nconst classes = {\n  root: 'form-demo-root',\n  label: 'form-demo-label',\n  content: 'form-demo-content',\n}\n\nconst styles = {\n  root: { background: '#f6f7fb', padding: '16px', borderRadius: '8px' },\n}\n</script>\n\n<template>\n  <a-form\n    :model=\"model\"\n    layout=\"vertical\"\n    :classes=\"classes\"\n    :styles=\"styles\"\n    style=\"max-width: 600px\"\n  >\n    <a-form-item label=\"Name\" name=\"name\" :rules=\"[{ required: true }]\">\n      <a-input v-model:value=\"model.name\" />\n    </a-form-item>\n    <a-form-item label=\"Email\" name=\"email\" :rules=\"[{ type: 'email' }]\">\n      <a-input v-model:value=\"model.email\" />\n    </a-form-item>\n    <a-form-item :label=\"null\">\n      <a-button type=\"primary\">\n        Submit\n      </a-button>\n    </a-form-item>\n  </a-form>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with form item margin-bottom, vertical-align, transitions, hidden states, error/warning states and other basic form item container styles",
+          "descriptionZh": "根元素，包含表单项的底边距、垂直对齐、过渡动画、隐藏状态、错误警告状态等表单项容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Form\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-form\n        name=\"basic\"\n        :label-col=\"{ span: 8 }\"\n        :wrapper-col=\"{ span: 16 }\"\n        :style=\"{ maxWidth: '600px' }\"\n        :initial-values=\"{ remember: true }\"\n        autocomplete=\"off\"\n        :classes=\"classes\"\n      >\n        <a-form-item\n          label=\"Username\"\n          name=\"username\"\n          :rules=\"[{ required: true, message: 'Please input your username!' }]\"\n        >\n          <a-input />\n        </a-form-item>\n        <a-form-item\n          label=\"Password\"\n          name=\"password\"\n          :rules=\"[{ required: true, message: 'Please input your password!' }]\"\n        >\n          <a-input-password />\n        </a-form-item>\n      </a-form>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "label",
+          "description": "Label element with flex layout, overflow hidden, whitespace nowrap, text alignment, vertical alignment, plus label color, font size, height, required marks and other label display styles",
+          "descriptionZh": "标签元素，包含 flex 布局、溢出隐藏、文本不换行、文本对齐、垂直对齐，以及标签的颜色、字体大小、高度、必填标记等标签显示样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with form content area layout, styling and control container related styles",
+          "descriptionZh": "内容元素，包含表单内容区域的布局、样式和控件容器的相关样式"
         }
       ]
     },
@@ -10346,7 +10826,8 @@
           "descriptionZh": "使用 `useBreakpoint` Hook 实现个性化布局，其中 `xs` 仅当满足最小宽度时生效。",
           "code": "<script setup lang=\"ts\">\nimport { useBreakpoint } from 'antdv-next'\nimport { computed } from 'vue'\n\nconst screens = useBreakpoint()\nconst screenKeys = computed(() => Object.entries(screens.value ?? {}).filter(screen => !!screen[1]))\n</script>\n\n<template>\n  Current break point:\n  <div class=\"gap-2 inline-flex\">\n    <template v-for=\"item in screenKeys\" :key=\"item[0]\">\n      <a-tag color=\"blue\">\n        {{ item[0] }}\n      </a-tag>\n    </template>\n  </div>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Icon",
@@ -10409,7 +10890,8 @@
           "descriptionZh": "`scriptUrl` 可引用多个资源，用户可灵活的管理 [iconfont.cn](http://iconfont.cn/) 图标。如果资源的图标出现重名，会按照数组顺序进行覆盖。",
           "code": "<script setup lang=\"ts\">\nimport { createFromIconfontCN } from '@antdv-next/icons'\n\nconst IconFont = createFromIconfontCN({\n  scriptUrl: [\n    '//at.alicdn.com/t/font_1788044_0dwu4guekcwr.js', // icon-javascript, icon-java, icon-shoppingcart (overridden)\n    '//at.alicdn.com/t/font_1788592_a5xf2bdic3u.js', // icon-shoppingcart, icon-python\n  ],\n})\n</script>\n\n<template>\n  <a-space>\n    <IconFont type=\"icon-javascript\" />\n    <IconFont type=\"icon-java\" />\n    <IconFont type=\"icon-shoppingcart\" />\n    <IconFont type=\"icon-python\" />\n  </a-space>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Image",
@@ -10636,14 +11118,48 @@
           "description": "Nested in the modal.",
           "descriptionZh": "嵌套在弹框当中使用。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst show1 = ref(false)\nconst show2 = ref(false)\nconst show3 = ref(false)\n\nfunction handlePreviewGroupChange(current: number, prev: number) {\n  console.log(`current index: ${current}, prev index: ${prev}`)\n}\n</script>\n\n<template>\n  <a-button @click=\"show1 = true\">\n    showModal\n  </a-button>\n  <a-modal\n    v-model:open=\"show1\"\n    @cancel=\"show1 = false\"\n    @ok=\"show1 = false\"\n  >\n    <a-button @click=\"show2 = true\">\n      test2\n    </a-button>\n    <a-modal\n      v-model:open=\"show2\"\n      @cancel=\"show2 = false\"\n      @ok=\"show2 = false\"\n    >\n      <a-button @click=\"show3 = true\">\n        test3\n      </a-button>\n      <a-modal\n        v-model:open=\"show3\"\n        @cancel=\"show3 = false\"\n        @ok=\"show3 = false\"\n      >\n        <a-image\n          :width=\"200\"\n          alt=\"svg image\"\n          src=\"https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg\"\n        />\n        <a-divider />\n        <a-image-preview-group\n          :preview=\"{\n            onChange: handlePreviewGroupChange,\n          }\"\n        >\n          <a-image\n            :width=\"200\"\n            alt=\"svg image\"\n            src=\"https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg\"\n          />\n          <a-image\n            :width=\"200\"\n            src=\"https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg\"\n          />\n        </a-image-preview-group>\n      </a-modal>\n    </a-modal>\n  </a-modal>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets relative positioning and inline-block layout styles",
+          "descriptionZh": "根元素，设置相对定位和行内块布局样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { theme } from 'antdv-next'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'image', desc: t('image') },\n  { name: 'cover', desc: t('cover') },\n  { name: 'popup.root', desc: t('popup.root') },\n  { name: 'popup.mask', desc: t('popup.mask') },\n  { name: 'popup.body', desc: t('popup.body') },\n  { name: 'popup.footer', desc: t('popup.footer') },\n  { name: 'popup.actions', desc: t('popup.actions') },\n])\n\nconst { token } = theme.useToken()\nconst holderRef = ref<HTMLDivElement | null>(null)\n\nconst previewItems = [\n  'https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg',\n  'https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg',\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Image\"\n    :padding=\"false\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical align=\"center\" :style=\"{ minHeight: '100%', width: '100%' }\">\n        <a-flex :style=\"{ padding: `${token.padding}px`, flex: 'none' }\" justify=\"center\">\n          <a-image\n            :width=\"200\"\n            src=\"https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png\"\n            :classes=\"classes\"\n            :preview=\"{ getContainer: () => holderRef! }\"\n          />\n        </a-flex>\n        <div ref=\"holderRef\" :style=\"{ flex: 1, position: 'relative', minHeight: '500px', width: '100%' }\">\n          <a-image-preview-group\n            :items=\"previewItems\"\n            :classes=\"classes\"\n            :styles=\"{ popup: { root: { position: 'absolute' } } }\"\n            :preview=\"{ getContainer: () => holderRef!, open: true }\"\n          />\n        </div>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "image",
+          "description": "Image element, sets width, height and vertical alignment styles",
+          "descriptionZh": "图片元素，设置宽度、高度和垂直对齐样式"
+        },
+        {
+          "key": "cover",
+          "description": "Image hover display prompt element, sets absolute positioning, background color, opacity and transition animation styles",
+          "descriptionZh": "悬浮图片显示的提示元素，设置绝对定位、背景色、透明度和过渡动画样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Preview root element, sets fixed positioning, z-index and background mask styles",
+          "descriptionZh": "预览根元素，设置固定定位、层级和背景遮罩样式"
+        },
+        {
+          "key": "popup.mask",
+          "description": "Preview mask element, sets absolute positioning and semi-transparent background styles",
+          "descriptionZh": "预览遮罩元素，设置绝对定位和半透明背景样式"
+        },
+        {
+          "key": "popup.body",
+          "description": "Preview body element, sets flex layout, center alignment and pointer event styles",
+          "descriptionZh": "预览内容元素，设置flex布局、居中对齐和指针事件样式"
+        },
+        {
+          "key": "popup.footer",
+          "description": "Preview footer element, sets absolute positioning, center layout and bottom operation area styles",
+          "descriptionZh": "预览页脚元素，设置绝对定位、居中布局和底部操作区域样式"
+        },
+        {
+          "key": "popup.actions",
+          "description": "Preview actions group element, sets flex layout, background color, border radius and action button styles",
+          "descriptionZh": "预览操作组元素，设置flex布局、背景色、圆角和操作按钮样式"
         }
       ]
     },
@@ -11366,46 +11882,68 @@
           "description": "You can customize the [semantic dom](#semantic-input) style of Input by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Input 的[语义化结构](#semantic-input)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { InputOTPProps, InputPasswordProps, InputProps, InputSearchProps, TextAreaProps } from 'antdv-next'\n\nconst classes: InputProps['classes'] = {\n  root: 'effect',\n}\n\nconst stylesFn: InputProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      root: {\n        borderColor: '#696FC7',\n      },\n    } satisfies InputProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnTextArea: TextAreaProps['styles'] = (info) => {\n  if (info.props.showCount) {\n    return {\n      root: { borderColor: '#BDE3C3' },\n      textarea: { resize: 'none' },\n      count: { color: '#BDE3C3' },\n    } satisfies TextAreaProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnPassword: InputPasswordProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      root: {\n        borderColor: '#F5D3C4',\n      },\n    } satisfies InputPasswordProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnOTP: InputOTPProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      input: {\n        borderColor: '#6E8CFB',\n        width: '32px',\n      },\n    } satisfies InputOTPProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnSearch: InputSearchProps['styles'] = (info) => {\n  if (info.props.size === 'large') {\n    return {\n      root: { color: '#4DA8DA' },\n      input: { color: '#4DA8DA', borderColor: '#4DA8DA' },\n      prefix: { color: '#4DA8DA' },\n      suffix: { color: '#4DA8DA' },\n      count: { color: '#4DA8DA' },\n      button: {\n        root: { color: '#4DA8DA', borderColor: '#4DA8DA' },\n        icon: { color: '#4DA8DA' },\n      },\n    } satisfies InputSearchProps['styles']\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-input :classes=\"classes\" placeholder=\"Object\" name=\"input-object\" />\n    <a-input :classes=\"classes\" :styles=\"stylesFn\" placeholder=\"Function\" size=\"middle\" name=\"input-fn\" />\n    <a-textarea :classes=\"classes\" :styles=\"stylesFnTextArea\" placeholder=\"Textarea\" show-count name=\"textarea-fn\" />\n    <a-input-password :classes=\"classes\" :styles=\"stylesFnPassword\" placeholder=\"Password\" size=\"middle\" name=\"password-fn\" />\n    <a-input-otp :classes=\"classes\" :styles=\"stylesFnOTP\" size=\"middle\" :length=\"6\" separator=\"*\" name=\"otp-fn\" />\n    <a-input-search :classes=\"classes\" :styles=\"stylesFnSearch\" placeholder=\"Search\" size=\"large\" name=\"search-fn\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-block display, width, min-width, padding, colors, fonts, line-height, border-radius, transitions and other input container basic styles",
+          "descriptionZh": "根元素，包含相对定位、行内块布局、宽度、最小宽度、内边距、颜色、字体、行高、圆角、过渡动画等输入框容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'count', desc: t('count') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Input\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-input\n          default-value=\"Hello, Antdv-Next\"\n          show-count\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <UserOutlined />\n          </template>\n          <template #suffix>\n            <EditOutlined />\n          </template>\n        </a-input>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "input",
+          "description": "Input element with core interactive styles and text input related styling",
+          "descriptionZh": "输入框元素，包含输入框的核心交互样式和文本输入相关的样式"
         },
         {
-          "name": "_semantic-textarea",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('TextAreaRoot') },\n  { name: 'textarea', desc: t('textarea') },\n  { name: 'count', desc: t('TextAreaCount') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"TextArea\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-textarea\n          default-value=\"Hello, Antdv-Next\"\n          :maxlength=\"100\"\n          show-count\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix wrapper element with layout and styling for prefix content",
+          "descriptionZh": "前缀的包裹元素，包含前缀内容的布局和样式"
         },
         {
-          "name": "_semantic-search",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'count', desc: t('count') },\n  { name: 'button.root', desc: t('button.root') },\n  { name: 'button.icon', desc: t('button.icon') },\n  { name: 'button.content', desc: t('button.content') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputSearch\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-input-search\n          default-value=\"Hello, Antdv-Next\"\n          enter-button=\"Searching...\"\n          loading\n          show-count\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <UserOutlined />\n          </template>\n          <template #suffix>\n            <EditOutlined />\n          </template>\n        </a-input-search>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "suffix",
+          "description": "Suffix wrapper element with layout and styling for suffix content",
+          "descriptionZh": "后缀的包裹元素，包含后缀内容的布局和样式"
         },
         {
-          "name": "_semantic-password",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'count', desc: t('count') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputPassword\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-input-password\n          default-value=\"Hello, Antdv-Next\"\n          show-count\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <UserOutlined />\n          </template>\n          <template #suffix>\n            <EditOutlined />\n          </template>\n        </a-input-password>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "count",
+          "description": "Character count element with font and color styles for count display",
+          "descriptionZh": "文字计数元素，包含字符计数显示的字体和颜色样式"
         },
         {
-          "name": "_semantic-otp",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'input', desc: t('input') },\n  { name: 'separator', desc: t('OTPSeparator') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputOTP\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-input-otp\n        :length=\"6\"\n        separator=\"-\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "TextAreaRoot",
+          "description": "Root element with textarea wrapper styles, border, border radius, transition animation and state control",
+          "descriptionZh": "根元素，设置文本域包装器的样式、边框、圆角、过渡动画和状态控制"
+        },
+        {
+          "key": "textarea",
+          "description": "Textarea element with font, line height, padding, color, background, border, text input and multi-line text display styles",
+          "descriptionZh": "文本域元素，设置字体、行高、内边距、颜色、背景、边框、文本输入和多行文本展示样式"
+        },
+        {
+          "key": "TextAreaCount",
+          "description": "Count element with character count display position, font, color and numeric statistics styles",
+          "descriptionZh": "文字计数元素，设置字符计数显示的位置、字体、颜色和数值统计样式"
+        },
+        {
+          "key": "button.root",
+          "description": "Search button root element with button styles, hover effects and click interactions",
+          "descriptionZh": "搜索按钮的根元素，设置按钮的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "button.icon",
+          "description": "Search button icon element with icon styles, hover effects and click interactions",
+          "descriptionZh": "搜索按钮的图标元素，设置图标的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "button.content",
+          "description": "Search button content element with text styles, hover effects and click interactions",
+          "descriptionZh": "搜索按钮的内容元素，设置文本的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "OTPSeparator",
+          "description": "Separator element, set separator display styles between OTP input boxes",
+          "descriptionZh": "分隔符元素，设置OTP输入框之间的分隔符显示样式"
         }
       ]
     },
@@ -11965,14 +12503,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of the InputNumber by passing objects/functions through",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 InputNumber 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { InputNumberProps } from 'antdv-next'\n\nconst shardStyle = {\n  root: 'shard',\n}\nconst styleObject: InputNumberProps['styles'] = {\n  input: {\n    fontSize: '14px',\n  },\n}\nconst styleFn: InputNumberProps['styles'] = ({ props }) => {\n  if (props.size === 'large') {\n    return {\n      root: {\n        backgroundColor: 'rgba(250,250,250, 0.5)',\n        borderColor: '#722ed1',\n      },\n    } satisfies InputNumberProps['styles']\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-input-number :classes=\"shardStyle\" :styles=\"styleObject\" placeholder=\"Object\" />\n    <a-input-number :classes=\"shardStyle\" :styles=\"styleFn\" placeholder=\"Function\" size=\"large\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets inline-block layout, width, border radius and reset styles",
+          "descriptionZh": "根元素，设置行内块布局、宽度、边框圆角和重置样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'actions', desc: t('actions') },\n  { name: 'action', desc: t('action') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputNumber\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ display: 'flex', flexDirection: 'column', gap: '16px' }\">\n        <a-input-number\n          prefix=\"￥\"\n          suffix=\"RMB\"\n          :default-value=\"100\"\n          :style=\"{ width: '200px' }\"\n          :styles=\"{ actions: { opacity: 1, width: '24px' }, suffix: { marginRight: '28px' } }\"\n          :classes=\"classes\"\n        />\n        <a-input-number\n          :default-value=\"100\"\n          :style=\"{ width: '200px' }\"\n          :styles=\"{ actions: { opacity: 1, width: '24px' }, suffix: { marginRight: '28px' } }\"\n          mode=\"spinner\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "input",
+          "description": "Input element, sets font, line height, text input and interaction styles",
+          "descriptionZh": "输入框元素，设置字体、行高、文本输入和交互样式"
+        },
+        {
+          "key": "prefix",
+          "description": "Prefix wrapper element, sets flex layout, alignment and right margin styles",
+          "descriptionZh": "前缀的包裹元素，设置flex布局、对齐方式和右边距样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix wrapper element, sets flex layout, margin and transition animation styles",
+          "descriptionZh": "后缀的包裹元素，设置flex布局、边距和过渡动画样式"
+        },
+        {
+          "key": "action",
+          "description": "Single action button element, sets button styling, hover effects and click interactions",
+          "descriptionZh": "单个操作按钮元素，设置按钮的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element, sets absolute positioning, width, flex layout and number adjustment button styles",
+          "descriptionZh": "操作元素，设置绝对定位、宽度、flex布局和数值调节按钮样式"
         }
       ]
     },
@@ -12284,7 +12846,8 @@
           "descriptionZh": "当内容较长时，使用固定侧边栏可以提供更好的体验。",
           "code": "<script setup lang=\"ts\">\nimport type { MenuItemType } from 'antdv-next'\nimport type { CSSProperties } from 'vue'\nimport {\n  AppstoreOutlined,\n  BarChartOutlined,\n  CloudOutlined,\n  ShopOutlined,\n  TeamOutlined,\n  UploadOutlined,\n  UserOutlined,\n  VideoCameraOutlined,\n} from '@antdv-next/icons'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\nconst year = new Date().getFullYear()\n\nconst siderStyle: CSSProperties = {\n  overflow: 'auto',\n  height: '100vh',\n  position: 'sticky',\n  insetInlineStart: 0,\n  top: 0,\n  scrollbarWidth: 'thin',\n  scrollbarGutter: 'stable',\n}\n\nconst items: MenuItemType[] = [\n  UserOutlined,\n  VideoCameraOutlined,\n  UploadOutlined,\n  BarChartOutlined,\n  CloudOutlined,\n  AppstoreOutlined,\n  TeamOutlined,\n  ShopOutlined,\n].map((icon, index) => ({\n  key: String(index + 1),\n  icon,\n  label: `nav ${index + 1}`,\n}))\n</script>\n\n<template>\n  <a-layout :has-sider=\"true\">\n    <a-layout-sider :style=\"siderStyle\">\n      <div class=\"demo-logo-vertical\" />\n      <a-menu\n        theme=\"dark\"\n        mode=\"inline\"\n        :default-selected-keys=\"['4']\"\n        :items=\"items\"\n      />\n    </a-layout-sider>\n    <a-layout>\n      <a-layout-header class=\"fixed-header\" :style=\"{ background: token.colorBgContainer }\" />\n      <a-layout-content class=\"fixed-content\">\n        <div\n          class=\"fixed-content-box\"\n          :style=\"{\n            background: token.colorBgContainer,\n            borderRadius: `${token.borderRadiusLG}px`,\n          }\"\n        >\n          <p>long content</p>\n          <template v-for=\"index in 100\" :key=\"index\">\n            {{ index % 20 === 0 && index !== 0 ? 'more' : '...' }}\n            <br>\n          </template>\n        </div>\n      </a-layout-content>\n      <a-layout-footer class=\"fixed-footer\">\n        Antdv Next ©{{ year }} Created by Ant UED\n      </a-layout-footer>\n    </a-layout>\n  </a-layout>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Masonry",
@@ -12406,14 +12969,18 @@
           "description": "When `fresh` is enabled, the masonry will continuously monitor size changes of child items and automatically re-layout. Click on cards to change their height.",
           "descriptionZh": "开启 `fresh` 属性后，瀑布流会持续监听子项的尺寸变化并自动重新布局。点击卡片可以改变其高度。",
           "code": "<script setup lang=\"ts\">\nimport { Card } from 'antdv-next'\nimport { defineComponent, h, ref } from 'vue'\n\nconst RandomHeightCard = defineComponent({\n  props: {\n    index: {\n      type: Number,\n      required: true,\n    },\n    defaultHeight: {\n      type: Number,\n      required: true,\n    },\n  },\n  setup(props) {\n    const height = ref(props.defaultHeight)\n\n    const handleClick = () => {\n      height.value = Math.floor(Math.random() * 100) + 50\n    }\n\n    return () =>\n      h(\n        Card,\n        {\n          size: 'small',\n          style: { height: `${height.value}px`, transition: 'height 0.3s' },\n          onClick: handleClick,\n        },\n        () => `${props.index + 1} - Click`,\n      )\n  },\n})\n\nconst heights = [150, 50, 90, 70, 110, 150, 130, 80, 50, 90, 100, 150, 60, 50, 80].map(\n  (height, index) => {\n    const item: {\n      key: string\n      data: number\n      column?: number\n    } = {\n      key: `item-${index}`,\n      data: height,\n    }\n\n    if (index === 4) {\n      item.column = 0\n    }\n\n    return item\n  },\n)\n</script>\n\n<template>\n  <a-masonry\n    fresh\n    :columns=\"4\"\n    :gutter=\"16\"\n    :items=\"heights\"\n  >\n    <template #itemRender=\"{ data, index }\">\n      <RandomHeightCard :index=\"index\" :default-height=\"data\" />\n    </template>\n  </a-masonry>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets relative positioning, flex layout and masonry container styles",
+          "descriptionZh": "根元素，设置相对定位、flex布局和瀑布流容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n])\n\nconst heights = [75, 50, 70, 60, 85, 75, 50].map((height, index) => ({\n  key: `item-${index}`,\n  data: height,\n}))\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Masonry\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-masonry\n        :columns=\"3\"\n        :gutter=\"16\"\n        :items=\"heights\"\n        style=\"width: 100%\"\n        :classes=\"classes\"\n      >\n        <template #itemRender=\"{ data, index }\">\n          <a-card size=\"small\" :style=\"{ height: data }\">\n            {{ index + 1 }}\n          </a-card>\n        </template>\n      </a-masonry>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element, sets absolute positioning, width calculation, transition animation and masonry item styles",
+          "descriptionZh": "条目元素，设置绝对定位、宽度计算、过渡动画和瀑布流项目样式"
         }
       ]
     },
@@ -12796,14 +13363,28 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Mentions by passing objects/functions through `classes` and `styles`. For example, set the textarea to be resizable.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Mentions 的[语义化结构](#semantic-dom)样式，例如设置文本框可缩放。",
           "code": "<script setup lang=\"ts\">\nimport type { MentionsProps } from 'antdv-next'\n\nconst options: MentionsProps['options'] = [\n  { value: 'afc163', label: 'afc163' },\n  { value: 'zombieJ', label: 'zombieJ' },\n  { value: 'meet-student', label: 'meet-student' },\n  { value: 'thinkasany', label: 'thinkasany' },\n]\n\nconst classes: MentionsProps['classes'] = {\n  root: 'mentions-demo-root',\n}\n\nconst stylesObject: MentionsProps['styles'] = {\n  textarea: {\n    fontSize: '14px',\n    resize: 'vertical',\n    fontWeight: 200,\n  },\n}\n\nconst stylesFn: MentionsProps['styles'] = ({ props }) => {\n  if (props.variant === 'filled') {\n    return {\n      root: {\n        border: '1px solid #722ed1',\n      },\n      popup: {\n        border: '1px solid #722ed1',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-mentions\n      :options=\"options\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      placeholder=\"Object\"\n      :rows=\"2\"\n    />\n    <a-mentions\n      :options=\"options\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      variant=\"filled\"\n      placeholder=\"Function\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set inline flex layout, relative positioning, padding and border styles",
+          "descriptionZh": "根元素，设置行内flex布局、相对定位、内边距和边框样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'textarea', desc: t('textarea'), version: '1.0.0' },\n  { name: 'suffix', desc: t('suffix'), version: '1.0.0' },\n  { name: 'popup', desc: t('popup'), version: '1.0.0' },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst options = [\n  { value: 'afc163', label: 'afc163' },\n  { value: 'zombieJ', label: 'zombieJ' },\n  { value: 'thinkasany', label: 'thinkasany' },\n  { value: 'meet-student', label: 'meet-student' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Mentions\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <a-mentions\n          placement=\"bottom\"\n          :style=\"{ width: '100%' }\"\n          value=\"Hi, @\"\n          allow-clear\n          open\n          :get-popup-container=\"() => divRef!\"\n          :options=\"options\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "textarea",
+          "description": "Textarea element, set font, line height, text input and background styles",
+          "descriptionZh": "文本域元素，设置字体、行高、文本输入和背景样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup element, set absolute positioning, z-index, background color, border radius, shadow and dropdown options styles",
+          "descriptionZh": "弹出框元素，设置绝对定位、层级、背景色、圆角、阴影和下拉选项样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with layout and styling for suffix content like clear button, etc.",
+          "descriptionZh": "后缀元素，包含后缀内容的布局和样式，如清除按钮等"
         }
       ]
     },
@@ -13545,14 +14126,68 @@
           "description": "Use the `popupRender` prop to customize submenu popup rendering.",
           "descriptionZh": "使用 `popupRender` 属性自定义弹出菜单的渲染。",
           "code": "<script setup lang=\"ts\">\nimport type { MenuItemType, MenuProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\nimport { computed, h } from 'vue'\n\nconst { token } = theme.useToken()\n\nconst popupStyle = computed(() => ({\n  padding: `${token.value.padding}px`,\n  minWidth: '480px',\n  background: token.value.colorBgElevated,\n  borderRadius: `${token.value.borderRadiusLG}px`,\n  boxShadow: token.value.boxShadowSecondary,\n}))\n\nconst headerStyle = computed(() => ({\n  margin: 0,\n  paddingBottom: `${token.value.paddingXS}px`,\n  borderBottom: `1px solid ${token.value.colorSplit}`,\n}))\n\nconst cardStyle = computed(() => ({\n  padding: `${token.value.paddingSM}px`,\n}))\n\nconst cardItemStyle = computed(() => ({\n  borderRadius: `${token.value.borderRadius}px`,\n  transition: `all ${token.value.motionDurationSlow}`,\n  cursor: 'pointer',\n}))\n\nfunction renderMenuCard(title: string, description: string) {\n  return h('div', { class: 'menu-card', style: cardStyle.value }, [\n    h('div', { class: 'menu-card-title' }, title),\n    h('div', { class: 'menu-card-desc' }, description),\n  ])\n}\n\nconst menuItems = computed<MenuItemType[]>(() => [\n  {\n    key: 'home',\n    label: 'Home',\n  },\n  {\n    key: 'features',\n    label: 'Features',\n    children: [\n      {\n        key: 'getting-started',\n        label: renderMenuCard('Getting Started', 'Quick start guide and learn the basics.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n      {\n        key: 'components',\n        label: renderMenuCard('Components', 'Explore our component library.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n      {\n        key: 'templates',\n        label: renderMenuCard('Templates', 'Ready-to-use template designs.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n    ],\n  },\n  {\n    key: 'resources',\n    label: 'Resources',\n    children: [\n      {\n        key: 'blog',\n        label: renderMenuCard('Blog', 'Latest updates and articles.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n      {\n        key: 'community',\n        label: renderMenuCard('Community', 'Join our developer community.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n    ],\n  },\n])\n\nconst popupRender: MenuProps['popupRender'] = (node, info) => {\n  const title = info.item.title || info.item.key\n  return h('div', { class: 'menu-popup', style: popupStyle.value }, [\n    h('div', { class: 'menu-popup-title', style: headerStyle.value }, title),\n    node,\n  ])\n}\n\nconst themeConfig = {\n  components: {\n    Menu: {\n      popupBg: '#fff',\n      horizontalItemSelectedColor: '#1677ff',\n      horizontalItemHoverColor: '#1677ff',\n    },\n  },\n}\n</script>\n\n<template>\n  <a-config-provider :theme=\"themeConfig\">\n    <a-menu mode=\"horizontal\" :items=\"menuItems\" :popup-render=\"popupRender\" />\n  </a-config-provider>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with basic menu container styles and layout",
+          "descriptionZh": "根元素，包含菜单容器的基础样式和布局"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { MailOutlined } from '@antdv-next/icons'\nimport { computed, h, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst mode = ref<'horizontal' | 'vertical' | 'inline'>('horizontal')\nconst current = ref('mail')\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst semantics = computed(() => {\n  const baseLocale = [\n    { name: 'root', desc: t('root') },\n    { name: 'item', desc: t('item') },\n    { name: 'itemIcon', desc: t('itemIcon') },\n    { name: 'itemContent', desc: t('itemContent') },\n  ]\n  const subMenuLocale = [\n    { name: 'subMenu.itemTitle', desc: t('subMenu.itemTitle') },\n    { name: 'subMenu.list', desc: t('subMenu.list') },\n    { name: 'subMenu.item', desc: t('subMenu.item') },\n    { name: 'subMenu.itemIcon', desc: t('subMenu.itemIcon') },\n    { name: 'subMenu.itemContent', desc: t('subMenu.itemContent') },\n  ]\n  const groupLocale = [\n    { name: 'itemTitle', desc: t('itemTitle') },\n    { name: 'list', desc: t('list') },\n  ]\n\n  const additionalPopupLocale = mode.value !== 'inline' ? [{ name: 'popup', desc: t('popup') }] : []\n  const additionalGroupLocale = mode.value !== 'horizontal' ? groupLocale : []\n\n  return [...baseLocale, ...additionalGroupLocale, ...additionalPopupLocale, ...subMenuLocale]\n})\n\nconst items = [\n  { label: 'Navigation One', key: 'mail', icon: h(MailOutlined) },\n  {\n    key: 'SubMenu',\n    label: 'Navigation One',\n    icon: h(MailOutlined),\n    children: [\n      {\n        key: 'g1',\n        label: 'Item 1',\n        type: 'group',\n        children: [\n          { key: '1', label: 'Option 1', icon: h(MailOutlined) },\n          { key: '2', label: 'Option 2' },\n        ],\n      },\n    ],\n  },\n]\n\nconst groupItem = [\n  {\n    key: 'grp',\n    label: 'Group',\n    type: 'group',\n    children: [\n      { key: '13', label: 'Option 13' },\n      { key: '14', label: 'Option 14' },\n    ],\n  },\n]\n\nconst itemList = computed(() => {\n  return mode.value === 'horizontal' ? items : [...items, ...groupItem]\n})\n\nfunction onClick(e: { key: string }) {\n  current.value = e.key\n}\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Menu\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" vertical gap=\"middle\" align=\"center\">\n        <a-segmented\n          :options=\"['horizontal', 'vertical', 'inline']\"\n          :value=\"mode\"\n          @change=\"(val: 'horizontal' | 'vertical' | 'inline') => mode = val\"\n        />\n        <div :style=\"{ height: '360px' }\">\n          <a-menu\n            :selected-keys=\"[current]\"\n            :mode=\"mode\"\n            :items=\"itemList\"\n            :styles=\"{\n              root: { width: mode === 'horizontal' ? '310px' : '230px' },\n              popup: { root: { zIndex: 1 } },\n            }\"\n            :open-keys=\"['SubMenu']\"\n            :get-popup-container=\"() => divRef!\"\n            :classes=\"classes\"\n            @click=\"onClick\"\n          />\n        </div>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with relative positioning, block display, margins, whitespace handling, cursor styles, transitions and other basic interactive styles for menu items",
+          "descriptionZh": "条目元素，包含相对定位、块级显示、外边距、空白符处理、光标样式、过渡动画等菜单项的基础交互样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Item content element with layout and typography styles for menu item content",
+          "descriptionZh": "条目内容元素，包含菜单项内容的布局和排版样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Icon element with min-width, font-size, transitions, icon reset styles, and spacing control with text",
+          "descriptionZh": "图标元素，包含最小宽度、字体大小、过渡动画、图标重置样式，以及与文本的间距控制"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Item title element (no effect in horizontal mode) with title text styles and layout",
+          "descriptionZh": "菜单标题元素(horizontal 模式不生效)，包含标题文字的样式和布局"
+        },
+        {
+          "key": "list",
+          "description": "Menu list element (no effect in horizontal mode) with menu list layout and container styles",
+          "descriptionZh": "菜单列表元素(horizontal 模式不生效)，包含菜单列表的布局和容器样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup menu element (no effect in inline mode) with popup layer positioning, z-index, background and other styles",
+          "descriptionZh": "弹出菜单(inline 模式不生效)，包含弹出层的定位、层级、背景等样式"
+        },
+        {
+          "key": "subMenu.itemTitle",
+          "description": "Submenu title element with submenu title styles and interactive effects",
+          "descriptionZh": "子菜单标题元素，包含子菜单标题的样式和交互效果"
+        },
+        {
+          "key": "subMenu.list",
+          "description": "Submenu list element with submenu list layout and container styles",
+          "descriptionZh": "子菜单列表元素，包含子菜单列表的布局和容器样式"
+        },
+        {
+          "key": "subMenu.item",
+          "description": "Submenu item element with submenu item styles and interactive effects",
+          "descriptionZh": "子菜单单项元素，包含子菜单项的样式和交互效果"
+        },
+        {
+          "key": "subMenu.itemIcon",
+          "description": "Submenu item icon element with submenu icon size and styles",
+          "descriptionZh": "子菜单条目图标元素，包含子菜单图标的尺寸和样式"
+        },
+        {
+          "key": "subMenu.itemContent",
+          "description": "Submenu item content element with submenu content layout and typography",
+          "descriptionZh": "子菜单条目内容元素，包含子菜单内容的布局和排版"
         }
       ]
     },
@@ -13674,14 +14309,23 @@
           "description": "Static methods cannot consume Context provided by `ConfigProvider`. When enable `layer`, they may also cause style errors. Please use hooks version or `App` provided instance first.",
           "descriptionZh": "静态方法无法消费 Context，不能动态响应 ConfigProvider 提供的各项配置，启用 `layer` 时还可能导致样式异常。请优先使用 hooks 版本或者 App 组件提供的 `message` 实例。",
           "code": "<script setup lang=\"ts\">\nimport { message } from 'antdv-next'\n\nfunction info() {\n  message.info('This is an info message')\n}\n</script>\n\n<template>\n  <a-button type=\"primary\" @click=\"info\">\n    Static Method\n  </a-button>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set fixed positioning, z-index, padding, background color, border radius, shadow and animation styles",
+          "descriptionZh": "根元素，设置固定定位、层级、内边距、背景色、圆角、阴影和动画样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { message } from 'antdv-next'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { _InternalPanelDoNotUseOrYouWillBeFired: InternalPanel } = message\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Message\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <InternalPanel\n        type=\"success\"\n        content=\"Hello, Ant Design!\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element, set font size, right margin and status color styles",
+          "descriptionZh": "图标元素，设置字体大小、右边距和状态颜色样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element, set inline block layout, text color and content display styles",
+          "descriptionZh": "内容元素，设置行内块布局、文字颜色和内容展示样式"
         }
       ]
     },
@@ -14239,14 +14883,48 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Modal by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Modal 组件的 [语义化结构](#semantic-dom) 样式。",
           "code": "<script setup lang=\"ts\">\nimport type { ModalProps } from 'antdv-next'\nimport { computed, ref } from 'vue'\n\nconst modalOpen = ref(false)\nconst modalFnOpen = ref(false)\n\nconst lineStyle = {\n  lineHeight: '28px',\n}\n\nconst classNames = computed(() => ({\n  container: 'custom-modal-container',\n}))\n\nconst styles: ModalProps['styles'] = {\n  mask: {\n    backgroundImage: `linear-gradient(to top, #18181b 0, rgba(21, 21, 22, 0.2) 100%)`,\n  },\n}\n\nconst stylesFn: ModalProps['styles'] = {\n  container: {\n    borderRadius: '14px',\n    border: '1px solid #ccc',\n    padding: '0',\n    overflow: 'hidden',\n  },\n  header: {\n    padding: '16px',\n  },\n  body: {\n    padding: '16px',\n  },\n  footer: {\n    padding: '16px 10px',\n    backgroundColor: '#fafafa',\n  },\n}\n\nconst sharedProps = computed<ModalProps>(() => ({\n  centered: true,\n  classes: classNames.value,\n}))\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-button @click=\"modalOpen = true\">\n      Open Style Modal\n    </a-button>\n    <a-button type=\"primary\" @click=\"modalFnOpen = true\">\n      Open Function Modal\n    </a-button>\n\n    <a-modal\n      v-bind=\"sharedProps\"\n      v-model:open=\"modalOpen\"\n      :footer=\"null\"\n      title=\"Custom Style Modal\"\n      :styles=\"styles\"\n    >\n      <div :style=\"lineStyle\">\n        Following the Ant Design specification, we developed a React UI library antd that contains a\n        set of high quality components and demos for building rich, interactive user interfaces.\n      </div>\n      <div :style=\"lineStyle\">\n        🌈 Enterprise-class UI designed for web applications.\n      </div>\n      <div :style=\"lineStyle\">\n        📦 A set of high-quality React components out of the box.\n      </div>\n      <div :style=\"lineStyle\">\n        🛡 Written in TypeScript with predictable static types.\n      </div>\n      <div :style=\"lineStyle\">\n        ⚙️ Whole package of design resources and development tools.\n      </div>\n      <div :style=\"lineStyle\">\n        🌍 Internationalization support for dozens of languages.\n      </div>\n      <div :style=\"lineStyle\">\n        🎨 Powerful theme customization in every detail.\n      </div>\n    </a-modal>\n\n    <a-modal\n      v-bind=\"sharedProps\"\n      v-model:open=\"modalFnOpen\"\n      title=\"Custom Function Modal\"\n      :styles=\"stylesFn\"\n      :mask=\"{ enabled: true, blur: true }\"\n    >\n      <div :style=\"lineStyle\">\n        Following the Ant Design specification, we developed a React UI library antd that contains a\n        set of high quality components and demos for building rich, interactive user interfaces.\n      </div>\n      <div :style=\"lineStyle\">\n        🌈 Enterprise-class UI designed for web applications.\n      </div>\n      <div :style=\"lineStyle\">\n        📦 A set of high-quality React components out of the box.\n      </div>\n      <div :style=\"lineStyle\">\n        🛡 Written in TypeScript with predictable static types.\n      </div>\n      <div :style=\"lineStyle\">\n        ⚙️ Whole package of design resources and development tools.\n      </div>\n      <div :style=\"lineStyle\">\n        🌍 Internationalization support for dozens of languages.\n      </div>\n      <div :style=\"lineStyle\">\n        🎨 Powerful theme customization in every detail.\n      </div>\n      <template #footer>\n        <a-button\n          :style=\"{ borderColor: '#ccc', color: '#171717', backgroundColor: '#fff' }\"\n          @click=\"modalFnOpen = false\"\n        >\n          Cancel\n        </a-button>\n        <a-button\n          type=\"primary\"\n          :style=\"{ backgroundColor: '#171717' }\"\n          @click=\"modalOpen = true\"\n        >\n          Submit\n        </a-button>\n      </template>\n    </a-modal>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, top position, width, max-width, margins, bottom padding and other basic layout styles for modal container",
+          "descriptionZh": "根元素，包含相对定位、顶部位置、宽度、最大宽度、外边距、底部内边距等模态框容器的基础布局样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'mask', desc: t('mask'), version: '1.0.0' },\n  { name: 'container', desc: t('container'), version: '1.0.0' },\n  { name: 'wrapper', desc: t('wrapper'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Modal\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', inset: 0 }\">\n        <a-modal\n          title=\"Title\"\n          :closable=\"false\"\n          open\n          :get-container=\"() => divRef!\"\n          :width=\"400\"\n          :styles=\"{\n            mask: { position: 'absolute', zIndex: 1 },\n            wrapper: { position: 'absolute', zIndex: 1 },\n          }\"\n          :style=\"{ top: '50%', transform: 'translateY(-50%)', marginBottom: 0, paddingBottom: 0 }\"\n          :classes=\"classes\"\n        >\n          <p>Some contents...</p>\n        </a-modal>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "mask",
+          "description": "Mask element with fixed positioning, z-index, background color, animation transitions and other mask layer styles",
+          "descriptionZh": "遮罩层元素，包含固定定位、层级、背景色、动画过渡等遮罩层的样式"
+        },
+        {
+          "key": "wrapper",
+          "description": "Wrapper element used for motion container with animation and transition effect styles",
+          "descriptionZh": "包裹层元素，一般用于动画容器，包含动画和过渡效果的样式"
+        },
+        {
+          "key": "container",
+          "description": "Modal container element with relative positioning, background, background-clip, border, border-radius, box-shadow, pointer-events, padding and other modal body styles",
+          "descriptionZh": "Modal 容器元素，包含相对定位、背景色、背景裁剪、边框、圆角、阴影、指针事件、内边距等模态框主体样式"
+        },
+        {
+          "key": "header",
+          "description": "Header element with padding, bottom border and other header area styles",
+          "descriptionZh": "头部元素，包含头部内边距、下边框等头部区域样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with margin, color, font-weight, font-size, line-height, word-wrap and other title text styles",
+          "descriptionZh": "标题元素，包含外边距、颜色、字体权重、字体大小、行高、文字换行等标题文字样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with content area background color, padding and other content display styles",
+          "descriptionZh": "内容元素，包含内容区域的背景色、内边距等内容展示样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with footer background color, padding, top border, border-radius and other footer area styles",
+          "descriptionZh": "底部元素，包含底部的背景色、内边距、上边框、圆角等底部区域样式"
         }
       ]
     },
@@ -14428,14 +15106,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Notification by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义通知的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { notification } from 'antdv-next'\n\nconst [api, ContextHolder] = notification.useNotification()\n\nconst classes = {\n  root: 'custom-notification-root',\n}\n\nfunction styleFn(info: any) {\n  if (info.props.type === 'error') {\n    return {\n      root: {\n        backgroundColor: 'rgba(255, 200, 200, 0.3)',\n      },\n    }\n  }\n  return {}\n}\n\nfunction openDefault() {\n  api.info({\n    title: 'Notification Title',\n    description: 'This is a notification description.',\n    duration: false,\n    classes,\n    styles: {\n      root: {\n        borderRadius: '8px',\n      },\n    },\n  })\n}\n\nfunction openError() {\n  api.error({\n    title: 'Notification Title',\n    description: 'This is a notification description.',\n    duration: false,\n    classes,\n    styles: styleFn,\n  })\n}\n</script>\n\n<template>\n  <ContextHolder />\n  <a-space>\n    <a-button type=\"primary\" @click=\"openDefault\">\n      Default Notification\n    </a-button>\n    <a-button @click=\"openError\">\n      Error Notification\n    </a-button>\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set fixed positioning, z-index, padding, background color, border radius, shadow and animation styles",
+          "descriptionZh": "根元素，设置固定定位、层级、内边距、背景色、圆角、阴影和动画样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { notification } from 'antdv-next'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { _InternalPanelDoNotUseOrYouWillBeFired: InternalPanel } = notification\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Notification\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <InternalPanel\n        title=\"Hello World!\"\n        description=\"Hello World?\"\n        type=\"success\"\n        :classes=\"classes\"\n      >\n        <template #actions>\n          <a-button type=\"primary\" size=\"small\">\n            My Button\n          </a-button>\n        </template>\n      </InternalPanel>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element, set absolute positioning, font size, line height and status color styles",
+          "descriptionZh": "图标元素，设置绝对定位、字体大小、行高和状态颜色样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element, set color, font size, line height and margin styles",
+          "descriptionZh": "标题元素，设置颜色、字体大小、行高和外边距样式"
+        },
+        {
+          "key": "description",
+          "description": "Description element, set font size, color and margin styles",
+          "descriptionZh": "描述元素，设置字体大小、颜色和外边距样式"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element, set float right, top margin and action button layout styles",
+          "descriptionZh": "操作组元素，设置右浮动、上边距和操作按钮布局样式"
         }
       ]
     },
@@ -14454,7 +15151,8 @@
       "props": [],
       "tokens": [],
       "faq": [],
-      "demos": []
+      "demos": [],
+      "semanticStructure": []
     },
     {
       "name": "Pagination",
@@ -14877,14 +15575,18 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Pagination by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Pagination 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { PaginationProps } from 'antdv-next'\nimport { useCssModule } from 'vue'\n\nconst moduleStyles = useCssModule()\n\nconst classes: PaginationProps['classes'] = {\n  root: moduleStyles.root,\n}\n\nconst stylesObject: PaginationProps['styles'] = {\n  item: {\n    borderRadius: '999px',\n  },\n}\n\nconst stylesFn: PaginationProps['styles'] = ({ props }) => {\n  if (props.size === 'small') {\n    return {\n      item: {\n        backgroundColor: 'rgba(200, 200, 200, 0.3)',\n        marginInlineEnd: '4px',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-pagination :total=\"500\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-pagination :total=\"500\" size=\"small\" :classes=\"classes\" :styles=\"stylesFn\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set flex layout, alignment, flex wrap and list styles",
+          "descriptionZh": "根元素，设置flex布局、对齐方式、换行和列表样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Pagination\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-pagination :default-current=\"1\" :total=\"50\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element, set size, padding, border, background color, hover state and active state styles",
+          "descriptionZh": "页码元素，设置尺寸、内边距、边框、背景色、悬停态和激活态样式"
         }
       ]
     },
@@ -15096,14 +15798,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Popconfirm by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Popconfirm 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { PopconfirmProps } from 'antdv-next'\n\nconst classes: PopconfirmProps['classes'] = {\n  container: 'demo-popconfirm-container',\n}\n\nconst stylesObject: PopconfirmProps['styles'] = {\n  container: {\n    backgroundColor: '#eee',\n    boxShadow: 'inset 5px 5px 3px #fff, inset -5px -5px 3px #ddd, 0 0 3px rgba(0,0,0,0.2)',\n  },\n  title: {\n    color: '#262626',\n  },\n  content: {\n    color: '#262626',\n  },\n}\n\nconst stylesFn: PopconfirmProps['styles'] = (info) => {\n  if (info?.props?.arrow === false) {\n    return {\n      container: {\n        backgroundColor: 'rgba(53, 71, 125, 0.8)',\n        padding: '12px',\n        borderRadius: '4px',\n      },\n      title: {\n        color: '#fff',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-popconfirm\n      title=\"Object text\"\n      description=\"Object description\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    >\n      <a-button>Object Style</a-button>\n    </a-popconfirm>\n    <a-popconfirm\n      title=\"Function text\"\n      description=\"Function description\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n      :ok-button-props=\"{ styles: { root: { backgroundColor: 'rgba(53, 71, 125, 0.6)', color: '#fff' } } }\"\n      :cancel-button-props=\"{ styles: { root: { borderColor: 'rgba(53, 71, 125, 0.6)', backgroundColor: '#fff', color: 'rgba(53, 71, 125, 0.8)' } } }\"\n    >\n      <a-button type=\"primary\">\n        Function Style\n      </a-button>\n    </a-popconfirm>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set absolute positioning, z-index, transform origin, arrow direction and popover container styles",
+          "descriptionZh": "根元素，设置绝对定位、层级、变换原点、箭头指向和弹层容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'container', desc: t('container') },\n  { name: 'title', desc: t('title') },\n  { name: 'content', desc: t('content') },\n  { name: 'arrow', desc: t('arrow') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Popconfirm\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', marginTop: '60px' }\">\n        <a-popconfirm\n          open\n          placement=\"top\"\n          title=\"Confirm\"\n          description=\"Are you sure you want to perform this action?\"\n          :auto-adjust-overflow=\"false\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "arrow",
+          "description": "Arrow element with width, height, position, color and border styles",
+          "descriptionZh": "箭头元素，设置宽高、位置、颜色和边框样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element, set title text styles and spacing",
+          "descriptionZh": "标题元素，设置标题文本样式和间距"
+        },
+        {
+          "key": "content",
+          "description": "Description element, set content text styles and layout",
+          "descriptionZh": "描述元素，设置描述文本样式和布局"
         }
       ]
     },
@@ -15307,14 +16028,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Popover by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Popover 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { PopoverProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: PopoverProps['classes'] = {\n  container: 'demo-popover-container',\n}\n\nconst stylesObject: PopoverProps['styles'] = {\n  container: {\n    backgroundColor: '#eee',\n    boxShadow: 'inset 5px 5px 3px #fff, inset -5px -5px 3px #ddd, 0 0 3px rgba(0,0,0,0.2)',\n  },\n  title: {\n    color: '#262626',\n  },\n  content: {\n    color: '#262626',\n  },\n}\n\nconst stylesFn: PopoverProps['styles'] = (info) => {\n  if (info?.props?.arrow === false) {\n    return {\n      container: {\n        backgroundColor: 'rgba(53, 71, 125, 0.8)',\n        padding: '12px',\n        borderRadius: '4px',\n      },\n      title: {\n        color: '#fff',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-popover\n      content=\"Object text\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    >\n      <a-button>Object Style</a-button>\n    </a-popover>\n    <a-popover\n      content=\"Function text\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n    >\n      <a-button type=\"primary\">\n        Function Style\n      </a-button>\n    </a-popover>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set absolute positioning, z-index, transform origin, arrow direction and popover container styles",
+          "descriptionZh": "根元素，设置绝对定位、层级、变换原点、箭头指向和弹层容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'container', desc: t('container') },\n  { name: 'title', desc: t('title') },\n  { name: 'content', desc: t('content') },\n  { name: 'arrow', desc: t('arrow') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Popover\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', marginTop: '60px' }\">\n        <a-popover\n          open\n          placement=\"top\"\n          title=\"Hello\"\n          content=\"Ant Design love you!\"\n          :auto-adjust-overflow=\"false\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "arrow",
+          "description": "Arrow element with width, height, position, color and border styles",
+          "descriptionZh": "箭头元素，设置宽高、位置、颜色和边框样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element, set title text styles and spacing",
+          "descriptionZh": "标题元素，设置标题文本样式和间距"
+        },
+        {
+          "key": "content",
+          "description": "Content element, set content text styles and layout",
+          "descriptionZh": "内容元素，设置内容文本样式和布局"
         }
       ]
     },
@@ -15617,14 +16357,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Progress by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Progress 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { ProgressProps } from 'antdv-next'\n\nconst classes: ProgressProps['classes'] = {\n  root: 'demo-progress-root',\n  rail: 'demo-progress-rail',\n  track: 'demo-progress-track',\n}\n\nconst stylesFn: ProgressProps['styles'] = (info) => {\n  const percent = info?.props?.percent ?? 0\n  const hue = 200 - (200 * percent) / 100\n  return {\n    track: {\n      backgroundImage: `\n        linear-gradient(\n          to right,\n          hsla(${hue}, 85%, 65%, 1),\n          hsla(${hue + 30}, 90%, 55%, 0.95)\n        )`,\n      borderRadius: 8,\n      transition: 'all 0.3s ease',\n    },\n    rail: {\n      backgroundColor: 'rgba(0, 0, 0, 0.1)',\n      borderRadius: 8,\n    },\n  } as ProgressProps['styles']\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"10\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"20\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"40\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"60\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"80\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"99\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set relative positioning and basic container styles",
+          "descriptionZh": "根元素，设置相对定位和基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'body', desc: t('body') },\n  { name: 'rail', desc: t('rail') },\n  { name: 'track', desc: t('track') },\n  { name: 'indicator', desc: t('indicator') },\n])\n\nconst gradient = ref(false)\nconst type = ref('line')\n\nconst colorMap = {\n  '0%': '#108ee9',\n  '100%': '#87d068',\n}\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Progress\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical gap=\"middle\" :style=\"{ width: '100%' }\" align=\"center\">\n        <a-flex align=\"center\" gap=\"middle\">\n          <a-segmented\n            :options=\"['line', 'steps', 'circle', 'dashboard']\"\n            :value=\"type\"\n            @change=\"(val: string) => type = val\"\n          />\n          <a-switch\n            :checked=\"gradient\"\n            checked-children=\"Gradient\"\n            un-checked-children=\"Gradient\"\n            @change=\"(val: boolean) => gradient = val\"\n          />\n        </a-flex>\n        <a-flex vertical align=\"center\" :style=\"{ height: '200px', width: '100%' }\">\n          <a-progress\n            :percent=\"80\"\n            :type=\"type === 'steps' ? 'line' : type\"\n            :steps=\"type === 'steps' ? 5 : undefined\"\n            :stroke-color=\"gradient ? colorMap : undefined\"\n            :classes=\"classes\"\n          />\n        </a-flex>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "body",
+          "description": "Body element, set progress bar layout and size styles",
+          "descriptionZh": "主体元素，设置进度条的布局和尺寸样式"
+        },
+        {
+          "key": "rail",
+          "description": "Rail element, set background track color and border radius styles. Not exist in steps mode",
+          "descriptionZh": "导轨元素，设置背景轨道的颜色和圆角样式，steps 模式下没有该元素"
+        },
+        {
+          "key": "track",
+          "description": "Track element, set progress fill color and transition animation styles",
+          "descriptionZh": "轨迹元素，设置进度填充部分的颜色和过渡动画样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element, set percentage text or icon position and font styles",
+          "descriptionZh": "指示器元素，设置百分比文本或图标的位置和字体样式"
         }
       ]
     },
@@ -15845,14 +16604,18 @@
           "description": "With Popover.",
           "descriptionZh": "带气泡卡片的例子。",
           "code": "<script setup lang=\"ts\">\ndefineOptions({ name: 'Popover' })\n</script>\n\n<template>\n  <a-popover>\n    <template #content>\n      <a-qrcode value=\"https://ant.design\" :bordered=\"false\" />\n    </template>\n    <a-button type=\"primary\">\n      Hover me\n    </a-button>\n  </a-popover>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set flex layout, padding, background color, border, border radius and relative positioning styles",
+          "descriptionZh": "根元素，设置flex布局、内边距、背景色、边框、圆角和相对定位样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'cover', desc: t('cover') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"QRCode\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-qrcode value=\"https://ant.design\" status=\"loading\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "cover",
+          "description": "Cover element, set absolute positioning, z-index, background color and loading state overlay styles",
+          "descriptionZh": "遮罩层元素，设置绝对定位、层级、背景色和加载状态覆盖样式"
         }
       ]
     },
@@ -16254,14 +17017,23 @@
           "description": "Solid radio button style.",
           "descriptionZh": "实色填底的单选按钮样式。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst value = shallowRef('a')\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-radio-group v-model:value=\"value\" button-style=\"solid\">\n      <a-radio-button value=\"a\">\n        Hangzhou\n      </a-radio-button>\n      <a-radio-button value=\"b\">\n        Shanghai\n      </a-radio-button>\n      <a-radio-button value=\"c\">\n        Beijing\n      </a-radio-button>\n      <a-radio-button value=\"d\">\n        Chengdu\n      </a-radio-button>\n    </a-radio-group>\n    <a-radio-group v-model:value=\"value\" button-style=\"solid\">\n      <a-radio-button value=\"a\">\n        Hangzhou\n      </a-radio-button>\n      <a-radio-button value=\"b\" disabled>\n        Shanghai\n      </a-radio-button>\n      <a-radio-button value=\"c\">\n        Beijing\n      </a-radio-button>\n      <a-radio-button value=\"d\">\n        Chengdu\n      </a-radio-button>\n    </a-radio-group>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with layout styles, cursor styles, disabled text color and other basic container styles",
+          "descriptionZh": "根元素，包含布局样式、鼠标样式、禁用状态文字颜色等基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Radio\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-radio :classes=\"classes\">\n        Radio\n      </a-radio>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element with border radius, transition animations, border styles, hover states, focus states and other interactive styles",
+          "descriptionZh": "选中框元素，包含圆角样式、过渡动画、边框样式、悬停状态、焦点状态等交互样式"
+        },
+        {
+          "key": "label",
+          "description": "Label element with padding, text color, disabled states, alignment and other text styles",
+          "descriptionZh": "文本元素，包含内边距、文字颜色、禁用状态、对齐方式等文本样式"
         }
       ]
     },
@@ -16537,7 +17309,8 @@
           "descriptionZh": "调试使用。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst value = ref(2.5)\n</script>\n\n<template>\n  <a-config-provider\n    :theme=\"{\n      components: {\n        Rate: {\n          starColor: 'blue',\n          starSize: 40,\n          starHoverScale: 'scale(2)',\n          starBg: 'red',\n        },\n      },\n    }\"\n  >\n    <a-rate v-model:value=\"value\" allow-half />\n  </a-config-provider>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Result",
@@ -16705,14 +17478,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Result by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Result 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { ResultProps } from 'antdv-next'\n\nconst classesObject: ResultProps['classes'] = {\n  root: 'demo-result-root',\n  title: 'demo-result-title',\n  subTitle: 'demo-result-subtitle',\n  icon: 'demo-result-icon',\n  extra: 'demo-result-extra',\n  body: 'demo-result-body',\n}\n\nconst classesFn: ResultProps['classes'] = (info) => {\n  if (info.props.status === 'success') {\n    return {\n      root: 'demo-result-root--success',\n    } satisfies ResultProps['classes']\n  }\n  return {\n    root: 'demo-result-root--default',\n  } satisfies ResultProps['classes']\n}\n\nconst stylesObject: ResultProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed', padding: '16px' },\n  title: { fontStyle: 'italic', color: '#1890ff' },\n  subTitle: { fontWeight: 'bold' },\n  icon: { opacity: 0.8 },\n  extra: { backgroundColor: '#f0f0f0', padding: 'px' },\n  body: { backgroundColor: '#fafafa', padding: '12px' },\n}\n\nconst stylesFn: ResultProps['styles'] = (info) => {\n  if (info.props.status === 'error') {\n    return {\n      root: { backgroundColor: '#fff2f0', borderColor: '#ff4d4f' },\n      title: { color: '#ff4d4f' },\n    } satisfies ResultProps['styles']\n  }\n  else {\n    return {\n      root: { backgroundColor: '#f6ffed', borderColor: '#52c41a' },\n      title: { color: '#52c41a' },\n    } satisfies ResultProps['styles']\n  }\n}\n</script>\n\n<template>\n  <a-result\n    status=\"info\"\n    title=\"classes Object\"\n    sub-title=\"This is a subtitle\"\n    :styles=\"stylesObject\"\n    :classes=\"classesObject\"\n  >\n    <template #extra>\n      <a-button type=\"primary\">\n        Action\n      </a-button>\n    </template>\n    <div>Content area</div>\n  </a-result>\n  <a-result\n    status=\"success\"\n    title=\"classes Function\"\n    sub-title=\"Dynamic class names\"\n    :styles=\"stylesFn\"\n    :classes=\"classesFn\"\n  >\n    <template #extra>\n      <a-button type=\"primary\">\n        Action\n      </a-button>\n    </template>\n  </a-result>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with text alignment, layout styles and other basic container styles",
+          "descriptionZh": "根元素，包含文本对齐、布局样式等基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'subTitle', desc: t('subTitle'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Result\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-result\n        title=\"title\"\n        sub-title=\"subTitle\"\n        :classes=\"classes\"\n      >\n        <template #extra>\n          <a-button type=\"primary\">\n            extra\n          </a-button>\n        </template>\n        <div :style=\"{ textAlign: 'center' }\">\n          The Content of Result\n        </div>\n      </a-result>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "title",
+          "description": "Title element with font size, text color, line height, text alignment and other text styles",
+          "descriptionZh": "标题元素，包含字体大小、文字颜色、行高、对齐方式等文字样式"
+        },
+        {
+          "key": "subTitle",
+          "description": "Subtitle element with font size, text color, line height and other text styles",
+          "descriptionZh": "副标题元素，包含字体大小、文字颜色、行高等文字样式"
+        },
+        {
+          "key": "body",
+          "description": "Content element with margin, padding, background color and other content area styles",
+          "descriptionZh": "内容元素，包含外边距、内边距、背景色等内容区域样式"
+        },
+        {
+          "key": "extra",
+          "description": "Action area element with margin, text alignment, inner element spacing and other layout styles",
+          "descriptionZh": "操作区域元素，包含外边距、文本对齐、内部元素间距等布局样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with margin, text alignment, font size, status colors and other icon styles",
+          "descriptionZh": "图标元素，包含外边距、文本对齐、字体大小、状态颜色等图标样式"
         }
       ]
     },
@@ -16976,14 +17773,28 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Segmented by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Segmented 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { SegmentedProps } from 'antdv-next'\nimport { CloudOutlined, RocketOutlined, ThunderboltOutlined } from '@antdv-next/icons'\nimport { h } from 'vue'\n\nconst classes: SegmentedProps['classes'] = {\n  root: 'custom-segmented-root',\n}\nconst styleFn: SegmentedProps['styles'] = (info) => {\n  if (info.props.vertical) {\n    return {\n      root: {\n        border: '1px solid #77BEF0',\n        padding: '4px',\n        width: '100px',\n      },\n      icon: {\n        color: '#77BEF0',\n      },\n      item: {\n        textAlign: 'start',\n      },\n    } satisfies SegmentedProps['styles']\n  }\n  return {}\n}\n\nconst styles: SegmentedProps['styles'] = {\n  root: {\n    padding: '4px',\n    width: '260px',\n  },\n}\n\nconst options: SegmentedProps['options'] = [\n  {\n    label: 'Boost',\n    value: 'boost',\n    icon: h(RocketOutlined),\n  },\n  {\n    label: 'Stream',\n    value: 'stream',\n    icon: h(ThunderboltOutlined),\n  },\n  {\n    label: 'Cloud',\n    value: 'cloud',\n    icon: h(CloudOutlined),\n  },\n]\nconst segmentedSharedProps: SegmentedProps = {\n  options,\n  classes,\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-segmented v-bind=\"segmentedSharedProps\" :styles=\"styles\" />\n    <a-segmented v-bind=\"segmentedSharedProps\" :styles=\"styleFn\" vertical />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with inline-block layout, padding, background, border radius, transition and container styles",
+          "descriptionZh": "根元素，设置行内块布局、内边距、背景色、圆角、过渡动画和容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AppstoreOutlined, BarsOutlined } from '@antdv-next/icons'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n])\n\nconst options = [\n  { label: 'List', value: 'List', icon: h(BarsOutlined) },\n  { label: 'Kanban', value: 'Kanban', icon: h(AppstoreOutlined) },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Segmented\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-segmented :options=\"options\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Option element with relative positioning, text alignment, cursor style, transition, selected state background and hover styles",
+          "descriptionZh": "选项元素，设置相对定位、文本对齐、光标样式、过渡动画、选中态背景色和悬停态样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with icon size, color and text spacing styles",
+          "descriptionZh": "图标元素，设置图标的尺寸、颜色和与文本的间距样式"
+        },
+        {
+          "key": "label",
+          "description": "Label content element with min height, line height, padding, text ellipsis and content layout styles",
+          "descriptionZh": "标签内容元素，设置最小高度、行高、内边距、文本省略和内容布局样式"
         }
       ]
     },
@@ -17825,14 +18636,73 @@
           "description": "You can customize the semantic dom style of Select by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "您可以通过 `classes` 和 `styles` 传入对象/函数来自定义 Select 的语义化 DOM 样式。",
           "code": "<script setup lang=\"ts\">\nimport { MehOutlined } from '@antdv-next/icons'\n\nconst options = [\n  { value: 'GuangZhou', label: 'GuangZhou' },\n  { value: 'ShenZhen', label: 'ShenZhen' },\n]\n\nconst stylesObject = {\n  prefix: {\n    color: '#1890ff',\n  },\n  suffix: {\n    color: '#1890ff',\n  },\n}\n\nconst stylesFilled = {\n  prefix: {\n    color: '#722ed1',\n  },\n  suffix: {\n    color: '#722ed1',\n  },\n  popup: {\n    root: {\n      border: '1px solid #722ed1',\n    },\n  },\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-select\n      :options=\"options\"\n      :classes=\"{ root: 'custom-select' }\"\n      :styles=\"stylesObject\"\n      placeholder=\"Object\"\n    >\n      <template #prefix>\n        <MehOutlined />\n      </template>\n    </a-select>\n    <a-select\n      :options=\"options\"\n      :classes=\"{ root: 'custom-select' }\"\n      :styles=\"stylesFilled\"\n      placeholder=\"Function\"\n      variant=\"filled\"\n    >\n      <template #prefix>\n        <MehOutlined />\n      </template>\n    </a-select>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, cursor styles, transitions, border and other basic selector container styles",
+          "descriptionZh": "根元素，包含相对定位、行内 flex 布局、光标样式、过渡动画、边框等选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst mode = ref<'single' | 'multiple'>('single')\n\nconst options = [\n  { value: 'aojunhao123', label: 'aojunhao123' },\n  { value: 'thinkasany', label: 'thinkasany' },\n  { value: 'meet-student', label: 'meet-student' },\n]\n\nconst value = computed(() => {\n  if (mode.value !== 'multiple')\n    return []\n\n  return options.length > 0\n    ? [options[0]!.value]\n    : []\n})\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => {\n  const base = [\n    { name: 'root', desc: t('root') },\n    { name: 'prefix', desc: t('prefix') },\n    { name: 'content', desc: t('content') },\n    { name: 'placeholder', desc: t('placeholder') },\n    { name: 'clear', desc: t('clear') },\n    { name: 'input', desc: t('input') },\n    { name: 'suffix', desc: t('suffix') },\n    { name: 'popup.root', desc: t('popup.root') },\n    { name: 'popup.list', desc: t('popup.list') },\n    { name: 'popup.listItem', desc: t('popup.listItem') },\n  ]\n\n  if (mode.value === 'multiple') {\n    return [\n      ...base,\n      { name: 'item', desc: t('item') },\n      { name: 'itemContent', desc: t('itemContent') },\n      { name: 'itemRemove', desc: t('itemRemove') },\n    ]\n  }\n\n  return base\n})\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Select\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <div :style=\"{ display: 'flex', justifyContent: 'center', marginBottom: '12px' }\">\n          <a-segmented v-model:value=\"mode\" :options=\"['single', 'multiple']\" />\n        </div>\n        <div :style=\"{ display: 'flex', flexDirection: 'column', gap: '12px' }\">\n          <a-select\n            prefix=\"prefix\"\n            :style=\"{ width: '300px' }\"\n            :options=\"options\"\n            :value=\"value\"\n            :mode=\"mode === 'multiple' ? 'multiple' : undefined\"\n            open\n            :get-popup-container=\"() => divRef!\"\n            :classes=\"classes\"\n          />\n        </div>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with layout and styling for prefix content",
+          "descriptionZh": "前缀元素，包含前缀内容的布局和样式"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "clear",
+          "description": "Clear button element with layout, styling and interactive effects for clear button",
+          "descriptionZh": "清除按钮元素，包含清除按钮的布局、样式和交互效果"
+        },
+        {
+          "key": "input",
+          "description": "Input element with search input styling, cursor control, font inheritance and other search-related styles. Remove border styles",
+          "descriptionZh": "输入框元素，包含搜索输入框的样式、光标控制、字体继承等搜索相关样式，去除了边框样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with layout and styling for suffix content like clear button, arrow icon, etc.",
+          "descriptionZh": "后缀元素，包含后缀内容的布局和样式，如清除按钮、箭头图标等"
+        },
+        {
+          "key": "item",
+          "description": "Multiple selection item element with border, background, padding, and margin styles",
+          "descriptionZh": "多选项元素，包含边框、背景、内边距、外边距样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Multiple selection item content area with text ellipsis styles",
+          "descriptionZh": "多选项内容区域，包含文字的省略样式"
+        },
+        {
+          "key": "itemRemove",
+          "description": "Multiple selection item remove button with font-related styless",
+          "descriptionZh": "多选项移除按钮，包含字体相关样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with popup layer positioning, z-index, background, border, box-shadow and other popup container styles",
+          "descriptionZh": "弹出菜单元素，包含弹出层的定位、层级、背景、边框、阴影等弹出容器样式"
+        },
+        {
+          "key": "popup.list",
+          "description": "Popup list element with option list layout, scrolling, max-height and other list container styles",
+          "descriptionZh": "弹出菜单列表元素，包含选项列表的布局、滚动、最大高度等列表容器样式"
+        },
+        {
+          "key": "popup.listItem",
+          "description": "Popup item element with option item padding, hover effects, selected states, disabled states and other option interactive styles",
+          "descriptionZh": "弹出菜单条目元素，包含选项项的内边距、悬浮效果、选中状态、禁用状态等选项交互样式"
         }
       ]
     },
@@ -18287,22 +19157,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Skeleton by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Skeleton 组件的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nconst classes = {\n  root: 'skeleton-root',\n  header: 'skeleton-header',\n}\n\nconst styles = {\n  avatar: {\n    border: '1px solid #aaa',\n  },\n  title: {\n    border: '1px solid #aaa',\n  },\n}\n\nfunction stylesFn(info: { props: { active?: boolean } }) {\n  if (info.props?.active) {\n    return {\n      root: {\n        border: '1px solid rgba(229, 243, 254, 0.3)',\n      },\n      title: {\n        backgroundColor: 'rgba(229, 243, 254, 0.5)',\n        height: '20px',\n        borderRadius: '20px',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-skeleton\n      :classes=\"classes\"\n      :styles=\"styles\"\n      avatar\n      :paragraph=\"false\"\n    />\n    <a-skeleton\n      :classes=\"{ ...classes, paragraph: 'skeleton-paragraph' }\"\n      :styles=\"stylesFn\"\n      active\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with table display, width, animation effects, border radius and other skeleton container basic styles",
+          "descriptionZh": "根元素，包含表格显示、宽度、动画效果、圆角等骨架屏容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'avatar', desc: t('avatar'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'paragraph', desc: t('paragraph'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Skeleton\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-skeleton avatar :paragraph=\"{ rows: 4 }\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with table cell, padding, vertical alignment and other avatar placeholder area layout styles",
+          "descriptionZh": "头部元素，包含表格单元格、内边距、垂直对齐等头像占位区域的布局样式"
         },
         {
-          "name": "_semantic_element",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport type { SegmentedOptions } from 'antdv-next'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\ntype SkeletonElement = 'Avatar' | 'Button' | 'Input' | 'Image' | 'Node'\nconst internalOptions: SegmentedOptions = ['Avatar', 'Button', 'Input', 'Image', 'Node']\n\nconst element = ref<SkeletonElement>('Avatar')\n\nconst componentMap: Record<SkeletonElement, string> = {\n  Avatar: 'a-skeleton-avatar',\n  Button: 'a-skeleton-button',\n  Input: 'a-skeleton-input',\n  Image: 'a-skeleton-image',\n  Node: 'a-skeleton-node',\n}\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('element.root'), version: '1.0.0' },\n  { name: 'content', desc: t('element.content'), version: '1.0.0' },\n])\n\nconst componentName = computed(() => `Skeleton.${element.value}`)\nconst currentComponent = computed(() => componentMap[element.value])\n</script>\n\n<template>\n  <SemanticPreview\n    :component-name=\"componentName\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical :style=\"{ width: 'fit-content', marginInlineEnd: 'auto' }\">\n        <a-segmented v-model:value=\"element\" :options=\"internalOptions\" />\n        <a-divider title-placement=\"start\" plain>\n          {{ t('element.preview') }}\n        </a-divider>\n        <component :is=\"currentComponent\" :classes=\"classes\" />\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Section element with skeleton content area layout styles",
+          "descriptionZh": "区块元素，包含骨架屏内容区域的布局样式"
+        },
+        {
+          "key": "avatar",
+          "description": "Avatar element with inline-block display, vertical alignment, background color, size, border radius and other avatar placeholder styles",
+          "descriptionZh": "头像元素，包含行内块显示、垂直对齐、背景色、尺寸、圆角等头像占位的样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with width, height, background color, border radius and other title placeholder styles",
+          "descriptionZh": "标题元素，包含宽度、高度、背景色、圆角等标题占位的样式"
+        },
+        {
+          "key": "paragraph",
+          "description": "Paragraph element with padding, list item styles, background color, border radius and other paragraph placeholder styles",
+          "descriptionZh": "段落元素，包含内边距、列表项样式、背景色、圆角等段落占位的样式"
+        },
+        {
+          "key": "element.root",
+          "description": "Root element",
+          "descriptionZh": "根元素"
+        },
+        {
+          "key": "element.content",
+          "description": "Content element",
+          "descriptionZh": "内容元素"
+        },
+        {
+          "key": "element.preview",
+          "description": "Preview",
+          "descriptionZh": "预览"
         }
       ]
     },
@@ -18700,14 +19601,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Sliders by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Sliders 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst value = ref(30)\nconst valueVertical = ref(30)\n\nconst stylesObject = {\n  track: { backgroundImage: 'linear-gradient(180deg, #91caff, #1677ff)' },\n  handle: { borderColor: '#1677ff', boxShadow: '0 2px 8px #1677ff' },\n}\n\nfunction stylesFn(info: any) {\n  if (info.props.orientation === 'vertical') {\n    return {\n      root: { height: '300px' },\n      track: { backgroundImage: 'linear-gradient(180deg, #722cc0, #722ed1)' },\n      handle: { borderColor: '#722ed1', boxShadow: '0 2px 8px #722ed1' },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-slider v-model:value=\"value\" class=\"custom-slider\" :styles=\"stylesObject\" />\n    <a-slider\n      v-model:value=\"valueVertical\"\n      class=\"custom-slider-vertical\"\n      orientation=\"vertical\"\n      reverse\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, height, margin, padding, cursor style and touch action control",
+          "descriptionZh": "根元素，设置相对定位、高度、边距、内边距、光标样式和触摸事件控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'track', desc: t('track'), version: '1.0.0' },\n  { name: 'tracks', desc: t('tracks'), version: '1.0.0' },\n  { name: 'rail', desc: t('rail'), version: '1.0.0' },\n  { name: 'handle', desc: t('handle'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Slider\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-slider\n        range\n        :default-value=\"[20, 30, 50]\"\n        :style=\"{ width: '100%' }\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "track",
+          "description": "Track selection bar element with absolute positioning, background color, border radius and transition animation styles",
+          "descriptionZh": "轨道选取条元素，设置绝对定位、背景色、圆角和过渡动画样式"
+        },
+        {
+          "key": "tracks",
+          "description": "Multi-segment track container element with absolute positioning and transition animation styles",
+          "descriptionZh": "多段轨道容器元素，设置绝对定位和过渡动画样式"
+        },
+        {
+          "key": "rail",
+          "description": "Background rail element with absolute positioning, background color, border radius and transition animation styles",
+          "descriptionZh": "背景轨道元素，设置绝对定位、背景色、圆角和过渡动画样式"
+        },
+        {
+          "key": "handle",
+          "description": "Slider handle control element with absolute positioning, size, outline, user selection, background color, border shadow, border radius, cursor style and transition animation",
+          "descriptionZh": "滑块控制点元素，设置绝对定位、尺寸、轮廓线、用户选择、背景色、边框阴影、圆角、光标样式和过渡动画"
         }
       ]
     },
@@ -18915,14 +19835,23 @@
           "description": "Customize semantic structure styles and class names. Supports both object and function forms.",
           "descriptionZh": "自定义语义化结构的样式和类名。支持对象和函数两种形式。",
           "code": "<script setup lang=\"ts\">\nimport type { SpaceProps } from 'antdv-next'\n\nconst classNamesObject: SpaceProps['classes'] = {\n  root: 'demo-space-root',\n  item: 'demo-space-item',\n  separator: 'demo-space-separator',\n}\n\nconst classNamesFn: SpaceProps['classes'] = (info) => {\n  if (info.props.orientation === 'vertical') {\n    return {\n      root: 'demo-space-root--vertical',\n    } satisfies SpaceProps['classes']\n  }\n  else {\n    return {\n      root: 'demo-space-root--horizontal',\n    } satisfies SpaceProps['classes']\n  }\n}\n\nconst stylesObject: SpaceProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed', padding: '8px', marginBottom: '10px' },\n  item: { backgroundColor: '#f0f0f0', padding: '4px' },\n  separator: { color: 'red', fontWeight: 'bold' },\n}\n\nconst stylesFn: SpaceProps['styles'] = (info) => {\n  if (info.props.size === 'large') {\n    return {\n      root: {\n        backgroundColor: '#e6f7ff',\n        borderColor: '#1890ff',\n        padding: '8px',\n      },\n    } satisfies SpaceProps['styles']\n  }\n  else {\n    return {\n      root: {\n        backgroundColor: '#fff7e6',\n        borderColor: '#fa8c16',\n      },\n    } satisfies SpaceProps['styles']\n  }\n}\n</script>\n\n<template>\n  <div>\n    <a-space :styles=\"stylesObject\" :classes=\"classNamesObject\" separator=\"•\">\n      <a-button>Styled Button 1</a-button>\n      <a-button>Styled Button 2</a-button>\n      <a-button>Styled Button 3</a-button>\n    </a-space>\n    <a-space size=\"large\" :styles=\"stylesFn\" :classes=\"classNamesFn\">\n      <a-button>Large Space Button 1</a-button>\n      <a-button>Large Space Button 2</a-button>\n      <a-button>Large Space Button 3</a-button>\n    </a-space>\n  </div>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, gap settings, alignment, wrap and other spacing container basic styles",
+          "descriptionZh": "根元素，包含 flex 布局、间隙设置、对齐方式、换行等间距容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n  { name: 'separator', desc: t('separator') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Space\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-space :classes=\"classes\">\n        <template #separator>\n          <a-divider vertical />\n        </template>\n        <a-button type=\"primary\">\n          Primary\n        </a-button>\n        <a-button>Default</a-button>\n        <a-button type=\"dashed\">\n          Dashed\n        </a-button>\n      </a-space>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Wrapped item element with spacing item layout and styles, providing wrapper for each child element for inline alignment",
+          "descriptionZh": "包裹的子组件，包含间距项的布局和样式，为每个子元素提供包装用于内联对齐"
+        },
+        {
+          "key": "separator",
+          "description": "Separator element with divider styling",
+          "descriptionZh": "分隔符，包含分隔元素的样式"
         }
       ]
     },
@@ -19120,14 +20049,18 @@
           "description": "The `fullscreen` mode is perfect for creating page loaders. It adds a dimmed overlay with a centered spinner.",
           "descriptionZh": "`fullscreen` 属性非常适合创建流畅的页面加载器。它添加了半透明覆盖层，并在其中心放置了一个旋转加载符号。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst spinning = ref(false)\nconst percent = ref(0)\n\nfunction showLoader() {\n  spinning.value = true\n  let ptg = -10\n\n  const interval = setInterval(() => {\n    ptg += 5\n    percent.value = ptg\n\n    if (ptg > 120) {\n      clearInterval(interval)\n      spinning.value = false\n      percent.value = 0\n    }\n  }, 100)\n}\n</script>\n\n<template>\n  <div>\n    <a-button @click=\"showLoader\">\n      Show fullscreen\n    </a-button>\n    <a-spin :spinning=\"spinning\" :percent=\"percent\" fullscreen />\n  </div>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with absolute positioning, display control, color, font size, text alignment, vertical alignment, opacity and transition animation (effective when fullscreen is false)",
+          "descriptionZh": "根元素，设置绝对定位、显示控制、颜色、字体大小、文本对齐、垂直对齐、透明度和过渡动画(fullscreen 为 false 时才有效)"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Spin\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div\n        :style=\"{\n          position: 'relative',\n          width: '500px',\n          height: '100px',\n          display: 'flex',\n          alignItems: 'center',\n          justifyContent: 'center',\n        }\"\n      >\n        <a-spin :percent=\"0\" :classes=\"classes\" />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "indicator",
+          "description": "Indicator element with width, height, font size, inline-block display, transition animation, transform origin, line height and color",
+          "descriptionZh": "指示器元素，设置宽度、高度、字体大小、行内块显示、过渡动画、变换原点、行高和颜色"
         }
       ]
     },
@@ -19410,14 +20343,23 @@
           "description": "Customize semantic structure styles and class names. Supports both object and function forms.",
           "descriptionZh": "自定义语义化结构的样式和类名。支持对象和函数两种形式。",
           "code": "<script setup lang=\"ts\">\nimport type { SplitterProps } from 'antdv-next'\n\nconst stylesObject: SplitterProps['styles'] = {\n  root: { backgroundColor: '#fffbe6' },\n  dragger: { backgroundColor: 'rgba(194,223,252,0.4)' },\n}\n\nconst stylesFn: SplitterProps['styles'] = ({ props }) => {\n  if (props.orientation === 'horizontal') {\n    return {\n      root: {\n        borderWidth: '2px',\n        borderStyle: 'dashed',\n        marginBottom: '10px',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-splitter\n      style=\"height: 200px\"\n      root-class=\"shadow-secondary\"\n      :styles=\"stylesObject\"\n    >\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\" style=\"color: #000\">\n            First\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\" style=\"color: #000\">\n            Second\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n    </a-splitter>\n    <a-splitter\n      style=\"height: 200px\"\n      root-class=\"shadow-secondary\"\n      :styles=\"stylesFn\"\n    >\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\">\n            First\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\">\n            Second\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n    </a-splitter>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, width and height, alignment and stretch styles",
+          "descriptionZh": "根元素，设置flex布局、宽度高度、对齐方式和拉伸样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'panel', desc: t('panel'), version: '1.0.0' },\n  { name: 'dragger', desc: t('dragger'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Splitter\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-splitter\n        :style=\"{ height: '200px', boxShadow: '0 0 10px rgba(0, 0, 0, 0.1)' }\"\n        :classes=\"classes\"\n      >\n        <a-splitter-panel>\n          <div :style=\"{ display: 'flex', height: '100%', alignItems: 'center', justifyContent: 'center' }\">\n            First\n          </div>\n        </a-splitter-panel>\n        <a-splitter-panel>\n          <div :style=\"{ display: 'flex', height: '100%', alignItems: 'center', justifyContent: 'center' }\">\n            Second\n          </div>\n        </a-splitter-panel>\n      </a-splitter>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "panel",
+          "description": "Panel element with flex basis, grow ratio and panel container styles",
+          "descriptionZh": "面板元素，设置flex基础值、增长比例和面板容器样式"
+        },
+        {
+          "key": "dragger",
+          "description": "Drag control element with absolute positioning, user selection, z-index, center alignment, background color, hover and active states styles",
+          "descriptionZh": "拖拽控制元素，设置绝对定位、用户选择、层级、居中对齐、背景色、悬停态和激活态样式"
         }
       ]
     },
@@ -19618,14 +20560,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of the Statistic by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Statistic 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { StatisticProps } from 'antdv-next'\nimport { ArrowDownOutlined, ArrowUpOutlined } from '@antdv-next/icons'\n\nconst classes = {\n  root: 'custom-statistic-root',\n}\nconst styleFn: StatisticProps['styles'] = ({ props }) => {\n  const numValue = Number(props.value ?? 0)\n  const isNegative = Number.isFinite(numValue) && numValue < 0\n  if (isNegative) {\n    return {\n      title: {\n        color: '#ff4d4f',\n      },\n      content: {\n        color: '#ff7875',\n      },\n    } satisfies StatisticProps['styles']\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-statistic\n      :value=\"93241\"\n      title=\"Monthly Active Users\"\n      :classes=\"classes\"\n      :styles=\"{ title: { color: '#1890ff', fontWeight: '600px' }, content: { fontSize: '24px' } }\"\n      suffix=\"users\"\n    >\n      <template #prefix>\n        <ArrowUpOutlined />\n      </template>\n    </a-statistic>\n\n    <a-statistic\n      :value=\"-18.7\"\n      title=\"Yearly Loss\"\n      :precision=\"1\"\n      :classes=\"classes\"\n      :styles=\"styleFn\"\n      suffix=\"%\"\n    >\n      <template #prefix>\n        <ArrowDownOutlined />\n      </template>\n    </a-statistic>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with reset styles and overall container styles for statistic component",
+          "descriptionZh": "根元素，包含统计数值组件的重置样式和整体容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { ArrowUpOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'prefix', desc: t('prefix'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'suffix', desc: t('suffix'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Statistic\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ position: 'absolute' }\">\n        <a-statistic\n          title=\"Active\"\n          :value=\"11.28\"\n          :precision=\"2\"\n          :styles=\"{ content: { color: '#3f8600' } }\"\n          suffix=\"%\"\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <ArrowUpOutlined />\n          </template>\n        </a-statistic>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with bottom padding and title area layout styles",
+          "descriptionZh": "头部元素，包含下内边距和标题区域的布局样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text color, font size and other title text display styles",
+          "descriptionZh": "标题元素，包含文字颜色、字体大小等标题文字的显示样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with text color, font size, font family and other numeric content display styles",
+          "descriptionZh": "内容元素，包含文字颜色、字体大小、字体族等数值内容的展示样式"
+        },
+        {
+          "key": "prefix",
+          "description": "Prefix element with inline-block display, right margin and other prefix content layout styles",
+          "descriptionZh": "前缀元素，包含行内块显示、右外边距等前缀内容的布局样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with inline-block display, left margin and other suffix content layout styles",
+          "descriptionZh": "后缀元素，包含行内块显示、左外边距等后缀内容的布局样式"
         }
       ]
     },
@@ -19931,14 +20897,58 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Steps by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Steps 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { StepsProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: StepsProps['classes'] = {\n  root: 'steps-demo-root',\n}\n\nconst stylesObject: StepsProps['styles'] = {\n  itemIcon: {\n    borderRadius: '30%',\n  },\n  itemContent: {\n    fontStyle: 'italic',\n  },\n}\n\nconst stylesFn: StepsProps['styles'] = (info) => {\n  if (info?.props?.type === 'navigation') {\n    return {\n      root: {\n        borderColor: '#1890ff',\n      },\n    }\n  }\n  return {}\n}\n\nconst items: StepsProps['items'] = [\n  { title: 'Finished', content: 'This is a content.' },\n  { title: 'In Progress', content: 'This is a content.' },\n  { title: 'Waiting', content: 'This is a content.' },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-steps :items=\"items\" :current=\"1\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-steps\n      :items=\"items\"\n      :current=\"1\"\n      type=\"navigation\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, nowrap, alignment, CSS variables and other basic step container styles",
+          "descriptionZh": "根元素，包含 flex 布局、禁止换行、对齐方式、CSS 变量等步骤条容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemWrapper', desc: t('itemWrapper') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n  { name: 'itemHeader', desc: t('itemHeader') },\n  { name: 'itemTitle', desc: t('itemTitle') },\n  { name: 'itemSubtitle', desc: t('itemSubtitle') },\n  { name: 'itemSection', desc: t('itemSection') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'itemRail', desc: t('itemRail') },\n])\n\nconst items = [\n  { title: 'Step 1', subTitle: '00:01', content: 'This is a content.' },\n  { title: 'Step 2', subTitle: '00:02', content: 'This is a content.' },\n  { title: 'Step 3', subTitle: '00:03', content: 'This is a content.' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Steps\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical gap=\"large\" :style=\"{ width: '100%' }\">\n        <a-steps\n          :current=\"1\"\n          :style=\"{ width: '100%' }\"\n          title-placement=\"vertical\"\n          :items=\"items\"\n          :classes=\"classes\"\n        />\n        <a-steps\n          :current=\"1\"\n          :style=\"{ width: '100%' }\"\n          type=\"panel\"\n          size=\"small\"\n          title-placement=\"horizontal\"\n          :items=\"items\"\n          :classes=\"classes\"\n        />\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Step item element with flex layout, relative positioning and other basic step item container styles",
+          "descriptionZh": "步骤项元素，包含 flex 布局、相对定位等单个步骤项的基础容器样式"
+        },
+        {
+          "key": "itemWrapper",
+          "description": "Step item wrapper element with flex layout, nowrap, top padding and other step content wrapping styles",
+          "descriptionZh": "步骤项内裹元素，包含 flex 布局、禁止换行、顶部内边距等步骤项内容的包装样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Step item icon element with icon size, positioning, font-size and other icon display related styles",
+          "descriptionZh": "步骤项图标元素，包含图标的尺寸、定位、字体大小等图标显示相关样式"
+        },
+        {
+          "key": "itemHeader",
+          "description": "Step item header element with flex layout, nowrap, alignment and other header area layout styles",
+          "descriptionZh": "步骤项头部元素，包含 flex 布局、禁止换行、对齐方式等头部区域的布局样式"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Step item title element with color, font-size, line-height, word-break, transitions and other title text styles",
+          "descriptionZh": "步骤项标题元素，包含颜色、字体大小、行高、文字换行、过渡动画等标题文字样式"
+        },
+        {
+          "key": "itemSubtitle",
+          "description": "Step item subtitle element with color, font-weight, font-size, line-height, margin, word-break and other subtitle styles",
+          "descriptionZh": "步骤项副标题元素，包含颜色、字体权重、字体大小、行高、外边距、文字换行等副标题样式"
+        },
+        {
+          "key": "itemSection",
+          "description": "Step item section element with step content area layout and styling",
+          "descriptionZh": "步骤项区域元素，包含步骤项内容区域的布局和样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Step item content element with color, font-size, line-height, word-break, transitions and other content text styles",
+          "descriptionZh": "步骤项内容元素，包含颜色、字体大小、行高、文字换行、过渡动画等内容文字样式"
+        },
+        {
+          "key": "itemRail",
+          "description": "Step item rail element with border-style, border-width, transitions and other connecting line styles",
+          "descriptionZh": "步骤项连接线元素，包含边框样式、边框宽度、过渡动画等连接线的样式"
         }
       ]
     },
@@ -20237,14 +21247,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Switch by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Switch 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes = {\n  root: 'custom-switch-root',\n}\n\nconst stylesObject = {\n  root: {\n    backgroundColor: '#F5D2D2',\n  },\n}\n\nfunction stylesFn(info: any) {\n  if (info.props.size === 'default') {\n    return {\n      root: {\n        backgroundColor: '#BDE3C3',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-switch\n      size=\"small\"\n      checked-children=\"on\"\n      un-checked-children=\"off\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n    />\n    <a-switch :classes=\"classes\" size=\"default\" :styles=\"stylesFn\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with min-width, height, line-height, vertical alignment, background color, border, border radius, cursor style, transition animations, user selection and other basic switch container styles",
+          "descriptionZh": "根元素，包含最小宽度、高度、行高、垂直对齐、背景色、边框、圆角、光标样式、过渡动画、用户选择等开关容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.3' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Switch\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-switch\n        checked-children=\"on\"\n        un-checked-children=\"off\"\n        default-checked\n        disabled\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "content",
+          "description": "Content element with block display, overflow hidden, border radius, height, padding, transition animations and other switch content area layout and styles",
+          "descriptionZh": "内容元素，包含块级显示、溢出隐藏、圆角、高度、内边距、过渡动画等开关内容区域的布局和样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element with absolute positioning, width, height, background color, border radius, shadow, transition animations and other switch handle styles and interactive effects",
+          "descriptionZh": "指示器元素,包含绝对定位、宽度、高度、背景色、圆角、阴影、过渡动画等开关把手的样式和交互效果"
         }
       ]
     },
@@ -21042,14 +22061,73 @@
           "description": "Customize header and body cells via the headerCell and bodyCell slots.",
           "descriptionZh": "通过 headerCell 与 bodyCell 插槽自定义表头和单元格内容。",
           "code": "<script setup lang=\"ts\">\nimport type { TableProps } from 'antdv-next'\n\ninterface DataItem {\n  key: string\n  name: string\n  age: number\n  address: string\n}\n\nconst columns: TableProps['columns'] = [\n  {\n    title: 'Name',\n    dataIndex: 'name',\n    key: 'name',\n  },\n  {\n    title: 'Age',\n    dataIndex: 'age',\n    key: 'age',\n  },\n  {\n    title: 'Address',\n    dataIndex: 'address',\n    key: 'address',\n  },\n  {\n    title: 'Action',\n    key: 'action',\n  },\n]\n\nconst dataSource: DataItem[] = [\n  {\n    key: '1',\n    name: 'John Brown',\n    age: 32,\n    address: 'New York No. 1 Lake Park',\n  },\n  {\n    key: '2',\n    name: 'Jim Green',\n    age: 42,\n    address: 'London No. 1 Lake Park',\n  },\n  {\n    key: '3',\n    name: 'Joe Black',\n    age: 32,\n    address: 'Sydney No. 1 Lake Park',\n  },\n]\n\nfunction handleAction(record: Record<string, any>) {\n  console.log('Action:', record.name)\n}\n</script>\n\n<template>\n  <a-table :columns=\"columns\" :data-source=\"dataSource\">\n    <template #headerCell=\"{ column }\">\n      <template v-if=\"column.key === 'name'\">\n        <span class=\"table-header-strong\">{{ column.title }}</span>\n      </template>\n    </template>\n    <template #bodyCell=\"{ column, text, record }\">\n      <template v-if=\"column.key === 'name'\">\n        <a class=\"table-name\" @click.prevent=\"handleAction(record)\">{{ text }}</a>\n      </template>\n      <template v-else-if=\"column.key === 'action'\">\n        <a @click.prevent=\"handleAction(record)\">Action</a>\n      </template>\n    </template>\n  </a-table>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with font-size, background, border-radius, scrollbar-color and other basic table container styles",
+          "descriptionZh": "根元素，包含字体大小、背景色、圆角、滚动条颜色等表格容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'title', desc: t('title') },\n  { name: 'content', desc: t('content') },\n  { name: 'header.wrapper', desc: t('header.wrapper') },\n  { name: 'header.row', desc: t('header.row') },\n  { name: 'header.cell', desc: t('header.cell') },\n  { name: 'section', desc: t('section') },\n  { name: 'body.wrapper', desc: t('body.wrapper') },\n  { name: 'body.row', desc: t('body.row') },\n  { name: 'body.cell', desc: t('body.cell') },\n  { name: 'footer', desc: t('footer') },\n  { name: 'pagination.root', desc: t('pagination.root') },\n  { name: 'pagination.item', desc: t('pagination.item') },\n])\n\nconst columns = [\n  {\n    title: 'Personal Info',\n    children: [\n      { title: 'Name', dataIndex: 'name', key: 'name' },\n      { title: 'Age', dataIndex: 'age', key: 'age' },\n    ],\n  },\n  { title: 'Address', dataIndex: 'address' },\n]\n\nconst data = [\n  { key: '1', name: 'thinkasany', age: 24, address: 'New York No. 1 Lake Park' },\n  { key: '2', name: 'Jim Green', age: 42, address: 'London No. 1 Lake Park' },\n  { key: '3', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n  { key: '4', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n  { key: '5', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n  { key: '6', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Table\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-table\n        bordered\n        :style=\"{ width: '100%' }\"\n        :columns=\"columns\"\n        :data-source=\"data\"\n        size=\"middle\"\n        :pagination=\"{ pageSize: 3 }\"\n        :classes=\"classes\"\n      >\n        <template #title>\n          table title\n        </template>\n        <template #footer>\n          table footer\n        </template>\n      </a-table>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Container element with clear-fix, max-width, scrollbar background and other table wrapper styles",
+          "descriptionZh": "容器元素，包含清除浮动、最大宽度、滚动条背景等表格包装容器样式"
+        },
+        {
+          "key": "header.wrapper",
+          "description": "Header wrapper element with table header layout and container styles",
+          "descriptionZh": "头部容器元素，包含表头的布局和容器样式"
+        },
+        {
+          "key": "header.row",
+          "description": "Header row element with table header row layout and styling",
+          "descriptionZh": "头部行元素，包含表头行的布局和样式"
+        },
+        {
+          "key": "header.cell",
+          "description": "Header cell element with relative positioning, padding, word-wrap, background, text color, font-weight and other header cell styles",
+          "descriptionZh": "头部单元格元素，包含相对定位、内边距、文字换行、背景色、文字颜色、字体权重等表头单元格样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with table title styling and layout",
+          "descriptionZh": "标题元素，包含表格标题的样式和布局"
+        },
+        {
+          "key": "body.wrapper",
+          "description": "Body wrapper element with table body layout and container styles",
+          "descriptionZh": "主体容器元素，包含表格主体的布局和容器样式"
+        },
+        {
+          "key": "body.row",
+          "description": "Body row element with hover effects, selected states, expanded states and other interactive row styles",
+          "descriptionZh": "主体行元素，包含数据行的悬浮效果、选中状态、展开状态等交互样式"
+        },
+        {
+          "key": "body.cell",
+          "description": "Body cell element with relative positioning, padding, word-wrap and other basic data cell styles",
+          "descriptionZh": "主体单元格元素，包含相对定位、内边距、文字换行等数据单元格的基础样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with table footer background color, text color and other footer styles",
+          "descriptionZh": "底部元素，包含表格底部的背景色、文字颜色等样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with table content area styling and layout",
+          "descriptionZh": "内容元素，包含表格内容区域的样式和布局"
+        },
+        {
+          "key": "pagination.root",
+          "description": "Pagination root element with pagination component basic styles and layout",
+          "descriptionZh": "分页根元素，包含分页组件的基础样式和布局"
+        },
+        {
+          "key": "pagination.item",
+          "description": "Pagination item element with pagination item styling and interactive effects",
+          "descriptionZh": "分页单项元素，包含分页项的样式和交互效果"
         }
       ]
     },
@@ -21554,14 +22632,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tabs by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tabs 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TabsProps } from 'antdv-next'\n\nconst items: TabsProps['items'] = [\n  { key: '1', label: 'Tab 1', content: 'Content of Tab Pane 1' },\n  { key: '2', label: 'Tab 2', content: 'Content of Tab Pane 2' },\n  { key: '3', label: 'Tab 3', content: 'Content of Tab Pane 3' },\n]\n\nconst classes: TabsProps['classes'] = {\n  root: 'custom-tabs-root',\n}\n\nconst stylesObject: TabsProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed', padding: '16px', marginBottom: '10px' },\n  header: { backgroundColor: 'rgba(245,245,245,0.5)' },\n  item: { fontWeight: 'bold', color: '#1890ff', padding: `6px 10px` },\n  indicator: { backgroundColor: 'rgba(255,77,79, 0.3)', height: '4px' },\n  content: { backgroundColor: 'rgba(230,247,255,0.8)', padding: '16px' },\n}\n\nconst stylesFn: TabsProps['styles'] = (info) => {\n  if (info.props.type === 'card') {\n    return {\n      root: { backgroundColor: 'rgba(250,250,250, 0.8)', borderColor: '#d9d9d9' },\n      header: { textAlign: 'start' },\n    } satisfies TabsProps['styles']\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-tabs :items=\"items\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-tabs type=\"card\" :items=\"items\" :classes=\"classes\" :styles=\"stylesFn\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with basic tab container styles, layout and direction control",
+          "descriptionZh": "根元素，包含标签页容器的基础样式、布局和方向控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'header', desc: t('header') },\n  { name: 'item', desc: t('item') },\n  { name: 'indicator', desc: t('indicator') },\n  { name: 'content', desc: t('content') },\n  { name: 'popup.root', desc: t('popup.root') },\n])\n\nconst items = computed(() =>\n  Array.from({ length: 30 }, (_, i) => {\n    const id = String(i)\n    return {\n      label: `Tab-${id}`,\n      key: id,\n      disabled: i === 28,\n      children: `Content of tab ${id}`,\n    }\n  }),\n)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tabs\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-tabs\n        default-active-key=\"1\"\n        :style=\"{ height: '220px', width: '100%' }\"\n        :styles=\"{\n          popup: {\n            root: { background: '#fff' },\n          },\n        }\"\n        :items=\"items\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with relative positioning, padding, colors, text ellipsis, border-radius, transitions and other tab item styles and interactive effects",
+          "descriptionZh": "Item 元素，包含相对定位、内边距、颜色、文本省略、圆角、过渡动画等标签项的样式和交互效果"
+        },
+        {
+          "key": "header",
+          "description": "Header element with tab navigation header layout, background, borders and other styles",
+          "descriptionZh": "头部元素，包含标签页头部导航的布局、背景、边框等样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element with indicator bar color, position, dimensions, transitions and other active state indication styles",
+          "descriptionZh": "指示器元素，包含指示条的颜色、位置、尺寸、过渡动画等活跃状态指示样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with tab content panel layout, padding and other content display styles",
+          "descriptionZh": "内容元素，包含标签页内容面板的布局、内边距等内容展示样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup menu element with dropdown absolute positioning, z-index, display control, max-height, scrolling and other styles",
+          "descriptionZh": "弹出菜单元素，包含下拉菜单的绝对定位、层级、显示控制、最大高度、滚动等样式"
         }
       ]
     },
@@ -21873,14 +22975,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tag by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tag 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { CheckCircleOutlined, CloseCircleOutlined } from '@antdv-next/icons'\n\nconst tagStyles = {\n  root: {\n    backgroundColor: '#e6f7ff',\n  },\n  icon: {\n    color: '#52c41a',\n  },\n  content: {\n    color: '#262626',\n  },\n}\n\nconst filledTagStyles = {\n  root: {\n    backgroundColor: '#F5EFFF',\n  },\n  icon: {\n    color: '#8F87F1',\n  },\n  content: {\n    color: '#8F87F1',\n  },\n}\n\nconst groupStyles = {\n  root: {\n    gap: '12px',\n    padding: '8px 12px',\n    backgroundColor: 'rgba(82, 196, 26, 0.08)',\n    borderRadius: '8px',\n  },\n  item: {\n    backgroundColor: 'rgba(82, 196, 26, 0.1)',\n    borderColor: 'rgba(82, 196, 26, 0.3)',\n    color: '#52c41a',\n  },\n}\n\nconst multipleGroupStyles = {\n  root: {\n    gap: '16px',\n    padding: '8px 12px',\n    backgroundColor: 'rgba(143, 135, 241, 0.08)',\n    borderRadius: '8px',\n  },\n  item: {\n    backgroundColor: 'rgba(143, 135, 241, 0.1)',\n    borderColor: 'rgba(143, 135, 241, 0.3)',\n    color: '#8F87F1',\n    fontWeight: 500,\n  },\n}\n\nconst options1 = ['React', 'Vue', 'Angular']\nconst options2 = ['meet-student', 'thinkasany']\n</script>\n\n<template>\n  <a-space size=\"large\" vertical>\n    <a-flex gap=\"middle\">\n      <a-tag :classes=\"{ root: 'custom-tag-root' }\" :styles=\"tagStyles\">\n        <template #icon>\n          <CheckCircleOutlined />\n        </template>\n        Object\n      </a-tag>\n      <a-tag\n        variant=\"filled\"\n        :classes=\"{ root: 'custom-tag-root' }\"\n        :styles=\"filledTagStyles\"\n      >\n        <template #icon>\n          <CloseCircleOutlined />\n        </template>\n        Function\n      </a-tag>\n    </a-flex>\n    <a-flex vertical gap=\"middle\">\n      <a-checkable-tag-group\n        :classes=\"{ root: 'custom-tag-root' }\"\n        :styles=\"groupStyles\"\n        :options=\"options1\"\n      />\n      <a-checkable-tag-group\n        :classes=\"{ root: 'custom-tag-root' }\"\n        :styles=\"multipleGroupStyles\"\n        :options=\"options2\"\n        multiple\n      />\n    </a-flex>\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with inline-block display, auto height, padding, font size, line height, nowrap, background color, border, border radius, opacity, transition animations, text alignment, relative positioning and other basic tag styles",
+          "descriptionZh": "根元素，包含行内块布局、自动高度、内边距、字体大小、行高、禁止换行、背景色、边框、圆角、透明度、过渡动画、文本对齐、相对定位等标签的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AntDesignOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tag\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-tag :classes=\"classes\">\n        <template #icon>\n          <AntDesignOutlined />\n        </template>\n        Ant Design\n      </a-tag>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element with font size, color, cursor style, transition animations and other icon display styles",
+          "descriptionZh": "图标元素，包含字体大小、颜色、光标样式、过渡动画等图标的显示样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with text content color, font styles and other content area styles",
+          "descriptionZh": "内容元素，包含文本内容的颜色、字体样式等内容区域的样式"
         }
       ]
     },
@@ -22027,14 +23138,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of TimePicker by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 TimePicker 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TimePickerProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { useToken } = theme\nconst { token } = useToken()\n\nconst customClasses = {\n  root: 'custom-timepicker-root',\n}\n\nconst stylesObject: TimePickerProps['styles'] = {\n  root: {\n    borderColor: '#d9d9d9',\n  },\n}\n\nconst stylesFn: TimePickerProps['styles'] = (info) => {\n  if (info.props.size === 'large') {\n    return {\n      root: {\n        borderColor: '#722ed1',\n      },\n      suffix: {\n        color: '#722ed1',\n      },\n      popup: {\n        container: { border: '1px solid #722ed1', borderRadius: '8px' },\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-time-picker :classes=\"customClasses\" :styles=\"stylesObject\" placeholder=\"Object\" />\n    <a-time-picker :classes=\"customClasses\" :styles=\"stylesFn\" placeholder=\"Function\" size=\"large\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, padding, border-radius, transition animations and other basic styles for time picker container",
+          "descriptionZh": "根元素，包含相对定位、行内flex布局、内边距、边框圆角、过渡动画等时间选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { SmileOutlined } from '@antdv-next/icons'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'popup.root', desc: t('popup') },\n  { name: 'popup.container', desc: t('popup.container') },\n  { name: 'popup.content', desc: t('popup.content') },\n  { name: 'popup.item', desc: t('popup.item') },\n  { name: 'popup.footer', desc: t('popup.footer') },\n])\n\nconst type = ref<'Single' | 'Multiple'>('Single')\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    :component-name=\"type === 'Single' ? 'TimePicker' : 'TimePicker.RangePicker'\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" vertical :style=\"{ alignSelf: 'flex-start' }\" gap=\"middle\" align=\"center\">\n        <a-segmented\n          :options=\"['Single', 'Multiple']\"\n          :value=\"type\"\n          @change=\"(val: 'Single' | 'Multiple') => type = val\"\n        />\n        <a-time-picker\n          v-if=\"type === 'Single'\"\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-time-picker>\n        <a-time-range-picker\n          v-else\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-time-range-picker>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with flex layout and margin styles for prefix content layout",
+          "descriptionZh": "前缀元素，包含flex布局、右外边距等前缀内容的布局样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with relative positioning, width, color, font, line-height, transition animations and other core interactive styles for input field",
+          "descriptionZh": "输入框元素，包含相对定位、宽度、颜色、字体、行高、过渡动画等输入框的核心交互样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with flex layout, color, line-height, pointer events, transition animations and other styles for suffix content",
+          "descriptionZh": "后缀元素，包含flex布局、颜色、行高、指针事件、过渡动画等后缀内容的样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup element",
+          "descriptionZh": "弹出框元素"
+        },
+        {
+          "key": "popup.container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "popup.content",
+          "description": "Popup content element with width, border, cell and other content display styles for time list",
+          "descriptionZh": "弹出框内容元素，包含时间列表的宽度、边框、单元格等内容展示样式"
+        },
+        {
+          "key": "popup.item",
+          "description": "Popup item element with size, background, border-radius, hover state, selected state and other interactive styles for time cells",
+          "descriptionZh": "弹出框单项元素，包含时间单元格的尺寸、背景色、边框圆角、悬停态、选中态等交互样式"
+        },
+        {
+          "key": "popup.footer",
+          "description": "Popup footer element with layout styles for bottom operation area including confirm/cancel buttons",
+          "descriptionZh": "弹出框底部元素，包含确认取消按钮等底部操作区域的布局样式"
         }
       ]
     },
@@ -22263,14 +23413,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Timeline by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Timeline 的[语义化结构](#semantic-dom)样式。",
           "code": "<script lang=\"ts\" setup>\nconst classes = {\n  root: 'custom-timeline-root',\n}\n\nconst styles = {\n  itemIcon: {\n    borderColor: '#1890ff',\n  },\n}\n\nfunction stylesFn(info: any) {\n  if (info.props.orientation === 'vertical') {\n    return {\n      root: {\n        padding: '10px 6px',\n        border: '1px solid #A294F9',\n      },\n      itemIcon: {\n        borderColor: '#A294F9',\n      },\n    }\n  }\n  return {}\n}\n\nconst items = [\n  {\n    title: '2015-09-01',\n    content: 'Create a services site',\n  },\n  {\n    title: '2015-09-01 09:12:11',\n    content: 'Solve initial network problems',\n  },\n  {\n    content: 'Technical testing',\n  },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-timeline :items=\"items\" orientation=\"horizontal\" :styles=\"styles\" :classes=\"classes\" />\n    <a-timeline :items=\"items\" orientation=\"vertical\" :styles=\"stylesFn\" :classes=\"classes\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with timeline container list style reset, vertical layout, dot icon, outlined style, alternate layout and other basic container styles",
+          "descriptionZh": "根元素，设置时间轴容器的列表样式重置、垂直布局、点状图标、轮廓样式、交替布局等基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemWrapper', desc: t('itemWrapper') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n  { name: 'itemSection', desc: t('itemSection') },\n  { name: 'itemHeader', desc: t('itemHeader') },\n  { name: 'itemTitle', desc: t('itemTitle') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'itemRail', desc: t('itemRail') },\n])\n\nconst items = [\n  { title: '2015-09-01', content: 'Create a services' },\n  { title: '2015-09-01 09:12:11', content: 'Solve initial network problems' },\n  { content: 'Technical testing' },\n  { title: '2015-09-01 09:12:11', content: 'Network problems being solved' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Timeline\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-timeline :items=\"items\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with single timeline node relative positioning, margin, padding, font size, finish state, color theme, layout direction and other node basic styles",
+          "descriptionZh": "节点元素，设置单个时间节点的相对定位、外边距、内边距、字体大小、完成状态、颜色主题、布局方向等节点基础样式"
+        },
+        {
+          "key": "itemWrapper",
+          "description": "Item wrapper element with timeline node content wrapping container styles",
+          "descriptionZh": "节点包装元素，设置时间节点内容的包装容器样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Item icon element with node head icon absolute positioning, width/height size, background color, border, border radius, wave animation and other icon styles",
+          "descriptionZh": "节点图标元素，设置节点头部图标的绝对定位、宽高尺寸、背景色、边框、圆角、波纹动画等图标样式"
+        },
+        {
+          "key": "itemHeader",
+          "description": "Item header element with header area layout containing title and rail, alignment, text direction and other styles",
+          "descriptionZh": "节点头部元素，设置包含标题和连接线的头部区域布局、对齐方式、文本方向等样式"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Item title element with node title text font size, line height, color and other text styles",
+          "descriptionZh": "节点标题元素，设置节点标题文字的字体大小、行高、颜色等文本样式"
+        },
+        {
+          "key": "itemSection",
+          "description": "Item section element with section container containing header and content flex layout, wrap, gap and other layout styles",
+          "descriptionZh": "节点区域元素，设置包含头部和内容的区域容器的Flex布局、换行、间距等布局样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Item content element with node detail content relative positioning, top offset, left margin, text color, word break and other content styles",
+          "descriptionZh": "节点内容元素，设置节点详细内容的相对定位、顶部偏移、左侧外边距、文字颜色、词汇换行等内容样式"
+        },
+        {
+          "key": "itemRail",
+          "description": "Item rail element with timeline node connection track line absolute positioning, top offset, left offset, height, border color, width, style and other connection line styles",
+          "descriptionZh": "节点连接线元素，设置连接时间节点的轨道线条的绝对定位、顶部偏移、左侧偏移、高度、边框颜色、宽度、样式等连接线样式"
         }
       ]
     },
@@ -22639,14 +23828,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tooltip by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tooltip 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TooltipProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: TooltipProps['classes'] = {\n  container: 'demo-tooltip-container',\n}\n\nconst stylesObject: TooltipProps['styles'] = {\n  container: {\n    borderRadius: '12px',\n    boxShadow: 'inset 0 0 8px #ccc',\n  },\n}\n\nconst stylesFn: TooltipProps['styles'] = (info) => {\n  if (info?.props?.arrow === false) {\n    return {\n      container: {\n        backgroundColor: 'rgba(53, 71, 125, 0.8)',\n        padding: '12px',\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-tooltip title=\"Object text\" :classes=\"classes\" :styles=\"stylesObject\" :arrow=\"false\">\n      <a-button>Object Style</a-button>\n    </a-tooltip>\n    <a-tooltip title=\"Function text\" :classes=\"classes\" :styles=\"stylesFn\" :arrow=\"false\">\n      <a-button type=\"primary\">\n        Function Style\n      </a-button>\n    </a-tooltip>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element (including arrows, content elements) with absolute positioning, z-index, block display, max width, visibility, transform origin and arrow background color",
+          "descriptionZh": "根元素 (包含箭头、内容元素)，设置绝对定位、层级、块级显示、最大宽度、可见性、变换原点和箭头背景色"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'container', desc: t('container') },\n  { name: 'arrow', desc: t('arrow') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tooltip\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', marginTop: '60px' }\">\n        <a-tooltip\n          open\n          placement=\"top\"\n          title=\"tooltip prompt text\"\n          :auto-adjust-overflow=\"false\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "container",
+          "description": "Content element with min width and height, padding, color, text alignment, background color, border radius, shadow and border styles",
+          "descriptionZh": "内容元素，设置最小宽度高度、内边距、颜色、文本对齐、背景色、圆角、阴影和边框样式"
+        },
+        {
+          "key": "arrow",
+          "description": "Arrow element with width, height, position, color and border styles",
+          "descriptionZh": "箭头元素，设置宽高、位置、颜色和边框样式"
         }
       ]
     },
@@ -22948,14 +24146,63 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tour by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tour 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TourProps, TourStepItem } from 'antdv-next'\nimport { computed, h, shallowRef } from 'vue'\n\nconst ref1 = shallowRef()\nconst ref2 = shallowRef()\nconst ref3 = shallowRef()\nconst open = shallowRef(false)\nconst openFn = shallowRef(false)\n\nconst btnProps = {\n  nextButtonProps: {\n    style: {\n      border: '1px solid #CDC1FF',\n      color: '#CDC1FF',\n    },\n  },\n  prevButtonProps: {\n    style: {\n      backgroundColor: '#CDC1FF',\n      color: '#fff',\n    },\n  },\n}\n\nconst coverNode = h('img', {\n  alt: 'tour.png',\n  src: 'https://user-images.githubusercontent.com/5378891/197385811-55df8480-7ff4-44bd-9d43-a7dade598d70.png',\n})\n\nconst steps: TourStepItem[] = [\n  {\n    title: 'Upload File',\n    description: 'Put your files here.',\n    cover: coverNode,\n    target: ref1,\n    prevButtonProps: {},\n  },\n  {\n    title: 'Save',\n    description: 'Save your changes.',\n    target: ref2,\n  },\n  {\n    title: 'Other Actions',\n    description: 'Click to see other actions.',\n    target: ref3,\n  },\n]\n\nconst stepsWithButtonProps = computed(() => steps.map(step => ({ ...step, ...btnProps })))\n\nconst classes: TourProps['classes'] = {\n  root: 'custom-tour-root',\n  section: 'custom-tour-section',\n}\n\nconst stylesObject: TourProps['styles'] = {\n  mask: {\n    backgroundColor: 'rgba(0, 0, 0, 0.3)',\n  },\n  section: {\n    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',\n    border: '2px solid #4096ff',\n  },\n  cover: {\n    borderRadius: '12px 12px 0 0',\n  },\n}\n\nconst stylesFn: TourProps['styles'] = (info) => {\n  if (info.props.type === 'primary') {\n    return {\n      mask: {\n        backgroundColor: 'rgba(0, 0, 0, 0.3)',\n      },\n      section: {\n        backgroundColor: 'rgba(205, 193, 255, 0.8)',\n        boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',\n      },\n      cover: {\n        borderRadius: '12px 12px 0 0',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-flex gap=\"middle\">\n      <a-button type=\"primary\" @click=\"open = true\">\n        Begin Tour Object\n      </a-button>\n      <a-button type=\"primary\" @click=\"openFn = true\">\n        Begin Tour Function\n      </a-button>\n    </a-flex>\n    <a-divider />\n    <a-tour\n      v-model:open=\"open\"\n      :steps=\"steps\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    />\n    <a-tour\n      v-model:open=\"openFn\"\n      :steps=\"stepsWithButtonProps\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n      type=\"primary\"\n    />\n    <a-space>\n      <a-button ref=\"ref1\" type=\"primary\">\n        Upload\n      </a-button>\n      <a-button ref=\"ref2\">\n        Save\n      </a-button>\n      <a-button ref=\"ref3\" type=\"dashed\">\n        Other Actions\n      </a-button>\n    </a-space>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Tour root container with absolute positioning, z-index control, max width, visibility, arrow background color variable, theme styles and other container styles",
+          "descriptionZh": "引导根容器，设置绝对定位、层级控制、最大宽度、可见性、箭头背景色变量、主题样式等容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'mask', desc: t('mask'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'cover', desc: t('cover'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n  { name: 'indicators', desc: t('indicators'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n])\n\nconst open = ref(true)\nconst createBtnRef = ref<HTMLButtonElement | null>(null)\n\nconst steps = [\n  {\n    title: 'Hello World!',\n    description: 'Hello World?!',\n    target: () => createBtnRef.value!,\n    mask: true,\n  },\n  {\n    title: 'Save',\n    description: 'Save your changes.',\n    target: () => createBtnRef.value!,\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tour\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div\n        :style=\"{\n          width: '100%',\n          height: '825px',\n          display: 'flex',\n          alignItems: 'center',\n          justifyContent: 'center',\n          position: 'relative',\n          overflow: 'hidden',\n        }\"\n      >\n        <a-button ref=\"createBtnRef\" @click=\"open = true\">\n          Show\n        </a-button>\n        <a-tour\n          v-model:open=\"open\"\n          :z-index=\"1\"\n          :default-current=\"0\"\n          :get-popup-container=\"false\"\n          :steps=\"steps\"\n          :classes=\"classes\"\n        >\n          <template #coverRender=\"{ index }\">\n            <template v-if=\"index === 0\">\n              <img src=\"https://user-images.githubusercontent.com/5378891/197385811-55df8480-7ff4-44bd-9d43-a7dade598d70.png\" alt=\"img\">\n            </template>\n          </template>\n        </a-tour>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "cover",
+          "description": "Card cover area with text center alignment, padding, image width and other image display styles",
+          "descriptionZh": "卡片封面区域，设置文本居中对齐、内边距、图片宽度等图片展示样式"
+        },
+        {
+          "key": "section",
+          "description": "Card main content area with text alignment, border radius, box shadow, relative positioning, background color, border, background clip and other card styles",
+          "descriptionZh": "卡片主要内容区域，设置文本对齐、边框圆角、盒阴影、相对定位、背景色、边框、背景裁剪等卡片样式"
+        },
+        {
+          "key": "footer",
+          "description": "Card bottom action area with padding, text right alignment, border radius, flex layout and other bottom container styles",
+          "descriptionZh": "卡片底部操作区域，设置内边距、文本右对齐、边框圆角、Flex布局等底部容器样式"
+        },
+        {
+          "key": "actions",
+          "description": "Action button group container with left auto margin, button spacing and other button group layout styles",
+          "descriptionZh": "操作按钮组容器，设置左侧自动外边距、按钮间距等按钮组布局样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Single indicator element with width/height size, inline-block display, border radius, background color, right margin, active state and other dot styles",
+          "descriptionZh": "单个指示器元素，设置宽高尺寸、行内块显示、圆角、背景色、右外边距、激活状态等圆点样式"
+        },
+        {
+          "key": "indicators",
+          "description": "Indicator group container with inline-block display and other indicator container styles",
+          "descriptionZh": "指示器组容器，设置行内块显示等指示器容器样式"
+        },
+        {
+          "key": "header",
+          "description": "Card header area with padding, width calculation, word break and other header container styles",
+          "descriptionZh": "卡片头部区域，设置内边距、宽度计算、词汇换行等头部容器样式"
+        },
+        {
+          "key": "title",
+          "description": "Guide title text with font weight and other title text styles",
+          "descriptionZh": "引导标题文字，设置字体粗细等标题文本样式"
+        },
+        {
+          "key": "description",
+          "description": "Guide description text with padding, word wrap and other description text styles",
+          "descriptionZh": "引导描述文字，设置内边距、词汇换行等描述文本样式"
+        },
+        {
+          "key": "mask",
+          "description": "Mask layer element with fixed positioning, full screen coverage, z-index, pointer events, transition animation and other mask styles",
+          "descriptionZh": "遮罩层元素，设置固定定位、全屏覆盖、层级、指针事件、过渡动画等遮罩样式"
         }
       ]
     },
@@ -23279,14 +24526,63 @@
           "description": "Custom the labels for select all checkboxes.",
           "descriptionZh": "自定义穿梭框全选按钮的文字。",
           "code": "<script setup lang=\"ts\">\nimport type { TransferEmits, TransferProps } from 'antdv-next'\nimport { ref } from 'vue'\n\ninterface RecordType {\n  key: string\n  title: string\n  description: string\n}\n\nconst mockData = Array.from({ length: 10 }).map<RecordType>((_, i) => ({\n  key: i.toString(),\n  title: `content${i + 1}`,\n  description: `description of content${i + 1}`,\n}))\n\nconst oriTargetKeys = mockData.filter(item => Number(item.key) % 3 > 1).map(item => item.key)\n\nconst selectAllLabels: TransferProps['selectAllLabels'] = [\n  'Select All',\n  ({ selectedCount, totalCount }) => `${selectedCount}/${totalCount}`,\n]\n\nconst targetKeys = ref(oriTargetKeys)\n\nconst handleChange: TransferEmits['change'] = (newTargetKeys) => {\n  targetKeys.value = newTargetKeys\n}\n</script>\n\n<template>\n  <a-transfer\n    v-model:target-keys=\"targetKeys\"\n    :data-source=\"mockData\"\n    :render=\"(item: RecordType) => item.title\"\n    :select-all-labels=\"selectAllLabels\"\n    @change=\"handleChange\"\n  />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, transfer container base styles and layout control",
+          "descriptionZh": "根元素，设置flex布局、穿梭框容器的基础样式和布局控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'section', desc: t('section') },\n  { name: 'header', desc: t('header') },\n  { name: 'title', desc: t('title') },\n  { name: 'body', desc: t('body') },\n  { name: 'list', desc: t('list') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'footer', desc: t('footer') },\n  { name: 'actions', desc: t('actions') },\n])\n\nconst mockData = Array.from({ length: 20 }).map((_, i) => ({\n  key: i,\n  title: `content ${i + 1}`,\n}))\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Transfer\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-transfer\n        show-search\n        :titles=\"['Source', 'Target']\"\n        :data-source=\"mockData\"\n        :selected-keys=\"[]\"\n        :target-keys=\"[3, 9]\"\n        :render=\"(item: any) => item.title\"\n        :styles=\"{\n          section: { height: '250px', width: '200px' },\n        }\"\n        :classes=\"classes\"\n      >\n        <template #footer>\n          <div :style=\"{ padding: '8px' }\">\n            Custom Footer\n          </div>\n        </template>\n      </a-transfer>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Section element with flex layout, width, height, min height, border, border radius and other single-side transfer container styles",
+          "descriptionZh": "区域元素，设置flex布局、宽度、高度、最小高度、边框、圆角等单侧穿梭框的容器样式"
+        },
+        {
+          "key": "header",
+          "description": "Header element with flex layout, alignment, height, padding, color, background color, bottom border, border radius and other header area styles",
+          "descriptionZh": "头部元素，设置flex布局、对齐方式、高度、内边距、颜色、背景色、下边框、圆角等头部区域的样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text ellipsis, flex ratio, text alignment, auto left margin and other title text layout and styles",
+          "descriptionZh": "标题元素，设置文本省略、flex占比、文本对齐、自动左边距等标题文字的布局和样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with list main area container styles and layout control",
+          "descriptionZh": "内容元素，设置列表主体区域的容器样式和布局控制"
+        },
+        {
+          "key": "list",
+          "description": "List element with list content styles, layout and scroll control",
+          "descriptionZh": "列表元素，设置列表内容的样式、布局和滚动控制"
+        },
+        {
+          "key": "item",
+          "description": "List item element with relative positioning, padding, border, hover state, selected state, disabled state and other list item interaction styles",
+          "descriptionZh": "列表项元素，设置相对定位、内边距、边框、悬停态、选中态、禁用态等列表项的交互样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "List item icon element with checkbox and other icon styles and interaction states",
+          "descriptionZh": "列表项图标元素，设置复选框等图标的样式和交互状态"
+        },
+        {
+          "key": "itemContent",
+          "description": "List item content element with text ellipsis, padding and other list item text content display styles",
+          "descriptionZh": "列表项内容元素，设置文本省略、内边距等列表项文本内容的展示样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with bottom operation area styles and layout",
+          "descriptionZh": "页脚元素，设置底部操作区域的样式和布局"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element with transfer button group styles, layout and interaction states",
+          "descriptionZh": "操作元素，设置穿梭按钮组的样式、布局和交互状态"
         }
       ]
     },
@@ -23981,14 +25277,28 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tree by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tree 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TreeDataNode, TreeProps } from 'antdv-next'\nimport { ref } from 'vue'\n\nconst treeData: TreeDataNode[] = [\n  {\n    title: 'parent 1',\n    key: '0-0',\n    children: [\n      {\n        title: 'parent 1-0',\n        key: '0-0-0',\n        children: [\n          {\n            title: 'leaf',\n            key: '0-0-0-0',\n          },\n          {\n            title: 'leaf',\n            key: '0-0-0-1',\n          },\n        ],\n      },\n      {\n        title: 'parent 1-1',\n        key: '0-0-1',\n        children: [\n          {\n            title: 'leaf',\n            key: '0-0-1-0',\n          },\n        ],\n      },\n    ],\n  },\n]\n\nconst styles: TreeProps['styles'] = {\n  root: { border: '2px solid #d9d9d9' },\n  item: { margin: '2px 0' },\n}\n\nconst stylesFn: TreeProps['styles'] = (info) => {\n  if (!info.props.checkable) {\n    return {\n      root: {\n        border: `2px solid #E5D9F2`,\n        borderRadius: '4px',\n      },\n    }\n  }\n  return {}\n}\n\nconst expandedKeys = ref(['0-0-0', '0-0-1'])\nconst selectedKeys = ref(['0-0-1'])\nconst checkedKeys = ref(['0-0-0', '0-0-1'])\nconst classes = {\n  root: 'root',\n  item: 'item',\n  itemTitle: 'itemTitle',\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-tree\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      auto-expand-parent\n      checkable\n      :styles=\"styles\"\n    />\n    <a-tree\n      v-model:expanded-keys=\"expandedKeys\"\n      v-model:selected-keys=\"selectedKeys\"\n      v-model:checked-keys=\"checkedKeys\"\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      auto-expand-parent\n      :checkable=\"false\"\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with tree control base styles, layout and container control",
+          "descriptionZh": "根元素，设置树形控件的基础样式、布局和容器控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { DownOutlined, FrownFilled, FrownOutlined, MehOutlined, SmileOutlined } from '@antdv-next/icons'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'itemIcon', desc: t('itemIcon'), version: '1.0.0' },\n  { name: 'itemTitle', desc: t('itemTitle'), version: '1.0.0' },\n])\n\nconst treeData = [\n  {\n    title: 'parent 1',\n    key: '0-0',\n    icon: h(SmileOutlined),\n    children: [\n      { title: 'leaf', key: '0-0-0', icon: h(MehOutlined) },\n      { title: 'leaf', key: '0-0-1', icon: ({ selected }: { selected: boolean }) => selected ? h(FrownFilled) : h(FrownOutlined) },\n    ],\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tree\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-tree\n        show-icon\n        default-expand-all\n        :default-selected-keys=\"['0-0-0']\"\n        :tree-data=\"treeData\"\n        :classes=\"classes\"\n      >\n        <template #switcherIcon>\n          <DownOutlined />\n        </template>\n      </a-tree>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with tree node base styles, drag state, role attributes, indentation, switcher, content wrapper and other node structure",
+          "descriptionZh": "条目元素，设置树节点的基础样式、拖拽状态、角色属性、缩进、切换器、内容包装器等节点结构"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Title element with tree node title text display styles and text content",
+          "descriptionZh": "标题元素，设置树节点标题文字的显示样式和文本内容"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Icon element with tree node icon styles, size and state display",
+          "descriptionZh": "图标元素，设置树节点图标的样式、尺寸和状态显示"
         }
       ]
     },
@@ -24571,14 +25881,68 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of TreeSelect by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 TreeSelect 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TreeSelectProps } from 'antdv-next'\n\nconst classes: TreeSelectProps['classes'] = {\n  root: 'custom-tree-select',\n}\n\nconst stylesObject: TreeSelectProps['styles'] = {\n  input: {\n    fontSize: 16,\n  },\n  suffix: {\n    color: '#1890ff',\n  },\n  popup: {\n    root: {\n      border: '1px solid #1890ff',\n    },\n  },\n}\n\nconst stylesFn: TreeSelectProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      suffix: {\n        color: '#722ed1',\n      },\n      popup: {\n        item: {\n          color: '#722ed1',\n        },\n      },\n    }\n  }\n  return {}\n}\n\nconst treeData: TreeSelectProps['treeData'] = [\n  {\n    value: 'parent 1',\n    title: 'parent 1',\n    children: [\n      {\n        value: 'parent 1-0',\n        title: 'parent 1-0',\n        children: [\n          {\n            value: 'leaf1',\n            title: 'leaf1',\n          },\n          {\n            value: 'leaf2',\n            title: 'leaf2',\n          },\n        ],\n      },\n      {\n        value: 'parent 1-1',\n        title: 'parent 1-1',\n        children: [\n          {\n            value: 'leaf3',\n            title: 'leaf3',\n          },\n        ],\n      },\n    ],\n  },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-tree-select\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      placeholder=\"Object\"\n    />\n    <a-tree-select\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      placeholder=\"Function\"\n      size=\"middle\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with tree selector base styles, border, border radius container styles",
+          "descriptionZh": "根元素，设置树选择器的基础样式、边框、圆角容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst mode = ref<'single' | 'multiple'>('single')\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => {\n  const base = [\n    { name: 'root', desc: t('root') },\n    { name: 'prefix', desc: t('prefix') },\n    { name: 'placeholder', desc: t('placeholder') },\n  ]\n\n  if (mode.value === 'multiple') {\n    base.push(\n      ...[\n        { name: 'content', desc: t('content') },\n        { name: 'item', desc: t('item') },\n        { name: 'itemContent', desc: t('itemContent') },\n        { name: 'itemRemove', desc: t('itemRemove') },\n      ],\n    )\n  }\n\n  base.push(\n    ...[\n      { name: 'input', desc: t('input') },\n      { name: 'suffix', desc: t('suffix') },\n      { name: 'popup.root', desc: t('popup.root') },\n      { name: 'popup.item', desc: t('popup.item') },\n      { name: 'popup.itemTitle', desc: t('popup.itemTitle') },\n    ],\n  )\n\n  return base\n})\n\nconst treeValue = ref<string[]>([])\nconsole.log(treeValue)\nfunction handleResetValue(newMode: string | number) {\n  if (newMode === 'multiple') {\n    treeValue.value = ['aojunhao123']\n  }\n  else {\n    treeValue.value = []\n  }\n}\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst treeData = [\n  {\n    value: 'contributors',\n    title: 'contributors',\n    children: [\n      { value: 'aojunhao123', title: 'aojunhao123' },\n      { value: 'thinkasany', title: 'thinkasany' },\n      { value: 'meet-student', title: 'meet-student' },\n    ],\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"TreeSelect\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <div :style=\"{ display: 'flex', justifyContent: 'center', marginBottom: '12px' }\">\n          <a-segmented v-model:value=\"mode\" :options=\"['single', 'multiple']\" @change=\"handleResetValue\" />\n        </div>\n\n        <a-tree-select\n          v-model:value=\"treeValue\"\n          prefix=\"prefix\"\n          :style=\"{ width: '300px' }\"\n          :tree-data=\"treeData\"\n          tree-default-expand-all\n          :multiple=\"mode === 'multiple'\"\n          show-search\n          max-tag-count=\"responsive\"\n          placeholder=\"Please select\"\n          allow-clear\n          open\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with prefix content layout and styles",
+          "descriptionZh": "前缀元素，设置前缀内容的布局和样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "input",
+          "description": "Input element with text input, search, selected value display and other input core interaction styles",
+          "descriptionZh": "输入框元素，设置文本输入、搜索、选择值显示等输入框的核心交互样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with suffix content, clear button, dropdown arrow and other suffix area styles",
+          "descriptionZh": "后缀元素，设置后缀内容、清除按钮、下拉箭头等后缀区域的样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with dropdown tree selection panel positioning, z-index, background, border, shadow and other popup layer styles",
+          "descriptionZh": "弹出菜单元素，设置下拉树形选择面板的定位、层级、背景、边框、阴影等弹层样式"
+        },
+        {
+          "key": "popup.item",
+          "description": "Popup item element with tree node option styles, hover state, selected state and other interaction states",
+          "descriptionZh": "弹出菜单条目元素，设置树节点选项的样式、悬停态、选中态等交互状态"
+        },
+        {
+          "key": "popup.itemTitle",
+          "description": "Popup title element with tree node title text display styles",
+          "descriptionZh": "弹出菜单标题元素，设置树节点标题文字的显示样式"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "item",
+          "description": "Multiple selection item element with border, background, padding, and margin styles",
+          "descriptionZh": "多选项元素，包含边框、背景、内边距、外边距样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Multiple selection item content area with text ellipsis styles",
+          "descriptionZh": "多选项内容区域，包含文字的省略样式"
+        },
+        {
+          "key": "itemRemove",
+          "description": "Multiple selection item remove button with font-related styles",
+          "descriptionZh": "多选项移除按钮，包含字体相关样式"
         }
       ]
     },
@@ -25091,7 +26455,8 @@
           "descriptionZh": "添加后缀的省略。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst rows = ref(1)\n\nconst article = `To be, or not to be, that is the question: Whether it is nobler in the mind to suffer. The slings and arrows of outrageous fortune Or to take arms against a sea of troubles, And by opposing end them? To die: to sleep; No more; and by a sleep to say we end The heart-ache and the thousand natural shocks That flesh is heir to, 'tis a consummation Devoutly to be wish'd. To die, to sleep To sleep- perchance to dream: ay, there's the rub! For in that sleep of death what dreams may come When we have shuffled off this mortal coil, Must give us pause. There 's the respect That makes calamity of so long life`\n\nfunction onEllipsis(ellipsis: boolean) {\n  console.log('Ellipsis changed:', ellipsis)\n}\n</script>\n\n<template>\n  <div>\n    <a-slider v-model:value=\"rows\" :min=\"1\" :max=\"10\" />\n    <a-typography-paragraph\n      :ellipsis=\"{\n        rows,\n        expandable: true,\n        suffix: '--William Shakespeare',\n        onEllipsis,\n      }\"\n      :title=\"`${article}--William Shakespeare`\"\n    >\n      {{ article }}\n    </a-typography-paragraph>\n  </div>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Upload",
@@ -25547,14 +26912,23 @@
           "description": "Component Token Debug.",
           "descriptionZh": "Component Token Debug.",
           "code": "<script setup lang=\"ts\">\nimport type { UploadEmits, UploadFile } from 'antdv-next'\nimport { UploadOutlined } from '@antdv-next/icons'\n\nconst defaultFileList: UploadFile[] = [\n  {\n    uid: '1',\n    name: 'xxx.png',\n    status: 'uploading',\n    url: 'http://www.baidu.com/xxx.png',\n    percent: 33,\n  },\n  {\n    uid: '2',\n    name: 'yyy.png',\n    status: 'done',\n    url: 'http://www.baidu.com/yyy.png',\n  },\n  {\n    uid: '3',\n    name: 'zzz.png',\n    status: 'error',\n    response: 'Server Error 500',\n    url: 'http://www.baidu.com/zzz.png',\n  },\n]\n\nconst handleChange: UploadEmits['change'] = ({ file, fileList }) => {\n  if (file.status !== 'uploading') {\n    console.log(file, fileList)\n  }\n}\n</script>\n\n<template>\n  <a-config-provider\n    :theme=\"{\n      components: {\n        Upload: {\n          actionsColor: 'yellow',\n        },\n      },\n    }\"\n  >\n    <a-upload\n      action=\"https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload\"\n      :default-file-list=\"defaultFileList\"\n      @change=\"handleChange\"\n    >\n      <a-button>\n        <template #icon>\n          <UploadOutlined />\n        </template>\n        Upload\n      </a-button>\n    </a-upload>\n  </a-config-provider>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root container element with layout styles, disabled text color, user-select control, cursor styles and other basic styles",
+          "descriptionZh": "根元素容器，包含布局样式、禁用状态文字颜色、用户选择控制、鼠标样式等基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { UploadOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'list', desc: t('list'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n])\n\nconst defaultFileList = [\n  { uid: '1', name: 'xxx.png', status: 'uploading', url: 'http://www.baidu.com/xxx.png', percent: 33 },\n  { uid: '2', name: 'yyy.png', status: 'done', url: 'http://www.baidu.com/yyy.png' },\n  { uid: '3', name: 'zzz.png', status: 'error', response: 'Server Error 500', url: 'http://www.baidu.com/zzz.png' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Upload\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-upload\n        action=\"https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload\"\n        :default-file-list=\"defaultFileList\"\n        :classes=\"classes\"\n      >\n        <a-button>\n          <template #icon>\n            <UploadOutlined />\n          </template>\n          Upload\n        </a-button>\n      </a-upload>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "list",
+          "description": "File list container with layout arrangement, transition animations, spacing control and other styles",
+          "descriptionZh": "文件列表容器，包含布局排列、过渡动画、间距控制等样式"
+        },
+        {
+          "key": "item",
+          "description": "File item element with padding, background color, border styles, hover effects, status colors, transition animations and other styles",
+          "descriptionZh": "文件项元素，包含内边距、背景色、边框样式、悬停效果、状态颜色、过渡动画等样式"
         }
       ]
     },
@@ -25701,7 +27075,8 @@
           "descriptionZh": "在 Modal 与 Drawer 中使用。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst showModal = shallowRef(false)\nconst showDrawer = shallowRef(false)\nconst showDrawer2 = shallowRef(false)\n\nconst placeholderStyle = {\n  height: '300px',\n  display: 'flex',\n  justifyContent: 'center',\n  alignItems: 'center',\n  backgroundColor: 'rgba(150, 150, 150, 0.2)',\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-button type=\"primary\" @click=\"showModal = true\">\n      Show in Modal\n    </a-button>\n    <a-button type=\"primary\" @click=\"showDrawer = true\">\n      Show in Drawer\n    </a-button>\n    <a-button type=\"primary\" @click=\"showDrawer2 = true\">\n      Not Show in Drawer\n    </a-button>\n  </a-flex>\n  <a-watermark content=\"Antdv Next\">\n    <a-modal\n      v-model:open=\"showModal\"\n      destroy-on-hidden\n      title=\"Modal\"\n      @ok=\"showModal = false\"\n      @cancel=\"showModal = false\"\n    >\n      <div :style=\"placeholderStyle\">\n        A mock height\n      </div>\n    </a-modal>\n    <a-drawer\n      v-model:open=\"showDrawer\"\n      destroy-on-hidden\n      title=\"Drawer\"\n      @close=\"showDrawer = false\"\n    >\n      <div :style=\"placeholderStyle\">\n        A mock height\n      </div>\n    </a-drawer>\n  </a-watermark>\n  <a-watermark content=\"Antdv Next\" :inherit=\"false\">\n    <a-drawer\n      v-model:open=\"showDrawer2\"\n      destroy-on-hidden\n      title=\"Drawer\"\n      @close=\"showDrawer2 = false\"\n    >\n      <div :style=\"placeholderStyle\">\n        A mock height\n      </div>\n    </a-drawer>\n  </a-watermark>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     }
   ],
   "changelog": [

--- a/data/v1.2.2.json
+++ b/data/v1.2.2.json
@@ -1812,7 +1812,8 @@
           "descriptionZh": "用 `target` 设置 `Affix` 需要监听其滚动事件的元素，默认为 `window`。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst container = shallowRef()\n</script>\n\n<template>\n  <div ref=\"container\" style=\"width: 100%;height: 100px;overflow: auto;box-shadow: 0 0 0 1px #1677ff;scrollbar-width: thin;scrollbar-gutter: stable\">\n    <div style=\"width: 100%;height: 1000px\">\n      <a-affix :target=\"() => container\">\n        <a-button type=\"primary\">\n          Fixed at the top of container\n        </a-button>\n      </a-affix>\n    </div>\n  </div>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Alert",
@@ -2081,14 +2082,43 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Alert by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Alert 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { AlertProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: AlertProps['classes'] = {\n  root: 'demo-alert-root',\n}\n\nconst stylesObject: AlertProps['styles'] = {\n  icon: {\n    fontSize: '18px',\n  },\n  section: {\n    fontWeight: 500,\n  },\n}\n\nconst stylesFn: AlertProps['styles'] = (info) => {\n  if (info?.props?.type === 'success') {\n    return {\n      root: {\n        backgroundColor: 'rgba(82, 196, 26, 0.1)',\n        borderColor: '#b7eb8f',\n      },\n      icon: {\n        color: '#52c41a',\n      },\n    }\n  }\n  if (info?.props?.type === 'warning') {\n    return {\n      root: {\n        backgroundColor: 'rgba(250, 173, 20, 0.1)',\n        borderColor: '#ffe58f',\n      },\n      icon: {\n        color: '#faad14',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"small\">\n    <a-alert\n      title=\"Object styles\"\n      type=\"info\"\n      show-icon\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n    >\n      <template #action>\n        <a-button size=\"small\">\n          Action\n        </a-button>\n      </template>\n    </a-alert>\n    <a-alert\n      title=\"Function styles\"\n      type=\"success\"\n      show-icon\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with border, background, padding, border-radius, and positioning styles for the alert container",
+          "descriptionZh": "根元素，包含边框、背景色、内边距、圆角、位置布局等警告提示框的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Alert\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-alert\n        closable\n        title=\"Info Text\"\n        show-icon\n        description=\"Info Description Info Description Info Description Info Description\"\n        type=\"info\"\n        :classes=\"classes\"\n      >\n        <template #action>\n          <a-space direction=\"vertical\">\n            <a-button size=\"small\" type=\"primary\">\n              Accept\n            </a-button>\n            <a-button size=\"small\" danger ghost>\n              Decline\n            </a-button>\n          </a-space>\n        </template>\n      </a-alert>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Content element with flex layout controlling content area typography and minimum width",
+          "descriptionZh": "内容元素，采用 flex 布局控制内容区域的排版和最小宽度"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with color, line-height, and margin styles, supporting different status icon types",
+          "descriptionZh": "图标元素，包含图标的颜色、行高、外边距等样式，支持不同类型的状态图标"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text color and font styling for the alert title",
+          "descriptionZh": "标题元素，包含标题文字的颜色、字体等样式"
+        },
+        {
+          "key": "description",
+          "description": "Description element with font-size and line-height styles for additional content",
+          "descriptionZh": "描述元素，包含描述文字的字体大小、行高等排版样式"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element with layout and spacing styles for action buttons",
+          "descriptionZh": "操作组元素，包含操作按钮的布局和间距样式"
+        },
+        {
+          "key": "close",
+          "description": "Close button element with basic button styling",
+          "descriptionZh": "关闭按钮元素，包含按钮的基础样式"
         }
       ]
     },
@@ -2326,14 +2356,28 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Anchor by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "您可以通过 `classes` 和 `styles` 传入对象/函数可以自定义 Anchor 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { AnchorProps } from 'antdv-next'\n\nconst classesObject: AnchorProps['classes'] = {\n  root: 'demo-anchor-root',\n  item: 'demo-anchor-item',\n  itemTitle: 'demo-anchor-title',\n  indicator: 'demo-anchor-indicator',\n}\n\nconst stylesFn: AnchorProps['styles'] = (info) => {\n  if (info.props.direction === 'vertical') {\n    return {\n      root: {\n        backgroundColor: 'rgba(255,251,230,0.5)',\n        height: '100vh',\n      },\n    }\n  }\n  return {}\n}\n\nconst items: NonNullable<AnchorProps['items']> = [\n  {\n    key: 'part-1',\n    href: '#part-1',\n    title: 'Part 1',\n  },\n  {\n    key: 'part-2',\n    href: '#part-2',\n    title: 'Part 2',\n  },\n  {\n    key: 'part-3',\n    href: '#part-3',\n    title: 'Part 3',\n  },\n]\n</script>\n\n<template>\n  <a-row>\n    <a-col :span=\"16\">\n      <div id=\"part-1\" style=\"height: 100vh; background: rgba(255, 0, 0, 0.08)\" />\n      <div id=\"part-2\" style=\"height: 100vh; background: rgba(0, 255, 0, 0.08)\" />\n      <div id=\"part-3\" style=\"height: 100vh; background: rgba(0, 0, 255, 0.08)\" />\n    </a-col>\n    <a-col :span=\"8\">\n      <a-anchor replace :items=\"items\" :styles=\"stylesFn\" :classes=\"classesObject\" />\n    </a-col>\n  </a-row>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with layout positioning, padding, margin, background color and other basic styles",
+          "descriptionZh": "根元素，包含布局定位、内边距、边距、背景色等基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'itemTitle', desc: t('itemTitle'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n])\n\nconst items = [\n  {\n    key: 'api',\n    href: '#api',\n    title: 'API',\n    children: [\n      { key: '4', href: '#anchor-props', title: 'Anchor Props' },\n      { key: '5', href: '#link-props', title: 'Link Props' },\n    ],\n  },\n  { key: '1', href: '#anchor-demo-basic', title: 'Basic demo' },\n  { key: '2', href: '#anchor-demo-static', title: 'Static demo' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Anchor\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-anchor :affix=\"false\" :items=\"items\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Link item element with padding, text color, hover states, transition animations and other styles",
+          "descriptionZh": "链接项元素，包含内边距、文字颜色、悬停状态、过渡动画等样式"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Title text element with font styles, color changes, text decoration, transition effects and other styles",
+          "descriptionZh": "标题文字元素，包含字体样式、颜色变化、文本装饰、过渡效果等样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element with width, height, background color, position changes, transition animations and other styles",
+          "descriptionZh": "指示器元素，包含宽度、高度、背景色、位置变化、过渡动画等样式"
         }
       ]
     },
@@ -2396,7 +2440,8 @@
           "descriptionZh": "对 `message`、`notification` 进行配置。。",
           "code": "<script setup lang=\"ts\">\nimport MyPage2 from './myPage2.vue'\n</script>\n\n<template>\n  <a-app :message=\"{ maxCount: 1 }\" :notification=\"{ placement: 'bottomLeft' }\">\n    <MyPage2 />\n  </a-app>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "AutoComplete",
@@ -2713,14 +2758,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of AutoComplete by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 AutoComplete 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst stylesObject = {\n  popup: {\n    root: {\n      borderWidth: '1px',\n      borderStyle: 'solid',\n      borderColor: '#1890ff',\n    },\n    list: {\n      backgroundColor: 'rgba(240, 240, 240, 0.85)',\n    },\n    listItem: {\n      color: '#272727',\n    },\n  },\n}\n\nfunction stylesFn({ props }: { props: { variant?: string } }) {\n  if (props.variant === 'filled') {\n    return {\n      popup: {\n        root: {\n          borderWidth: '1px',\n          borderStyle: 'solid',\n          borderColor: '#ccc',\n        },\n        list: {\n          backgroundColor: 'rgba(240, 240, 240, 0.85)',\n        },\n        listItem: {\n          color: '#272727',\n        },\n      },\n    }\n  }\n  return {}\n}\n\nconst options = [\n  { value: 'Burnaby' },\n  { value: 'Seattle' },\n  { value: 'Los Angeles' },\n  { value: 'San Francisco' },\n  { value: 'Meet student' },\n]\n\nconst sharedProps = {\n  options,\n  classes: {\n    root: 'auto-complete-style-root',\n  },\n  style: { width: '200px' },\n}\n\nconst value = ref('')\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-auto-complete v-model:value=\"value\" v-bind=\"sharedProps\" placeholder=\"object styles\" :styles=\"stylesObject\" />\n    <a-auto-complete\n      v-model:value=\"value\"\n      v-bind=\"sharedProps\"\n      placeholder=\"function styles\"\n      :styles=\"stylesFn\"\n      variant=\"filled\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, cursor styles, transitions, border and other basic selector container styles",
+          "descriptionZh": "根元素，包含相对定位、行内 flex 布局、光标样式、过渡动画、边框等选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'placeholder', desc: t('placeholder') },\n  { name: 'content', desc: t('content') },\n  { name: 'clear', desc: t('clear') },\n  { name: 'popup.root', desc: t('popup.root') },\n  { name: 'popup.list', desc: t('popup.list') },\n  { name: 'popup.listItem', desc: t('popup.listItem') },\n])\n\nconst options = ref([\n  { value: 'aojunhao123', label: 'aojunhao123' },\n  { value: 'thinkasany', label: 'thinkasany' },\n  { value: 'meet-student', label: 'meet-student' },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"AutoComplete\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <a-auto-complete\n          prefix=\"prefix\"\n          :style=\"{ width: '200px' }\"\n          :options=\"options\"\n          placeholder=\"input here\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with layout and styling for prefix content",
+          "descriptionZh": "前缀元素，包含前缀内容的布局和样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with search input styling, cursor control, font inheritance and other search-related styles. Remove border styles",
+          "descriptionZh": "输入框元素，包含搜索输入框的样式、光标控制、字体继承等搜索相关样式，去除了边框样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "clear",
+          "description": "Clear button element with layout, styling and interactive effects for clear button",
+          "descriptionZh": "清除按钮元素，包含清除按钮的布局、样式和交互效果"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with popup layer positioning, z-index, background, border, box-shadow and other popup container styles",
+          "descriptionZh": "弹出菜单元素，包含弹出层的定位、层级、背景、边框、阴影等弹出容器样式"
+        },
+        {
+          "key": "popup.list",
+          "description": "Popup list element with option list layout, scrolling, max-height and other list container styles",
+          "descriptionZh": "弹出菜单列表元素，包含选项列表的布局、滚动、最大高度等列表容器样式"
+        },
+        {
+          "key": "popup.listItem",
+          "description": "Popup item element with option item padding, hover effects, selected states, disabled states and other option interactive styles",
+          "descriptionZh": "弹出菜单条目元素，包含选项项的内边距、悬浮效果、选中状态、禁用状态等选项交互样式"
         }
       ]
     },
@@ -3009,7 +3093,8 @@
           "descriptionZh": "头像大小可以根据屏幕大小自动调整。",
           "code": "<script setup lang=\"ts\">\nimport { AntDesignOutlined } from '@antdv-next/icons'\n</script>\n\n<template>\n  <a-avatar\n    :size=\"{ xs: 24, sm: 32, md: 40, lg: 64, xl: 80, xxl: 100 }\"\n  >\n    <template #icon>\n      <AntDesignOutlined />\n    </template>\n  </a-avatar>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Badge",
@@ -3279,22 +3364,33 @@
           "description": "The badge will display `title` when hovered over, instead of `count`.",
           "descriptionZh": "设置鼠标放在状态点上时显示的文字。",
           "code": "<script setup lang=\"ts\">\n</script>\n\n<template>\n  <a-space size=\"large\">\n    <a-badge :count=\"5\" title=\"Custom hover text\">\n      <a-avatar shape=\"square\" size=\"large\" />\n    </a-badge>\n    <a-badge :count=\"-5\" title=\"Negative\">\n      <a-avatar shape=\"square\" size=\"large\" />\n    </a-badge>\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-block display, and fit-content width for basic layout",
+          "descriptionZh": "根元素，包含相对定位、行内块布局、适应内容宽度等基础布局样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Badge\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-badge :count=\"5\" :classes=\"classes\">\n        <a-avatar shape=\"square\" size=\"large\" />\n      </a-badge>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "indicator",
+          "description": "Indicator element with positioning, z-index, dimensions, colors, fonts, text alignment, background, border-radius, box-shadow, and transition animations for complete badge styling",
+          "descriptionZh": "指示器元素，包含定位、层级、尺寸、颜色、字体、文本对齐、背景、圆角、阴影、过渡动画等完整的徽标样式"
         },
         {
-          "name": "_semantic_ribbon",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('ribbonRoot'), version: '1.0.0' },\n  { name: 'indicator', desc: t('ribbonIndicator'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <div style=\"display: flex; flex-direction: column; gap: 24px;\">\n    <SemanticPreview\n      component-name=\"Badge\"\n      :semantics=\"semantics\"\n    >\n      <template #default=\"{ classes }\">\n        <div style=\"width: 100%;\">\n          <a-badge-ribbon text=\"Hippies\" color=\"magenta\" :classes=\"classes\">\n            <a-card title=\"Pushes open the window\" size=\"small\">\n              and raises the spyglass.\n            </a-card>\n          </a-badge-ribbon>\n        </div>\n      </template>\n    </SemanticPreview>\n  </div>\n</template>"
+          "key": "ribbonRoot",
+          "description": "Root element, set relative positioning and wrapper container styles",
+          "descriptionZh": "根元素，设置相对定位和包装容器样式"
+        },
+        {
+          "key": "ribbonIndicator",
+          "description": "Indicator element, set absolute positioning, padding, background color, border radius and ribbon styles",
+          "descriptionZh": "指示器元素，设置绝对定位、内边距、背景色、圆角和缎带样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element, set text color and ribbon content display styles",
+          "descriptionZh": "文本元素，设置文本颜色和缎带内容显示样式"
         }
       ]
     },
@@ -3484,14 +3580,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Breadcrumb by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Breadcrumb 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { BreadcrumbProps } from 'antdv-next'\n\nconst classesObject = {\n  root: 'demo-breadcrumb-root',\n  item: 'demo-breadcrumb-item',\n  separator: 'demo-breadcrumb-separator',\n}\n\nconst stylesObject: BreadcrumbProps['styles'] = {\n  root: { border: '1px solid #f0f0f0', padding: '8px', borderRadius: '4px' },\n  item: { color: '#1890ff' },\n  separator: { color: 'rgba(0, 0, 0, 0.45)' },\n}\n\nconst stylesFn: BreadcrumbProps['styles'] = (info) => {\n  const items = info.props.items || []\n  if (items.length > 2) {\n    return {\n      root: { border: '1px solid #F5EFFF', padding: '8px', borderRadius: '4px' },\n      item: { color: '#8F87F1' },\n    }\n  }\n  return {}\n}\n\nconst items = [\n  { title: 'Antdv Next' },\n  { title: 'Component' },\n  { title: 'Breadcrumb' },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-breadcrumb\n      :classes=\"classesObject\"\n      :items=\"items.slice(0, 2)\"\n      :styles=\"stylesObject\"\n      aria-label=\"Breadcrumb with Object\"\n    />\n    <a-breadcrumb\n      :classes=\"classesObject\"\n      :items=\"items\"\n      :styles=\"stylesFn\"\n      aria-label=\"Breadcrumb with Function\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with text color, font size, icon size and other basic styles, using flex layout with ordered list",
+          "descriptionZh": "根元素，包含文字颜色、字体大小、图标尺寸等基础样式，内部使用 flex 布局的有序列表"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { HomeOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'separator', desc: t('separator'), version: '1.0.0' },\n])\n\nconst items = [\n  { href: '', title: h(HomeOutlined) },\n  { href: '', title: [h(UserOutlined), h('span', 'Application List')] },\n  { title: 'Application' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Breadcrumb\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-breadcrumb :items=\"items\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with text color, link color transitions, hover effects, padding, border-radius, height, and margin styles",
+          "descriptionZh": "Item 元素，包含文字颜色、链接的颜色变化、悬浮效果、内边距、圆角、高度、外边距等样式"
+        },
+        {
+          "key": "separator",
+          "description": "Separator element with margin and color styles for the divider",
+          "descriptionZh": "分隔符元素，包含分隔符的外边距和颜色样式"
         }
       ]
     },
@@ -4005,20 +4110,29 @@
           "code": "<script setup lang=\"ts\">\nimport type { ButtonProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: ButtonProps['classes'] = {\n  root: 'demo-button-root',\n  content: 'demo-button-content',\n}\n\nconst stylesObject: ButtonProps['styles'] = {\n  root: {\n    boxShadow: '0 1px 2px 0 rgba(0,0,0,0.05)',\n  },\n}\n\nconst stylesFn: ButtonProps['styles'] = (info) => {\n  if (info?.props?.type === 'primary') {\n    return {\n      root: {\n        backgroundColor: '#171717',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"small\">\n    <a-button type=\"default\" :classes=\"classes\" :styles=\"stylesObject\">\n      Object\n    </a-button>\n    <a-button type=\"primary\" :classes=\"classes\" :styles=\"stylesFn\">\n      Function\n    </a-button>\n  </a-flex>\n</template>"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AntDesignOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Button\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-button type=\"primary\" :classes=\"classes\">\n        <template #icon>\n          <AntDesignOutlined />\n        </template>\n        Antdv Next\n      </a-button>\n    </template>\n  </SemanticPreview>\n</template>"
-        },
-        {
           "name": "chinese-space",
           "title": "",
           "titleZh": "移除两个汉字之间的空格",
           "description": "We add a space between two Chinese characters by default, which can be removed by setting `autoInsertSpace` to `false`.",
           "descriptionZh": "我们默认在两个汉字之间添加空格，可以通过设置 `autoInsertSpace` 为 `false` 关闭。",
           "code": "<template>\n  <a-flex gap=\"small\" wrap>\n    <a-button type=\"primary\" :auto-insert-space=\"false\">\n      确定\n    </a-button>\n    <a-button type=\"primary\" auto-insert-space>\n      确定\n    </a-button>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with comprehensive button styling including border, background, padding, border-radius, box-shadow, transitions, cursor, font-weight, alignment, and layout properties",
+          "descriptionZh": "根元素，包含边框样式、背景色、内边距、圆角、阴影效果、过渡动画、光标样式、文字权重、对齐方式等完整的按钮外观样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element that wraps button text with typography styles including nowrap, text-align center, and Chinese character spacing optimization",
+          "descriptionZh": "内容元素，包装按钮文本内容，控制文本的不换行显示、居中对齐、中文字符间距优化等文本排版样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with font-size, color inheritance, and SVG style reset for proper icon display",
+          "descriptionZh": "图标元素，包含图标的字体大小、颜色继承、SVG 样式重置等图标显示相关样式"
         }
       ]
     },
@@ -4306,14 +4420,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Calendar by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Calendar 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CalendarProps } from 'antdv-next'\nimport type { Dayjs } from 'dayjs'\n\nconst classes = {\n  root: 'custom-calendar-root',\n}\n\nconst stylesObject: CalendarProps<Dayjs>['styles'] = {\n  root: {\n    borderRadius: '8px',\n    width: '600px',\n  },\n}\n\nconst stylesFunction: CalendarProps<Dayjs>['styles'] = (info) => {\n  if (info.props.fullscreen) {\n    return {\n      root: {\n        border: '2px solid #BDE3C3',\n        borderRadius: '10px',\n        backgroundColor: 'rgba(189,227,195, 0.3)',\n      },\n    } satisfies CalendarProps<Dayjs>['styles']\n  }\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-calendar :fullscreen=\"false\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-calendar :classes=\"classes\" :styles=\"stylesFunction\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element containing background, border, border-radius and overall layout structure of the calendar component",
+          "descriptionZh": "根元素，包含日历组件的背景色、边框、圆角等基础样式和整体布局结构"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Calendar\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-calendar :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with layout and style control for year selector, month selector and mode switcher",
+          "descriptionZh": "头部元素，包含年份选择器、月份选择器、模式切换器的布局和样式控制"
+        },
+        {
+          "key": "body",
+          "description": "Body element with padding and layout control for the calendar table that contains the calendar grid",
+          "descriptionZh": "主体元素，包含日历表格的内边距、布局控制等样式，用于容纳日历网格"
+        },
+        {
+          "key": "content",
+          "description": "Content element with width, height and table styling control for the calendar table",
+          "descriptionZh": "内容元素，包含日历表格的宽度、高度等尺寸控制和表格样式"
+        },
+        {
+          "key": "item",
+          "description": "Item element with background, border, hover state, selected state and other interactive styles for calendar cells",
+          "descriptionZh": "条目元素，包含日历单元格的背景色、边框、悬停态、选中态等交互样式"
         }
       ]
     },
@@ -4791,14 +4924,43 @@
           "description": "",
           "descriptionZh": "",
           "code": "<script setup lang=\"ts\">\nconst cover = 'https://api.dicebear.com/7.x/miniavs/svg?seed=8'\n</script>\n\n<template>\n  <a-card style=\"width: 300px\">\n    <template #cover>\n      <img alt=\"example\" :src=\"cover\">\n    </template>\n    <template #actions>\n      <span key=\"setting\">setting</span>\n      <span key=\"edit\">edit</span>\n    </template>\n  </a-card>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Card root element with positioning, background, border, border-radius, box-shadow, padding and other container styles",
+          "descriptionZh": "卡片根元素，包含位置定位、背景色、边框、圆角、阴影、内边距等卡片容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, EllipsisOutlined, SettingOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'cover', desc: t('cover'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Card\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ position: 'absolute' }\">\n        <a-card\n          title=\"Card title\"\n          extra=\"More\"\n          :style=\"{ width: '300px' }\"\n          :classes=\"classes\"\n        >\n          <template #cover>\n            <img\n              draggable=\"false\"\n              alt=\"example\"\n              src=\"https://gw.alipayobjects.com/zos/rmsportal/JiqGstEfoWAOHiTxclqi.png\"\n            >\n          </template>\n          <template #actions>\n            <SettingOutlined key=\"setting\" />\n            <EditOutlined key=\"edit\" />\n            <EllipsisOutlined key=\"ellipsis\" />\n          </template>\n          <a-card-meta\n            title=\"Card Meta title\"\n            description=\"This is the description\"\n          >\n            <template #avatar>\n              <a-avatar src=\"https://api.dicebear.com/7.x/miniavs/svg?seed=8\" />\n            </template>\n          </a-card-meta>\n        </a-card>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Card header area with flex layout, min-height, padding, text color, font-weight, font-size, background, bottom border and top border-radius",
+          "descriptionZh": "卡片头部区域，包含 flex 布局、最小高度、内边距、文字颜色、字体权重、字体大小、背景色、下边框、顶部圆角等样式"
+        },
+        {
+          "key": "body",
+          "description": "Card content area with padding, font-size and other content display styles",
+          "descriptionZh": "卡片内容区域，包含内边距、字体大小等内容展示的基础样式"
+        },
+        {
+          "key": "extra",
+          "description": "Card extra operation area in top-right corner with text color and layout styles for additional content",
+          "descriptionZh": "卡片右上角的操作区域，包含额外内容的文字颜色和布局样式"
+        },
+        {
+          "key": "title",
+          "description": "Card title with inline-block display, flex-grow, text ellipsis and other title display styles",
+          "descriptionZh": "卡片标题，包含行内块布局、flex 占比、文本省略等标题显示样式"
+        },
+        {
+          "key": "actions",
+          "description": "Card bottom action group with flex layout, list-style reset, background, top border and bottom border-radius for action buttons container",
+          "descriptionZh": "卡片底部操作组，包含 flex 布局、列表样式重置、背景色、上边框、底部圆角等操作按钮容器样式"
+        },
+        {
+          "key": "cover",
+          "description": "Title cover with styles for cover image display and layout",
+          "descriptionZh": "标题封面，包含封面图片的显示和布局样式"
         }
       ]
     },
@@ -5064,7 +5226,8 @@
           "descriptionZh": "展示指示点的进度。",
           "code": "<template>\n  <a-carousel :autoplay=\"{ dotDuration: true }\" :autoplay-speed=\"5000\">\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        1\n      </h3>\n    </div>\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        2\n      </h3>\n    </div>\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        3\n      </h3>\n    </div>\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        4\n      </h3>\n    </div>\n  </a-carousel>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Cascader",
@@ -5456,14 +5619,6 @@
           "code": "<script setup lang=\"ts\">\nimport type { CascaderEmits } from 'antdv-next'\nimport { ref } from 'vue'\n\ninterface Option {\n  value: string | number\n  label: string\n  children?: Option[]\n}\n\nconst options: Option[] = [\n  {\n    value: 'zhejiang',\n    label: 'Zhejiang',\n    children: [\n      {\n        value: 'hangzhou',\n        label: 'Hangzhou',\n        children: [\n          {\n            value: 'xihu',\n            label: 'West Lake',\n          },\n        ],\n      },\n    ],\n  },\n  {\n    value: 'jiangsu',\n    label: 'Jiangsu',\n    children: [\n      {\n        value: 'nanjing',\n        label: 'Nanjing',\n        children: [\n          {\n            value: 'zhonghuamen',\n            label: 'Zhong Hua Men',\n          },\n        ],\n      },\n    ],\n  },\n]\n\nconst disabled = ref(false)\n\nconst onChange: CascaderEmits['change'] = (value) => {\n  console.log(value)\n}\n\nconst onMultipleChange: CascaderEmits['change'] = (value) => {\n  console.log(value)\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"small\" align=\"flex-start\">\n    <a-switch\n      v-model:checked=\"disabled\"\n      checked-children=\"Enabled\"\n      un-checked-children=\"Disabled\"\n      aria-label=\"disabled switch\"\n    />\n    <a-cascader-panel :options=\"options\" :disabled=\"disabled\" @change=\"onChange\" />\n    <a-cascader-panel multiple :options=\"options\" :disabled=\"disabled\" @change=\"onMultipleChange\" />\n    <a-cascader-panel />\n  </a-flex>\n</template>"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst mode = ref<'single' | 'multiple'>('single')\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => {\n  const base = [\n    { name: 'root', desc: t('root') },\n    { name: 'prefix', desc: t('prefix') },\n    { name: 'content', desc: t('content') },\n    { name: 'placeholder', desc: t('placeholder') },\n    { name: 'clear', desc: t('clear') },\n    { name: 'input', desc: t('input') },\n    { name: 'suffix', desc: t('suffix') },\n    { name: 'popup.root', desc: t('popup.root') },\n    { name: 'popup.list', desc: t('popup.list') },\n    { name: 'popup.listItem', desc: t('popup.listItem') },\n  ]\n\n  if (mode.value === 'multiple') {\n    return [\n      ...base,\n      { name: 'item', desc: t('item') },\n      { name: 'itemContent', desc: t('itemContent') },\n      { name: 'itemRemove', desc: t('itemRemove') },\n    ]\n  }\n\n  return base\n})\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst options = [\n  {\n    value: 'contributors',\n    label: 'contributors',\n    children: [\n      { value: 'aojunhao123', label: 'aojunhao123' },\n      { value: 'thinkasany', label: 'thinkasany' },\n      { value: 'meet-student', label: 'meet-student' },\n    ],\n  },\n]\n\nconst value = computed(() => {\n  if (mode.value !== 'multiple')\n    return ['contributors', 'thinkasany']\n\n  return [['contributors', 'aojunhao123']]\n})\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Cascader\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <div :style=\"{ display: 'flex', justifyContent: 'center', marginBottom: '12px' }\">\n          <a-segmented v-model:value=\"mode\" :options=\"['single', 'multiple']\" />\n        </div>\n        <div :style=\"{ display: 'flex', flexDirection: 'column', gap: '12px' }\">\n          <a-cascader\n            prefix=\"prefix\"\n            :style=\"{ width: '300px' }\"\n            :options=\"options\"\n            :value=\"value\"\n            :multiple=\"mode === 'multiple'\"\n            open\n            :get-popup-container=\"() => divRef!\"\n            :classes=\"classes\"\n          />\n        </div>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
-        },
-        {
           "name": "basic",
           "title": "",
           "titleZh": "基本",
@@ -5510,6 +5665,73 @@
           "description": "Allows the selection of only parent options.",
           "descriptionZh": "这种交互允许只选中父级选项。",
           "code": "<script setup lang=\"ts\">\nimport type { CascaderEmits } from 'antdv-next'\nimport { shallowRef } from 'vue'\n\ninterface Option {\n  value: string\n  label: string\n  children?: Option[]\n}\n\nconst options: Option[] = [\n  {\n    value: 'zhejiang',\n    label: 'Zhejiang',\n    children: [\n      {\n        value: 'hangzhou',\n        label: 'Hanzhou',\n        children: [\n          {\n            value: 'xihu',\n            label: 'West Lake',\n          },\n        ],\n      },\n    ],\n  },\n  {\n    value: 'jiangsu',\n    label: 'Jiangsu',\n    children: [\n      {\n        value: 'nanjing',\n        label: 'Nanjing',\n        children: [\n          {\n            value: 'zhonghuamen',\n            label: 'Zhong Hua Men',\n          },\n        ],\n      },\n    ],\n  },\n]\n\nconst onChange: CascaderEmits['change'] = (value) => {\n  console.log(value)\n}\nconst value = shallowRef()\n</script>\n\n<template>\n  <a-cascader v-model:value=\"value\" :options=\"options\" change-on-select @change=\"onChange\" />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, cursor styles, transitions, border and other basic selector container styles",
+          "descriptionZh": "根元素，包含相对定位、行内 flex 布局、光标样式、过渡动画、边框等选择器容器的基础样式"
+        },
+        {
+          "key": "prefix",
+          "description": "Prefix element with layout and styling for prefix content",
+          "descriptionZh": "前缀元素，包含前缀内容的布局和样式"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "clear",
+          "description": "Clear button element with layout, styling and interactive effects for clear button式",
+          "descriptionZh": "清除按钮元素，包含清除按钮的布局、样式和交互效果"
+        },
+        {
+          "key": "item",
+          "description": "Multiple selection item element with border, background, padding, and margin styles",
+          "descriptionZh": "多选项元素，包含边框、背景、内边距、外边距样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Multiple selection item content area with text ellipsis styles",
+          "descriptionZh": "多选项内容区域，包含文字的省略样式"
+        },
+        {
+          "key": "itemRemove",
+          "description": "Multiple selection item remove button with font-related styles式",
+          "descriptionZh": "多选项移除按钮，包含字体相关样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with search input styling, cursor control, font inheritance and other search-related styles. Remove border styles",
+          "descriptionZh": "输入框元素，包含搜索输入框的样式、光标控制、字体继承等搜索相关样式，去除了边框样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with layout and styling for suffix content like clear button, arrow icon, etc.",
+          "descriptionZh": "后缀元素，包含后缀内容的布局和样式，如清除按钮、箭头图标等"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with popup layer positioning, z-index, background, border, box-shadow and other popup container styles",
+          "descriptionZh": "弹出菜单元素，包含弹出层的定位、层级、背景、边框、阴影等弹出容器样式"
+        },
+        {
+          "key": "popup.list",
+          "description": "Popup list element with option list layout, scrolling, max-height and other list container styles",
+          "descriptionZh": "弹出菜单列表元素，包含选项列表的布局、滚动、最大高度等列表容器样式"
+        },
+        {
+          "key": "popup.listItem",
+          "description": "Popup item element with option item padding, hover effects, selected states, disabled states and other option interactive styles",
+          "descriptionZh": "弹出菜单条目元素，包含选项项的内边距、悬浮效果、选中状态、禁用状态等选项交互样式式"
         }
       ]
     },
@@ -5738,14 +5960,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Checkbox by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Checkbox 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CheckboxProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\nimport { ref } from 'vue'\n\nconst checked = ref(true)\nconst { token } = theme.useToken()\n\n// Object styles — 静态样式对象\nconst stylesObject: CheckboxProps['styles'] = {\n  icon: {\n    borderRadius: '6px',\n  },\n  label: {\n    color: 'blue',\n  },\n}\n\n// Function classes — 根据 checked 状态动态返回类名\nconst classesFn: CheckboxProps['classes'] = (info) => {\n  const base: Record<string, string> = {\n    root: 'checkbox-demo-root',\n    icon: 'checkbox-demo-icon',\n    label: 'checkbox-demo-label',\n  }\n  if (info.props.checked) {\n    return {\n      root: base.root,\n      icon: `${base.icon} checkbox-demo-icon-checked`,\n      label: `${base.label} checkbox-demo-label-checked`,\n    }\n  }\n  return base\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-checkbox :styles=\"stylesObject\">\n      Object styles\n    </a-checkbox>\n    <a-checkbox\n      v-model:checked=\"checked\"\n      :classes=\"classesFn\"\n    >\n      Function classes\n    </a-checkbox>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with inline-flex layout, baseline alignment, cursor style, reset styles and other basic checkbox container styles",
+          "descriptionZh": "根元素，包含行内 flex 布局、基线对齐、光标样式、重置样式等复选框容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Checkbox\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-checkbox :classes=\"classes\">\n        Checkbox\n      </a-checkbox>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Checkbox icon element with size, direction, background, border, border-radius, transitions, and checked state checkmark styles",
+          "descriptionZh": "选中框元素，包含尺寸、方向、背景色、边框、圆角、过渡动画，以及选中状态的勾选标记样式"
+        },
+        {
+          "key": "label",
+          "description": "Label text element with padding and spacing styles relative to the checkbox",
+          "descriptionZh": "文本元素，包含文本的内边距和与复选框的间距样式"
         }
       ]
     },
@@ -6093,14 +6324,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Collapse by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Collapse 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CollapseProps } from 'antdv-next'\nimport { h } from 'vue'\n\nconst text\n  = 'A dog is a type of domesticated animal. Known for its loyalty and faithfulness, it can be found as a welcome guest in many households across the world.'\n\nconst element = h('p', text)\n\nconst items = [\n  {\n    key: '1',\n    label: 'This is panel header 1',\n    content: element,\n  },\n  {\n    key: '2',\n    label: 'This is panel header 2',\n    content: element,\n  },\n  {\n    key: '3',\n    label: 'This is panel header 3',\n    content: element,\n  },\n]\n\nconst classes: CollapseProps['classes'] = {\n  root: 'demo-collapse-root',\n}\n\nconst stylesObject: CollapseProps['styles'] = {\n  root: {\n    backgroundColor: '#fafafa',\n    border: '1px solid #e0e0e0',\n    borderRadius: '8px',\n  },\n  header: {\n    backgroundColor: '#f0f0f0',\n    padding: '12px 16px',\n    color: '#141414',\n  },\n}\n\nconst stylesFn: CollapseProps['styles'] = (info) => {\n  if (info?.props?.size === 'large') {\n    return {\n      root: {\n        backgroundColor: '#fff',\n        border: '1px solid #696FC7',\n        borderRadius: '8px',\n      },\n      header: {\n        backgroundColor: '#F5EFFF',\n        padding: '12px 16px',\n        color: '#141414',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-collapse :items=\"items\" :classes=\"classes\" :styles=\"stylesObject\" :default-active-key=\"['1']\" />\n    <a-collapse :items=\"items\" :classes=\"classes\" :styles=\"stylesFn\" size=\"large\" :default-active-key=\"['2']\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with border, border-radius, background color and container styles that control the overall layout and appearance of collapse panels",
+          "descriptionZh": "根元素，包含折叠面板的边框、圆角、背景色等容器样式，控制面板的整体布局和外观"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { theme } from 'antdv-next'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n])\n\nconst { token } = theme.useToken()\n\nconst items = computed(() => [\n  {\n    key: '1',\n    label: 'This is panel header',\n    children: 'This is panel body',\n  },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Collapse\"\n    items-a-p-i=\"items\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ position: 'absolute', inset: 0, margin: `${token.marginXL}px` }\">\n        <a-collapse\n          :items=\"items\"\n          :default-active-key=\"['1']\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with flex layout, padding, color, line-height, cursor style, transition animations and other interactive styles for panel headers",
+          "descriptionZh": "头部元素，包含flex布局、内边距、颜色、行高、光标样式、过渡动画等面板头部的交互和样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with flex auto layout and margin styles for title text layout and typography",
+          "descriptionZh": "标题元素，包含flex自适应布局、右边距等标题文字的布局和排版样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with padding, color, background color and other styles for panel content area display",
+          "descriptionZh": "内容元素，包含内边距、颜色、背景色等面板内容区域的展示样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with font size, transition animations, rotation transforms and other styles and animations for expand/collapse arrows",
+          "descriptionZh": "图标元素，包含字体大小、过渡动画、旋转变换等展开收起箭头的样式和动效"
         }
       ]
     },
@@ -6448,14 +6698,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of ColorPicker by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或函数可以自定义 ColorPicker 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst classes = { root: 'custom-color-picker' }\n\nconst color = shallowRef('#1677ff')\nconst colorLarge = shallowRef('#722ed1')\n\nconst stylesObject = {\n  popup: {\n    root: {\n      border: '1px solid #fff',\n    },\n  },\n}\n\nfunction stylesFn(info: any) {\n  if (info?.props?.size === 'large') {\n    return {\n      popup: {\n        root: {\n          border: '1px solid #722ed1',\n        },\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-space size=\"middle\" wrap>\n    <a-color-picker\n      v-model:value=\"color\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    />\n    <a-color-picker\n      v-model:value=\"colorLarge\"\n      size=\"large\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n    />\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Trigger container with border styles, transition animations, size controls, displaying color block and text content",
+          "descriptionZh": "触发器容器，包含边框样式、过渡动画、尺寸控制等样式，显示颜色块和文本内容"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'body', desc: t('body') },\n  { name: 'content', desc: t('content') },\n  { name: 'description', desc: t('description') },\n  { name: 'popup.root', desc: t('popup.root') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\nconst body = document?.body\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"ColorPicker\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" :style=\"{ height: '300px' }\" align=\"flex-start\" gap=\"small\">\n        <a-color-picker\n          default-value=\"#1677ff\"\n          open\n          show-text\n          :get-popup-container=\"() => divRef || body\"\n          :styles=\"{ popup: { root: { zIndex: 1 } } }\"\n          :classes=\"classes\"\n        />\n        <a-color-picker :open=\"false\" allow-clear :classes=\"classes\" />\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "popup.root",
+          "description": "Popup panel root container with background color, shadow effects, color selection panel, slider controls and preset colors",
+          "descriptionZh": "弹出面板根容器，包含背景色、阴影效果、色彩选择面板、滑块控制和预设颜色等样式"
+        },
+        {
+          "key": "body",
+          "description": "Color block container with background color, border styles",
+          "descriptionZh": "色块容器，包含底色、边框等样式"
+        },
+        {
+          "key": "content",
+          "description": "Color block element with actual selected color styles",
+          "descriptionZh": "色块颜色元素，包含实际选择的颜色样式"
+        },
+        {
+          "key": "description",
+          "description": "Description text content with font styles and color",
+          "descriptionZh": "描述文本内容，包含字体样式、颜色等样式"
         }
       ]
     },
@@ -6669,7 +6938,8 @@
           "descriptionZh": "获取父级 `Provider` 的值。如 `DisabledContextProvider`、`SizeContextProvider`。",
           "code": "<script setup lang=\"ts\">\nimport type { ConfigProviderProps } from 'antdv-next'\nimport { ref } from 'vue'\nimport ConfigDisplay from './use-config-display.vue'\n\ntype SizeType = ConfigProviderProps['componentSize']\n\nconst componentSize = ref<SizeType>('small')\nconst disabled = ref(true)\n</script>\n\n<template>\n  <div>\n    <a-space>\n      <a-radio-group v-model:value=\"componentSize\">\n        <a-radio-button value=\"small\">\n          Small\n        </a-radio-button>\n        <a-radio-button value=\"middle\">\n          Middle\n        </a-radio-button>\n        <a-radio-button value=\"large\">\n          Large\n        </a-radio-button>\n      </a-radio-group>\n      <a-checkbox v-model:checked=\"disabled\">\n        Form disabled\n      </a-checkbox>\n    </a-space>\n    <a-divider />\n    <a-config-provider :component-size=\"componentSize\">\n      <div class=\"example\">\n        <a-form :disabled=\"disabled\">\n          <ConfigDisplay />\n        </a-form>\n      </div>\n    </a-config-provider>\n  </div>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "DatePicker",
@@ -7296,14 +7566,63 @@
           "description": "Custom `prefix` and `suffixIcon`.",
           "descriptionZh": "自定义前缀 `prefix` 和后缀图标 `suffixIcon`。",
           "code": "<script setup lang=\"ts\">\nimport type { Dayjs } from 'dayjs'\nimport { SmileOutlined } from '@antdv-next/icons'\nimport { h } from 'vue'\n\nconst smileIcon = h(SmileOutlined)\n\nfunction handleChange(date: Dayjs | (Dayjs | null)[] | null, dateString: string | string[] | null) {\n  console.log(date, dateString)\n}\n</script>\n\n<template>\n  <a-space vertical :size=\"12\">\n    <a-date-picker :suffix-icon=\"smileIcon\" @change=\"handleChange\" />\n    <a-date-picker :suffix-icon=\"smileIcon\" picker=\"month\" @change=\"handleChange\" />\n    <a-range-picker :suffix-icon=\"smileIcon\" @change=\"handleChange\" />\n    <a-date-picker :suffix-icon=\"smileIcon\" picker=\"week\" @change=\"handleChange\" />\n    <a-date-picker suffix-icon=\"ab\" @change=\"handleChange\" />\n    <a-date-picker suffix-icon=\"ab\" picker=\"month\" @change=\"handleChange\" />\n    <a-range-picker suffix-icon=\"ab\" @change=\"handleChange\" />\n    <a-date-picker suffix-icon=\"ab\" picker=\"week\" @change=\"handleChange\" />\n    <a-date-picker :prefix=\"smileIcon\" picker=\"week\" @change=\"handleChange\" />\n    <a-date-picker prefix=\"Event Period\" picker=\"week\" @change=\"handleChange\" />\n    <a-range-picker :prefix=\"smileIcon\" picker=\"week\" @change=\"handleChange\" />\n    <a-range-picker prefix=\"Event Period\" picker=\"week\" @change=\"handleChange\" />\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, padding, border-radius, transition animations and other basic styles for date picker container",
+          "descriptionZh": "根元素，包含相对定位、行内flex布局、内边距、边框圆角、过渡动画等日期选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { SmileOutlined } from '@antdv-next/icons'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'popup.root', desc: t('popup') },\n  { name: 'popup.container', desc: t('popup.container') },\n  { name: 'popup.header', desc: t('popup.header') },\n  { name: 'popup.body', desc: t('popup.body') },\n  { name: 'popup.content', desc: t('popup.content') },\n  { name: 'popup.item', desc: t('popup.item') },\n  { name: 'popup.footer', desc: t('popup.footer') },\n])\n\nconst type = ref<'Single' | 'Multiple'>('Single')\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    :component-name=\"type === 'Single' ? 'DatePicker' : 'DatePicker.RangePicker'\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" vertical :style=\"{ alignSelf: 'flex-start' }\" gap=\"middle\" align=\"center\">\n        <a-segmented\n          :options=\"['Single', 'Multiple']\"\n          :value=\"type\"\n          @change=\"(val: 'Single' | 'Multiple') => type = val\"\n        />\n        <a-date-picker\n          v-if=\"type === 'Single'\"\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-date-picker>\n        <a-range-picker\n          v-else\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-range-picker>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with flex layout and margin styles for prefix content layout",
+          "descriptionZh": "前缀元素，包含flex布局、右外边距等前缀内容的布局样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with relative positioning, width, color, font, line-height, transition animations and other core interactive styles for input field",
+          "descriptionZh": "输入框元素，包含相对定位、宽度、颜色、字体、行高、过渡动画等输入框的核心交互样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with flex layout, color, line-height, pointer events, transition animations and other styles for suffix content",
+          "descriptionZh": "后缀元素，包含flex布局、颜色、行高、指针事件、过渡动画等后缀内容的样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup element",
+          "descriptionZh": "弹出框元素"
+        },
+        {
+          "key": "popup.container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "popup.header",
+          "description": "Popup header element with navigation buttons, month/year selectors and other header control area layout and styles",
+          "descriptionZh": "弹出框头部元素，包含导航按钮、月份年份选择器等头部控制区域的布局和样式"
+        },
+        {
+          "key": "popup.body",
+          "description": "Popup body element with container layout and styles for date panel table",
+          "descriptionZh": "弹出框主体元素，包含日期面板表格的容器布局和样式"
+        },
+        {
+          "key": "popup.content",
+          "description": "Popup content element with width, border, cell and other content display styles for date table",
+          "descriptionZh": "弹出框内容元素，包含日期表格的宽度、边框、单元格等内容展示样式"
+        },
+        {
+          "key": "popup.item",
+          "description": "Popup item element with size, background, border-radius, hover state, selected state and other interactive styles for date cells",
+          "descriptionZh": "弹出框单项元素，包含日期单元格的尺寸、背景色、边框圆角、悬停态、选中态等交互样式"
+        },
+        {
+          "key": "popup.footer",
+          "description": "Popup footer element with layout styles for bottom operation area including confirm/cancel buttons and shortcuts",
+          "descriptionZh": "弹出框底部元素，包含确认取消按钮、快捷选择等底部操作区域的布局样式"
         }
       ]
     },
@@ -7557,14 +7876,38 @@
           "description": "Display of the entire line.",
           "descriptionZh": "整行的展示。",
           "code": "<script setup lang=\"ts\">\nimport type { DescriptionsItemType } from 'antdv-next'\n\nconst items: DescriptionsItemType[] = [\n  {\n    label: 'UserName',\n    content: 'Zhou Maomao',\n  },\n  {\n    label: 'Live',\n    span: 'filled', // span = 2\n    content: 'Hangzhou, Zhejiang',\n  },\n  {\n    label: 'Remark',\n    span: 'filled', // span = 3\n    content: 'empty',\n  },\n  {\n    label: 'Address',\n    span: 1, // span will be 3 and warning for span is not align to the end\n    content: 'No. 18, Wantang Road, Xihu District, Hangzhou, Zhejiang, China',\n  },\n]\n</script>\n\n<template>\n  <a-descriptions title=\"User Info\" :items=\"items\" bordered />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with basic styles, reset styles, border styles, layout direction and other overall styles for description list container",
+          "descriptionZh": "根元素，包含描述列表容器的基础样式、重置样式、边框样式、布局方向等整体样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n\nconst bordered = ref(false)\n\nconst items = [\n  { key: '1', label: 'Telephone', content: '1810000000' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Descriptions\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ width: '100%', height: '100%' }\">\n        <a-switch v-model:checked=\"bordered\" />\n        Toggle Border\n        <a-divider />\n        <a-descriptions\n          title=\"User Info\"\n          :items=\"items\"\n          :bordered=\"bordered\"\n          :classes=\"classes\"\n        >\n          <template #extra>\n            <a-button type=\"primary\">\n              Edit\n            </a-button>\n          </template>\n        </a-descriptions>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with flex layout, alignment, bottom margin and other layout and style controls for header area",
+          "descriptionZh": "头部元素，包含flex布局、对齐方式、下边距等头部区域的布局和样式控制"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text ellipsis, flex ratio, color, font weight, font size, line height and other title text styles",
+          "descriptionZh": "标题元素，包含文本省略、flex占比、颜色、字体权重、字体大小、行高等标题文字样式"
+        },
+        {
+          "key": "extra",
+          "description": "Extra content element with left margin, color, font size and other styles for additional operation area",
+          "descriptionZh": "额外内容元素，包含左边距、颜色、字体大小等额外操作区域的样式"
+        },
+        {
+          "key": "label",
+          "description": "Label element with color, font weight, font size, line height, text align, colon styles and other label text styles",
+          "descriptionZh": "标签元素，包含颜色、字体权重、字体大小、行高、文本对齐、冒号样式等标签文字的样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with table cell layout, color, font size, line height, word break and other content display styles",
+          "descriptionZh": "内容元素，包含表格单元格布局、颜色、字体大小、行高、文字换行等内容展示样式"
         }
       ]
     },
@@ -7733,14 +8076,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of divider by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义分割线的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { DividerProps } from 'antdv-next'\n\nconst classesObject: DividerProps['classes'] = {\n  root: 'demo-divider-root',\n  content: 'demo-divider-content',\n  rail: 'demo-divider-rail',\n}\n\nconst classesFn: DividerProps['classes'] = (info) => {\n  if (info?.props?.titlePlacement === 'start') {\n    return {\n      root: 'demo-divider-root--start',\n    }\n  }\n  return {\n    root: 'demo-divider-root--default',\n  }\n}\n\nconst stylesObject: DividerProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed' },\n  content: { fontStyle: 'italic' },\n  rail: { opacity: 0.85 },\n}\n\nconst stylesFn: DividerProps['styles'] = (info) => {\n  if (info?.props?.size === 'small') {\n    return {\n      root: { opacity: 0.6, cursor: 'default' },\n    }\n  }\n  return {\n    root: { backgroundColor: '#fafafa', borderColor: '#d9d9d9' },\n  }\n}\n</script>\n\n<template>\n  <div>\n    <a-divider :classes=\"classesObject\">\n      classes Object\n    </a-divider>\n    <a-divider title-placement=\"start\" :classes=\"classesFn\">\n      classes Function\n    </a-divider>\n    <a-divider :styles=\"stylesObject\">\n      styles Object\n    </a-divider>\n    <a-divider size=\"small\" :styles=\"stylesFn\">\n      styles Function\n    </a-divider>\n  </div>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with border-top style, divider styling and other basic divider container styles",
+          "descriptionZh": "根元素，包含边框顶部样式、分隔线样式等分割线容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'rail', desc: t('rail') },\n  { name: 'content', desc: t('content') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Divider\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div>\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider :classes=\"classes\" />\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider :classes=\"classes\">\n          Solid\n        </a-divider>\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider title-placement=\"left\" variant=\"dotted\" :classes=\"classes\">\n          Dotted\n        </a-divider>\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider title-placement=\"right\" variant=\"dashed\" :classes=\"classes\">\n          Dashed\n        </a-divider>\n        These\n        <a-divider orientation=\"vertical\" :classes=\"classes\" />\n        are\n        <a-divider orientation=\"vertical\" :classes=\"classes\" />\n        vertical\n        <a-divider orientation=\"vertical\" :classes=\"classes\" />\n        Dividers\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "content",
+          "description": "Content element with inline-block display, padding and other divider text content styles",
+          "descriptionZh": "内容元素，包含行内块显示、内边距等分割线文本内容的样式"
+        },
+        {
+          "key": "rail",
+          "description": "Background rail element with border-top style and other divider connection line styles",
+          "descriptionZh": "背景条元素，包含边框顶部样式等分割线连接条的样式"
         }
       ]
     },
@@ -8117,14 +8469,58 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Drawer by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Drawer 组件的 [语义化结构](#semantic-dom) 样式。",
           "code": "<script setup lang=\"ts\">\nimport type { DrawerProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\nimport { ref } from 'vue'\n\nconst { token } = theme.useToken()\nconst open = ref(false)\nconst openFn = ref(false)\n\nconst classes: DrawerProps['classes'] = {\n  header: 'demo-drawer-header',\n  body: 'demo-drawer-body',\n}\n\nconst stylesObject: DrawerProps['styles'] = {\n  body: {\n    backgroundColor: '#f5f5f5',\n  },\n  footer: {\n    backgroundColor: '#fafafa',\n  },\n}\n\nconst stylesFn: DrawerProps['styles'] = (info) => {\n  if (info?.props?.placement === 'right') {\n    return {\n      mask: {\n        backgroundColor: 'rgba(0, 0, 0, 0.2)',\n      },\n      wrapper: {\n        boxShadow: '0 8px 24px rgba(0, 0, 0, 0.15)',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-button @click=\"open = true\">\n      Object Style\n    </a-button>\n    <a-button type=\"primary\" @click=\"openFn = true\">\n      Function Style\n    </a-button>\n  </a-flex>\n\n  <a-drawer\n    v-model:open=\"open\"\n    title=\"Custom Style Drawer\"\n    :classes=\"classes\"\n    :styles=\"stylesObject\"\n    @close=\"open = false\"\n  >\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n  </a-drawer>\n\n  <a-drawer\n    v-model:open=\"openFn\"\n    title=\"Custom Function Drawer\"\n    :classes=\"classes\"\n    :styles=\"stylesFn\"\n    @close=\"openFn = false\"\n  >\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n  </a-drawer>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with fixed positioning, z-index control, pointer events, color and other basic styles and layout control for drawer container",
+          "descriptionZh": "根元素，包含固定定位、层级控制、指针事件、颜色等抽屉容器的基础样式和布局控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'mask', desc: t('mask'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n  { name: 'dragger', desc: t('dragger'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Drawer\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-drawer\n        title=\"Title\"\n        placement=\"right\"\n        open\n        :get-container=\"false\"\n        :size=\"300\"\n        :resizable=\"{}\"\n        :classes=\"classes\"\n      >\n        <template #footer>\n          <a-typography-link>Footer</a-typography-link>\n        </template>\n        <template #extra>\n          <a-button>Cancel</a-button>\n        </template>\n        <p>Some contents...</p>\n      </a-drawer>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "mask",
+          "description": "Mask element with absolute positioning, z-index, background color, pointer events and other mask layer styles and interaction controls",
+          "descriptionZh": "遮罩层元素，包含绝对定位、层级、背景色、指针事件等遮罩层的样式和交互控制"
+        },
+        {
+          "key": "section",
+          "description": "Drawer container element with flex layout, width/height, overflow control, background color, pointer events and other drawer body styles",
+          "descriptionZh": "Drawer 容器元素，包含flex布局、宽高、溢出控制、背景色、指针事件等抽屉主体的样式"
+        },
+        {
+          "key": "header",
+          "description": "Header element with flex layout, alignment, padding, font size, line height, bottom border and other header area styles",
+          "descriptionZh": "头部元素，包含flex布局、对齐方式、内边距、字体大小、行高、下边框等头部区域的样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with flex ratio, minimum size, padding, overflow scroll and other content area display and layout styles",
+          "descriptionZh": "内容元素，包含flex占比、最小尺寸、内边距、溢出滚动等内容区域的展示和布局样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with flex shrink, padding, top border and other bottom operation area styles",
+          "descriptionZh": "底部元素，包含flex收缩、内边距、上边框等底部操作区域的样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with flex ratio, margin, font weight, font size, line height and other title text styles",
+          "descriptionZh": "标题元素，包含flex占比、外边距、字体权重、字体大小、行高等标题文字的样式"
+        },
+        {
+          "key": "extra",
+          "description": "Extra element with flex fixed layout and other additional operation content style controls",
+          "descriptionZh": "额外元素，包含flex固定布局等额外操作内容的样式控制"
+        },
+        {
+          "key": "dragger",
+          "description": "Dragger element used to resize the drawer, with absolute positioning, transparent background, pointer events control, hover state styles, and dragging state styles",
+          "descriptionZh": "拖拽元素，用于调整抽屉大小的拖拽手柄，包含绝对定位、背景透明、指针事件控制、hover状态样式、拖拽状态样式等"
+        },
+        {
+          "key": "close",
+          "description": "Close button element with basic button styling",
+          "descriptionZh": "关闭按钮元素，包含按钮的基础样式"
         }
       ]
     },
@@ -8481,14 +8877,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of the Dropdown by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Dropdown 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { DropdownProps, MenuItemType } from 'antdv-next'\nimport { DownOutlined, LogoutOutlined, SettingOutlined } from '@antdv-next/icons'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst items: MenuItemType[] = [\n  {\n    key: '1',\n    label: 'Profile',\n  },\n  {\n    key: '2',\n    label: 'Settings',\n    icon: SettingOutlined,\n  },\n  {\n    type: 'divider',\n  },\n  {\n    key: '3',\n    label: 'Logout',\n    icon: LogoutOutlined,\n    danger: true,\n  },\n]\n\nconst classes: DropdownProps['classes'] = {\n  root: 'demo-dropdown-root',\n}\n\nconst objectStyles: DropdownProps['styles'] = {\n  root: {\n    backgroundColor: '#ffffff',\n    border: '1px solid #d9d9d9',\n    borderRadius: '4px',\n  },\n  item: {\n    padding: '8px 12px',\n    fontSize: '14px',\n  },\n  itemTitle: {\n    fontWeight: '500',\n  },\n  itemIcon: {\n    color: '#1890ff',\n    marginRight: '8px',\n  },\n  itemContent: {\n    backgroundColor: 'transparent',\n  },\n}\n\nconst functionStyles: DropdownProps['styles'] = (info) => {\n  const isClick = info.props.trigger?.includes('click')\n  if (isClick) {\n    return {\n      root: {\n        borderColor: '#1890ff',\n        borderRadius: '8px',\n      },\n    }\n  }\n  return {}\n}\n\nconst sharedProps: DropdownProps = {\n  menu: { items },\n  placement: 'bottomLeft',\n  classes,\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\" wrap=\"wrap\">\n    <a-space direction=\"vertical\" size=\"large\">\n      <a-dropdown v-bind=\"sharedProps\" :styles=\"objectStyles\">\n        <a-button>\n          <a-space>\n            Object Style\n            <DownOutlined />\n          </a-space>\n        </a-button>\n      </a-dropdown>\n\n      <a-dropdown v-bind=\"sharedProps\" :styles=\"functionStyles\" :trigger=\"['click']\">\n        <a-button type=\"primary\">\n          <a-space>\n            Function Style\n            <DownOutlined />\n          </a-space>\n        </a-button>\n      </a-dropdown>\n    </a-space>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element of dropdown, sets positioning, z-index and container styles",
+          "descriptionZh": "dropdown 的根元素，设置定位、层级和容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { DeleteOutlined, DownOutlined, EditOutlined, SaveOutlined } from '@antdv-next/icons'\nimport { computed, h, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'itemTitle', desc: t('itemTitle') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst items: any[] = [\n  {\n    key: '1',\n    type: 'group',\n    label: 'Group title',\n    children: [\n      { key: '1-1', label: '1st menu item', icon: h(SaveOutlined) },\n      { key: '1-2', label: '2nd menu item', icon: h(EditOutlined) },\n    ],\n  },\n  {\n    key: 'SubMenu',\n    label: 'SubMenu',\n    children: [\n      {\n        key: 'g1',\n        label: 'Item 1',\n        type: 'group',\n        children: [\n          { key: '1', label: 'Option 1' },\n          { key: '2', label: 'Option 2' },\n        ],\n      },\n    ],\n  },\n  { key: '3', type: 'divider' },\n  { key: '4', label: 'Delete', icon: h(DeleteOutlined), danger: true },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Dropdown\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ height: '120px', position: 'absolute', top: '50px' }\">\n        <a-dropdown\n          open\n          :menu=\"{ items }\"\n          :styles=\"{ root: { width: '200px', zIndex: 1 } }\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        >\n          <a @click.prevent>\n            <a-space>\n              Hover me\n              <DownOutlined />\n            </a-space>\n          </a>\n        </a-dropdown>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "itemTitle",
+          "description": "Title content area of dropdown option, sets layout and text styles",
+          "descriptionZh": "dropdown 选项的标题内容区域，设置布局和文字样式"
+        },
+        {
+          "key": "item",
+          "description": "Individual dropdown option element, sets interaction states and background styles",
+          "descriptionZh": "dropdown 的单个选项元素，设置选项的交互状态和背景样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Main content area of dropdown option, sets content layout and link styles",
+          "descriptionZh": "dropdown 选项的主要内容区域，设置内容布局和链接样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Icon area of dropdown option, sets icon size and spacing styles",
+          "descriptionZh": "dropdown 选项的图标区域，设置图标的尺寸和间距样式"
         }
       ]
     },
@@ -8598,14 +9013,28 @@
           "description": "Hide default description.",
           "descriptionZh": "隐藏默认描述。",
           "code": "<template>\n  <a-empty :description=\"false\" />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets text alignment, font and line height styles",
+          "descriptionZh": "根元素，设置文本对齐、字体和行高样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'image', desc: t('image'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Empty\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-empty\n        :image=\"1\"\n        :styles=\"{ image: { height: '60px' } }\"\n        :classes=\"classes\"\n      >\n        <template #description>\n          <a-typography-text>\n            Customize <a href=\"#API\">Description</a>\n          </a-typography-text>\n        </template>\n        <a-button type=\"primary\">\n          Create Now\n        </a-button>\n      </a-empty>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "image",
+          "description": "Image element, sets height, opacity, margin and image styles",
+          "descriptionZh": "图标元素，设置高度、透明度、边距和图片样式"
+        },
+        {
+          "key": "description",
+          "description": "Description element, sets text color styles",
+          "descriptionZh": "描述元素，设置文本颜色样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element, sets top margin and action button styles",
+          "descriptionZh": "底部元素，设置顶部边距和操作按钮样式"
         }
       ]
     },
@@ -8715,7 +9144,8 @@
           "descriptionZh": "嵌套使用，可以实现更复杂的布局。",
           "code": "<script setup lang=\"ts\">\nimport type { CSSProperties } from 'vue'\n\nconst cardStyle: CSSProperties = {\n  width: '620px',\n}\nconst imgStyle: CSSProperties = {\n  display: 'block',\n  width: '273px',\n}\n</script>\n\n<template>\n  <a-card :style=\"cardStyle\" :styles=\"{ body: { padding: 0, overflow: 'hidden' } }\">\n    <a-flex justify=\"space-between\">\n      <img\n        alt=\"avatar\"\n        src=\"https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png\"\n        :style=\"imgStyle\"\n      >\n      <a-flex vertical align=\"flex-end\" justify=\"space-between\" :style=\"{ padding: '32px' }\">\n        <a-typography>\n          <a-typography-title :level=\"3\">\n            “antd is an enterprise-class UI design language and Vue UI library.”\n          </a-typography-title>\n        </a-typography>\n        <a-button type=\"primary\" href=\"https://antdv.com\" target=\"_blank\">\n          Get Start\n        </a-button>\n      </a-flex>\n    </a-flex>\n  </a-card>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "FloatButton",
@@ -9124,22 +9554,63 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of FloatButton by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 FloatButton 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { FloatButtonProps } from 'antdv-next'\nimport { QuestionCircleOutlined } from '@antdv-next/icons'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: FloatButtonProps['classes'] = {\n  root: 'demo-float-button-root',\n  content: 'demo-float-button-content',\n}\n\nconst stylesObject: FloatButtonProps['styles'] = {\n  root: {\n    boxShadow: '0 1px 2px 0 rgba(0,0,0,0.05)',\n  },\n}\n\nconst stylesFn: FloatButtonProps['styles'] = (info) => {\n  if (info?.props?.type === 'primary') {\n    return {\n      root: {\n        backgroundColor: '#171717',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-float-button-group shape=\"circle\" style=\"inset-inline-end: 94px;\">\n    <a-float-button\n      type=\"primary\"\n      :classes=\"classes\"\n      href=\"https://ant.design/index-cn\"\n      :styles=\"stylesFn\"\n    >\n      <template #tooltip>\n        <div>custom style class</div>\n      </template>\n    </a-float-button>\n    <a-float-button\n      type=\"default\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n    >\n      <template #icon>\n        <QuestionCircleOutlined />\n      </template>\n    </a-float-button>\n  </a-float-button-group>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with float button base styles, shape size, type theme, fixed positioning, z-index, shadow, spacing and other container styles",
+          "descriptionZh": "根元素，设置悬浮按钮的基础样式、形状尺寸、类型主题、固定定位、层级、阴影、间距等容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { QuestionCircleOutlined } from '@antdv-next/icons'\nimport { FloatButton } from 'antdv-next'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst PurePanel = (FloatButton as any)._InternalPanelDoNotUseOrYouWillBeFired\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'icon', desc: t('icon') },\n  { name: 'content', desc: t('content') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"FloatButton\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <PurePanel\n        type=\"primary\"\n        shape=\"square\"\n        content=\"HELP\"\n        :classes=\"classes\"\n      >\n        <template #icon>\n          <QuestionCircleOutlined />\n        </template>\n      </PurePanel>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "content",
+          "description": "Content element with button text content font size, color, alignment, line wrap and other text display styles",
+          "descriptionZh": "内容元素，设置按钮内文字内容的字体大小、颜色、对齐、换行等文本显示样式"
         },
         {
-          "name": "_semantic_group",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AlertOutlined, BugOutlined, BulbOutlined } from '@antdv-next/icons'\nimport { FloatButton } from 'antdv-next'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst PurePanel = (FloatButton as any)._InternalPanelDoNotUseOrYouWillBeFired\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('group.root') },\n  { name: 'list', desc: t('group.list') },\n  { name: 'item', desc: t('group.item') },\n  { name: 'itemIcon', desc: t('group.itemIcon') },\n  { name: 'itemContent', desc: t('group.itemContent') },\n  { name: 'trigger', desc: t('group.trigger') },\n  { name: 'triggerIcon', desc: t('group.triggerIcon') },\n  { name: 'triggerContent', desc: t('group.triggerContent') },\n])\n\nconst items = [\n  {\n    icon: h(AlertOutlined),\n    content: 'warn',\n  },\n  {\n    icon: h(BugOutlined),\n    content: 'bug',\n  },\n  {\n    icon: h(BulbOutlined),\n    content: 'idea',\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"FloatButton\"\n    :semantics=\"semantics\"\n    :style=\"{ paddingTop: '100px' }\"\n  >\n    <template #default=\"{ classes }\">\n      <PurePanel\n        type=\"primary\"\n        shape=\"square\"\n        :items=\"items\"\n        trigger=\"hover\"\n        :open=\"true\"\n        content=\"back\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element with button icon size, color, line height, alignment and other icon display styles",
+          "descriptionZh": "图标元素，设置按钮内图标的尺寸、颜色、行高、对齐等图标显示样式"
+        },
+        {
+          "key": "group.root",
+          "description": "Root element with float button group container styles, fixed positioning, z-index, padding, gap, direction mode and other combined layout styles",
+          "descriptionZh": "根元素，设置悬浮按钮组的容器样式、固定定位、层级、内边距、间距、方向模式等组合布局样式"
+        },
+        {
+          "key": "group.list",
+          "description": "List element with button group list flex layout, border radius, shadow, animation transition, vertical alignment and other list container styles",
+          "descriptionZh": "列表元素，设置按钮组列表的Flex布局、圆角、阴影、动画过渡、垂直对齐等列表容器样式"
+        },
+        {
+          "key": "group.item",
+          "description": "Item element with individual float button styles, size, shape, type, state, icon content and other button base styles",
+          "descriptionZh": "列表项元素，设置单个悬浮按钮的样式、尺寸、形状、类型、状态、图标内容等按钮基础样式"
+        },
+        {
+          "key": "group.itemIcon",
+          "description": "Item icon element with float button icon size, color, alignment and other icon display styles",
+          "descriptionZh": "列表项图标元素，设置悬浮按钮内图标的尺寸、颜色、对齐等图标显示样式"
+        },
+        {
+          "key": "group.itemContent",
+          "description": "Item content element with float button text content, badge, description and other content area styles",
+          "descriptionZh": "列表项内容元素，设置悬浮按钮内文字内容、徽标、描述等内容区域样式"
+        },
+        {
+          "key": "group.trigger",
+          "description": "Trigger element with menu mode trigger button styles, shape, icon, hover state, expand/collapse state and other interaction styles",
+          "descriptionZh": "触发元素，设置菜单模式下触发按钮的样式、形状、图标、悬停态、展开收起状态等交互样式"
+        },
+        {
+          "key": "group.triggerIcon",
+          "description": "Trigger icon element with trigger button icon styles, rotation animation, toggle state and other icon interaction styles",
+          "descriptionZh": "触发图标元素，设置触发按钮内图标的样式、旋转动画、切换状态等图标交互样式"
+        },
+        {
+          "key": "group.triggerContent",
+          "description": "Trigger content element with trigger button content area text, identifier, state indicator and other content styles",
+          "descriptionZh": "触发内容元素，设置触发按钮内容区域的文字、标识、状态指示等内容样式"
         }
       ]
     },
@@ -10090,14 +10561,23 @@
           "description": "Custom semantic dom styling.",
           "descriptionZh": "自定义语义化结构的样式和类。",
           "code": "<script setup lang=\"ts\">\nimport { reactive } from 'vue'\n\nconst model = reactive({\n  name: '',\n  email: '',\n})\n\nconst classes = {\n  root: 'form-demo-root',\n  label: 'form-demo-label',\n  content: 'form-demo-content',\n}\n\nconst styles = {\n  root: { background: '#f6f7fb', padding: '16px', borderRadius: '8px' },\n}\n</script>\n\n<template>\n  <a-form\n    :model=\"model\"\n    layout=\"vertical\"\n    :classes=\"classes\"\n    :styles=\"styles\"\n    style=\"max-width: 600px\"\n  >\n    <a-form-item label=\"Name\" name=\"name\" :rules=\"[{ required: true }]\">\n      <a-input v-model:value=\"model.name\" />\n    </a-form-item>\n    <a-form-item label=\"Email\" name=\"email\" :rules=\"[{ type: 'email' }]\">\n      <a-input v-model:value=\"model.email\" />\n    </a-form-item>\n    <a-form-item :label=\"null\">\n      <a-button type=\"primary\">\n        Submit\n      </a-button>\n    </a-form-item>\n  </a-form>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with form item margin-bottom, vertical-align, transitions, hidden states, error/warning states and other basic form item container styles",
+          "descriptionZh": "根元素，包含表单项的底边距、垂直对齐、过渡动画、隐藏状态、错误警告状态等表单项容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Form\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-form\n        name=\"basic\"\n        :label-col=\"{ span: 8 }\"\n        :wrapper-col=\"{ span: 16 }\"\n        :style=\"{ maxWidth: '600px' }\"\n        :initial-values=\"{ remember: true }\"\n        autocomplete=\"off\"\n        :classes=\"classes\"\n      >\n        <a-form-item\n          label=\"Username\"\n          name=\"username\"\n          :rules=\"[{ required: true, message: 'Please input your username!' }]\"\n        >\n          <a-input />\n        </a-form-item>\n        <a-form-item\n          label=\"Password\"\n          name=\"password\"\n          :rules=\"[{ required: true, message: 'Please input your password!' }]\"\n        >\n          <a-input-password />\n        </a-form-item>\n      </a-form>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "label",
+          "description": "Label element with flex layout, overflow hidden, whitespace nowrap, text alignment, vertical alignment, plus label color, font size, height, required marks and other label display styles",
+          "descriptionZh": "标签元素，包含 flex 布局、溢出隐藏、文本不换行、文本对齐、垂直对齐，以及标签的颜色、字体大小、高度、必填标记等标签显示样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with form content area layout, styling and control container related styles",
+          "descriptionZh": "内容元素，包含表单内容区域的布局、样式和控件容器的相关样式"
         }
       ]
     },
@@ -10375,7 +10855,8 @@
           "descriptionZh": "使用 `useBreakpoint` Hook 实现个性化布局，其中 `xs` 仅当满足最小宽度时生效。",
           "code": "<script setup lang=\"ts\">\nimport { useBreakpoint } from 'antdv-next'\nimport { computed } from 'vue'\n\nconst screens = useBreakpoint()\nconst screenKeys = computed(() => Object.entries(screens.value ?? {}).filter(screen => !!screen[1]))\n</script>\n\n<template>\n  Current break point:\n  <div class=\"gap-2 inline-flex\">\n    <template v-for=\"item in screenKeys\" :key=\"item[0]\">\n      <a-tag color=\"blue\">\n        {{ item[0] }}\n      </a-tag>\n    </template>\n  </div>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Icon",
@@ -10438,7 +10919,8 @@
           "descriptionZh": "`scriptUrl` 可引用多个资源，用户可灵活的管理 [iconfont.cn](http://iconfont.cn/) 图标。如果资源的图标出现重名，会按照数组顺序进行覆盖。",
           "code": "<script setup lang=\"ts\">\nimport { createFromIconfontCN } from '@antdv-next/icons'\n\nconst IconFont = createFromIconfontCN({\n  scriptUrl: [\n    '//at.alicdn.com/t/font_1788044_0dwu4guekcwr.js', // icon-javascript, icon-java, icon-shoppingcart (overridden)\n    '//at.alicdn.com/t/font_1788592_a5xf2bdic3u.js', // icon-shoppingcart, icon-python\n  ],\n})\n</script>\n\n<template>\n  <a-space>\n    <IconFont type=\"icon-javascript\" />\n    <IconFont type=\"icon-java\" />\n    <IconFont type=\"icon-shoppingcart\" />\n    <IconFont type=\"icon-python\" />\n  </a-space>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Image",
@@ -10665,14 +11147,48 @@
           "description": "Nested in the modal.",
           "descriptionZh": "嵌套在弹框当中使用。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst show1 = ref(false)\nconst show2 = ref(false)\nconst show3 = ref(false)\n\nfunction handlePreviewGroupChange(current: number, prev: number) {\n  console.log(`current index: ${current}, prev index: ${prev}`)\n}\n</script>\n\n<template>\n  <a-button @click=\"show1 = true\">\n    showModal\n  </a-button>\n  <a-modal\n    v-model:open=\"show1\"\n    @cancel=\"show1 = false\"\n    @ok=\"show1 = false\"\n  >\n    <a-button @click=\"show2 = true\">\n      test2\n    </a-button>\n    <a-modal\n      v-model:open=\"show2\"\n      @cancel=\"show2 = false\"\n      @ok=\"show2 = false\"\n    >\n      <a-button @click=\"show3 = true\">\n        test3\n      </a-button>\n      <a-modal\n        v-model:open=\"show3\"\n        @cancel=\"show3 = false\"\n        @ok=\"show3 = false\"\n      >\n        <a-image\n          :width=\"200\"\n          alt=\"svg image\"\n          src=\"https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg\"\n        />\n        <a-divider />\n        <a-image-preview-group\n          :preview=\"{\n            onChange: handlePreviewGroupChange,\n          }\"\n        >\n          <a-image\n            :width=\"200\"\n            alt=\"svg image\"\n            src=\"https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg\"\n          />\n          <a-image\n            :width=\"200\"\n            src=\"https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg\"\n          />\n        </a-image-preview-group>\n      </a-modal>\n    </a-modal>\n  </a-modal>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets relative positioning and inline-block layout styles",
+          "descriptionZh": "根元素，设置相对定位和行内块布局样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { theme } from 'antdv-next'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'image', desc: t('image') },\n  { name: 'cover', desc: t('cover') },\n  { name: 'popup.root', desc: t('popup.root') },\n  { name: 'popup.mask', desc: t('popup.mask') },\n  { name: 'popup.body', desc: t('popup.body') },\n  { name: 'popup.footer', desc: t('popup.footer') },\n  { name: 'popup.actions', desc: t('popup.actions') },\n])\n\nconst { token } = theme.useToken()\nconst holderRef = ref<HTMLDivElement | null>(null)\n\nconst previewItems = [\n  'https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg',\n  'https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg',\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Image\"\n    :padding=\"false\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical align=\"center\" :style=\"{ minHeight: '100%', width: '100%' }\">\n        <a-flex :style=\"{ padding: `${token.padding}px`, flex: 'none' }\" justify=\"center\">\n          <a-image\n            :width=\"200\"\n            src=\"https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png\"\n            :classes=\"classes\"\n            :preview=\"{ getContainer: () => holderRef! }\"\n          />\n        </a-flex>\n        <div ref=\"holderRef\" :style=\"{ flex: 1, position: 'relative', minHeight: '500px', width: '100%' }\">\n          <a-image-preview-group\n            :items=\"previewItems\"\n            :classes=\"classes\"\n            :styles=\"{ popup: { root: { position: 'absolute' } } }\"\n            :preview=\"{ getContainer: () => holderRef!, open: true }\"\n          />\n        </div>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "image",
+          "description": "Image element, sets width, height and vertical alignment styles",
+          "descriptionZh": "图片元素，设置宽度、高度和垂直对齐样式"
+        },
+        {
+          "key": "cover",
+          "description": "Image hover display prompt element, sets absolute positioning, background color, opacity and transition animation styles",
+          "descriptionZh": "悬浮图片显示的提示元素，设置绝对定位、背景色、透明度和过渡动画样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Preview root element, sets fixed positioning, z-index and background mask styles",
+          "descriptionZh": "预览根元素，设置固定定位、层级和背景遮罩样式"
+        },
+        {
+          "key": "popup.mask",
+          "description": "Preview mask element, sets absolute positioning and semi-transparent background styles",
+          "descriptionZh": "预览遮罩元素，设置绝对定位和半透明背景样式"
+        },
+        {
+          "key": "popup.body",
+          "description": "Preview body element, sets flex layout, center alignment and pointer event styles",
+          "descriptionZh": "预览内容元素，设置flex布局、居中对齐和指针事件样式"
+        },
+        {
+          "key": "popup.footer",
+          "description": "Preview footer element, sets absolute positioning, center layout and bottom operation area styles",
+          "descriptionZh": "预览页脚元素，设置绝对定位、居中布局和底部操作区域样式"
+        },
+        {
+          "key": "popup.actions",
+          "description": "Preview actions group element, sets flex layout, background color, border radius and action button styles",
+          "descriptionZh": "预览操作组元素，设置flex布局、背景色、圆角和操作按钮样式"
         }
       ]
     },
@@ -11395,46 +11911,68 @@
           "description": "You can customize the [semantic dom](#semantic-input) style of Input by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Input 的[语义化结构](#semantic-input)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { InputOTPProps, InputPasswordProps, InputProps, InputSearchProps, TextAreaProps } from 'antdv-next'\n\nconst classes: InputProps['classes'] = {\n  root: 'effect',\n}\n\nconst stylesFn: InputProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      root: {\n        borderColor: '#696FC7',\n      },\n    } satisfies InputProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnTextArea: TextAreaProps['styles'] = (info) => {\n  if (info.props.showCount) {\n    return {\n      root: { borderColor: '#BDE3C3' },\n      textarea: { resize: 'none' },\n      count: { color: '#BDE3C3' },\n    } satisfies TextAreaProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnPassword: InputPasswordProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      root: {\n        borderColor: '#F5D3C4',\n      },\n    } satisfies InputPasswordProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnOTP: InputOTPProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      input: {\n        borderColor: '#6E8CFB',\n        width: '32px',\n      },\n    } satisfies InputOTPProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnSearch: InputSearchProps['styles'] = (info) => {\n  if (info.props.size === 'large') {\n    return {\n      root: { color: '#4DA8DA' },\n      input: { color: '#4DA8DA', borderColor: '#4DA8DA' },\n      prefix: { color: '#4DA8DA' },\n      suffix: { color: '#4DA8DA' },\n      count: { color: '#4DA8DA' },\n      button: {\n        root: { color: '#4DA8DA', borderColor: '#4DA8DA' },\n        icon: { color: '#4DA8DA' },\n      },\n    } satisfies InputSearchProps['styles']\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-input :classes=\"classes\" placeholder=\"Object\" name=\"input-object\" />\n    <a-input :classes=\"classes\" :styles=\"stylesFn\" placeholder=\"Function\" size=\"middle\" name=\"input-fn\" />\n    <a-textarea :classes=\"classes\" :styles=\"stylesFnTextArea\" placeholder=\"Textarea\" show-count name=\"textarea-fn\" />\n    <a-input-password :classes=\"classes\" :styles=\"stylesFnPassword\" placeholder=\"Password\" size=\"middle\" name=\"password-fn\" />\n    <a-input-otp :classes=\"classes\" :styles=\"stylesFnOTP\" size=\"middle\" :length=\"6\" separator=\"*\" name=\"otp-fn\" />\n    <a-input-search :classes=\"classes\" :styles=\"stylesFnSearch\" placeholder=\"Search\" size=\"large\" name=\"search-fn\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-block display, width, min-width, padding, colors, fonts, line-height, border-radius, transitions and other input container basic styles",
+          "descriptionZh": "根元素，包含相对定位、行内块布局、宽度、最小宽度、内边距、颜色、字体、行高、圆角、过渡动画等输入框容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'count', desc: t('count') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Input\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-input\n          default-value=\"Hello, Antdv-Next\"\n          show-count\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <UserOutlined />\n          </template>\n          <template #suffix>\n            <EditOutlined />\n          </template>\n        </a-input>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "input",
+          "description": "Input element with core interactive styles and text input related styling",
+          "descriptionZh": "输入框元素，包含输入框的核心交互样式和文本输入相关的样式"
         },
         {
-          "name": "_semantic-textarea",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('TextAreaRoot') },\n  { name: 'textarea', desc: t('textarea') },\n  { name: 'count', desc: t('TextAreaCount') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"TextArea\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-textarea\n          default-value=\"Hello, Antdv-Next\"\n          :maxlength=\"100\"\n          show-count\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix wrapper element with layout and styling for prefix content",
+          "descriptionZh": "前缀的包裹元素，包含前缀内容的布局和样式"
         },
         {
-          "name": "_semantic-search",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'count', desc: t('count') },\n  { name: 'button.root', desc: t('button.root') },\n  { name: 'button.icon', desc: t('button.icon') },\n  { name: 'button.content', desc: t('button.content') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputSearch\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-input-search\n          default-value=\"Hello, Antdv-Next\"\n          enter-button=\"Searching...\"\n          loading\n          show-count\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <UserOutlined />\n          </template>\n          <template #suffix>\n            <EditOutlined />\n          </template>\n        </a-input-search>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "suffix",
+          "description": "Suffix wrapper element with layout and styling for suffix content",
+          "descriptionZh": "后缀的包裹元素，包含后缀内容的布局和样式"
         },
         {
-          "name": "_semantic-password",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'count', desc: t('count') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputPassword\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-input-password\n          default-value=\"Hello, Antdv-Next\"\n          show-count\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <UserOutlined />\n          </template>\n          <template #suffix>\n            <EditOutlined />\n          </template>\n        </a-input-password>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "count",
+          "description": "Character count element with font and color styles for count display",
+          "descriptionZh": "文字计数元素，包含字符计数显示的字体和颜色样式"
         },
         {
-          "name": "_semantic-otp",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'input', desc: t('input') },\n  { name: 'separator', desc: t('OTPSeparator') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputOTP\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-input-otp\n        :length=\"6\"\n        separator=\"-\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "TextAreaRoot",
+          "description": "Root element with textarea wrapper styles, border, border radius, transition animation and state control",
+          "descriptionZh": "根元素，设置文本域包装器的样式、边框、圆角、过渡动画和状态控制"
+        },
+        {
+          "key": "textarea",
+          "description": "Textarea element with font, line height, padding, color, background, border, text input and multi-line text display styles",
+          "descriptionZh": "文本域元素，设置字体、行高、内边距、颜色、背景、边框、文本输入和多行文本展示样式"
+        },
+        {
+          "key": "TextAreaCount",
+          "description": "Count element with character count display position, font, color and numeric statistics styles",
+          "descriptionZh": "文字计数元素，设置字符计数显示的位置、字体、颜色和数值统计样式"
+        },
+        {
+          "key": "button.root",
+          "description": "Search button root element with button styles, hover effects and click interactions",
+          "descriptionZh": "搜索按钮的根元素，设置按钮的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "button.icon",
+          "description": "Search button icon element with icon styles, hover effects and click interactions",
+          "descriptionZh": "搜索按钮的图标元素，设置图标的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "button.content",
+          "description": "Search button content element with text styles, hover effects and click interactions",
+          "descriptionZh": "搜索按钮的内容元素，设置文本的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "OTPSeparator",
+          "description": "Separator element, set separator display styles between OTP input boxes",
+          "descriptionZh": "分隔符元素，设置OTP输入框之间的分隔符显示样式"
         }
       ]
     },
@@ -12008,14 +12546,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of the InputNumber by passing objects/functions through",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 InputNumber 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { InputNumberProps } from 'antdv-next'\n\nconst shardStyle = {\n  root: 'shard',\n}\nconst styleObject: InputNumberProps['styles'] = {\n  input: {\n    fontSize: '14px',\n  },\n}\nconst styleFn: InputNumberProps['styles'] = ({ props }) => {\n  if (props.size === 'large') {\n    return {\n      root: {\n        backgroundColor: 'rgba(250,250,250, 0.5)',\n        borderColor: '#722ed1',\n      },\n    } satisfies InputNumberProps['styles']\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-input-number :classes=\"shardStyle\" :styles=\"styleObject\" placeholder=\"Object\" />\n    <a-input-number :classes=\"shardStyle\" :styles=\"styleFn\" placeholder=\"Function\" size=\"large\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets inline-block layout, width, border radius and reset styles",
+          "descriptionZh": "根元素，设置行内块布局、宽度、边框圆角和重置样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'actions', desc: t('actions') },\n  { name: 'action', desc: t('action') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputNumber\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ display: 'flex', flexDirection: 'column', gap: '16px' }\">\n        <a-input-number\n          prefix=\"￥\"\n          suffix=\"RMB\"\n          :default-value=\"100\"\n          :style=\"{ width: '200px' }\"\n          :styles=\"{ actions: { opacity: 1, width: '24px' }, suffix: { marginRight: '28px' } }\"\n          :classes=\"classes\"\n        />\n        <a-input-number\n          :default-value=\"100\"\n          :style=\"{ width: '200px' }\"\n          :styles=\"{ actions: { opacity: 1, width: '24px' }, suffix: { marginRight: '28px' } }\"\n          mode=\"spinner\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "input",
+          "description": "Input element, sets font, line height, text input and interaction styles",
+          "descriptionZh": "输入框元素，设置字体、行高、文本输入和交互样式"
+        },
+        {
+          "key": "prefix",
+          "description": "Prefix wrapper element, sets flex layout, alignment and right margin styles",
+          "descriptionZh": "前缀的包裹元素，设置flex布局、对齐方式和右边距样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix wrapper element, sets flex layout, margin and transition animation styles",
+          "descriptionZh": "后缀的包裹元素，设置flex布局、边距和过渡动画样式"
+        },
+        {
+          "key": "action",
+          "description": "Single action button element, sets button styling, hover effects and click interactions",
+          "descriptionZh": "单个操作按钮元素，设置按钮的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element, sets absolute positioning, width, flex layout and number adjustment button styles",
+          "descriptionZh": "操作元素，设置绝对定位、宽度、flex布局和数值调节按钮样式"
         }
       ]
     },
@@ -12327,7 +12889,8 @@
           "descriptionZh": "当内容较长时，使用固定侧边栏可以提供更好的体验。",
           "code": "<script setup lang=\"ts\">\nimport type { MenuItemType } from 'antdv-next'\nimport type { CSSProperties } from 'vue'\nimport {\n  AppstoreOutlined,\n  BarChartOutlined,\n  CloudOutlined,\n  ShopOutlined,\n  TeamOutlined,\n  UploadOutlined,\n  UserOutlined,\n  VideoCameraOutlined,\n} from '@antdv-next/icons'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\nconst year = new Date().getFullYear()\n\nconst siderStyle: CSSProperties = {\n  overflow: 'auto',\n  height: '100vh',\n  position: 'sticky',\n  insetInlineStart: 0,\n  top: 0,\n  scrollbarWidth: 'thin',\n  scrollbarGutter: 'stable',\n}\n\nconst items: MenuItemType[] = [\n  UserOutlined,\n  VideoCameraOutlined,\n  UploadOutlined,\n  BarChartOutlined,\n  CloudOutlined,\n  AppstoreOutlined,\n  TeamOutlined,\n  ShopOutlined,\n].map((icon, index) => ({\n  key: String(index + 1),\n  icon,\n  label: `nav ${index + 1}`,\n}))\n</script>\n\n<template>\n  <a-layout :has-sider=\"true\">\n    <a-layout-sider :style=\"siderStyle\">\n      <div class=\"demo-logo-vertical\" />\n      <a-menu\n        theme=\"dark\"\n        mode=\"inline\"\n        :default-selected-keys=\"['4']\"\n        :items=\"items\"\n      />\n    </a-layout-sider>\n    <a-layout>\n      <a-layout-header class=\"fixed-header\" :style=\"{ background: token.colorBgContainer }\" />\n      <a-layout-content class=\"fixed-content\">\n        <div\n          class=\"fixed-content-box\"\n          :style=\"{\n            background: token.colorBgContainer,\n            borderRadius: `${token.borderRadiusLG}px`,\n          }\"\n        >\n          <p>long content</p>\n          <template v-for=\"index in 100\" :key=\"index\">\n            {{ index % 20 === 0 && index !== 0 ? 'more' : '...' }}\n            <br>\n          </template>\n        </div>\n      </a-layout-content>\n      <a-layout-footer class=\"fixed-footer\">\n        Antdv Next ©{{ year }} Created by Ant UED\n      </a-layout-footer>\n    </a-layout>\n  </a-layout>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Masonry",
@@ -12449,14 +13012,18 @@
           "description": "When `fresh` is enabled, the masonry will continuously monitor size changes of child items and automatically re-layout. Click on cards to change their height.",
           "descriptionZh": "开启 `fresh` 属性后，瀑布流会持续监听子项的尺寸变化并自动重新布局。点击卡片可以改变其高度。",
           "code": "<script setup lang=\"ts\">\nimport { Card } from 'antdv-next'\nimport { defineComponent, h, ref } from 'vue'\n\nconst RandomHeightCard = defineComponent({\n  props: {\n    index: {\n      type: Number,\n      required: true,\n    },\n    defaultHeight: {\n      type: Number,\n      required: true,\n    },\n  },\n  setup(props) {\n    const height = ref(props.defaultHeight)\n\n    const handleClick = () => {\n      height.value = Math.floor(Math.random() * 100) + 50\n    }\n\n    return () =>\n      h(\n        Card,\n        {\n          size: 'small',\n          style: { height: `${height.value}px`, transition: 'height 0.3s' },\n          onClick: handleClick,\n        },\n        () => `${props.index + 1} - Click`,\n      )\n  },\n})\n\nconst heights = [150, 50, 90, 70, 110, 150, 130, 80, 50, 90, 100, 150, 60, 50, 80].map(\n  (height, index) => {\n    const item: {\n      key: string\n      data: number\n      column?: number\n    } = {\n      key: `item-${index}`,\n      data: height,\n    }\n\n    if (index === 4) {\n      item.column = 0\n    }\n\n    return item\n  },\n)\n</script>\n\n<template>\n  <a-masonry\n    fresh\n    :columns=\"4\"\n    :gutter=\"16\"\n    :items=\"heights\"\n  >\n    <template #itemRender=\"{ data, index }\">\n      <RandomHeightCard :index=\"index\" :default-height=\"data\" />\n    </template>\n  </a-masonry>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets relative positioning, flex layout and masonry container styles",
+          "descriptionZh": "根元素，设置相对定位、flex布局和瀑布流容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n])\n\nconst heights = [75, 50, 70, 60, 85, 75, 50].map((height, index) => ({\n  key: `item-${index}`,\n  data: height,\n}))\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Masonry\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-masonry\n        :columns=\"3\"\n        :gutter=\"16\"\n        :items=\"heights\"\n        style=\"width: 100%\"\n        :classes=\"classes\"\n      >\n        <template #itemRender=\"{ data, index }\">\n          <a-card size=\"small\" :style=\"{ height: data }\">\n            {{ index + 1 }}\n          </a-card>\n        </template>\n      </a-masonry>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element, sets absolute positioning, width calculation, transition animation and masonry item styles",
+          "descriptionZh": "条目元素，设置绝对定位、宽度计算、过渡动画和瀑布流项目样式"
         }
       ]
     },
@@ -12839,14 +13406,28 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Mentions by passing objects/functions through `classes` and `styles`. For example, set the textarea to be resizable.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Mentions 的[语义化结构](#semantic-dom)样式，例如设置文本框可缩放。",
           "code": "<script setup lang=\"ts\">\nimport type { MentionsProps } from 'antdv-next'\n\nconst options: MentionsProps['options'] = [\n  { value: 'afc163', label: 'afc163' },\n  { value: 'zombieJ', label: 'zombieJ' },\n  { value: 'meet-student', label: 'meet-student' },\n  { value: 'thinkasany', label: 'thinkasany' },\n]\n\nconst classes: MentionsProps['classes'] = {\n  root: 'mentions-demo-root',\n}\n\nconst stylesObject: MentionsProps['styles'] = {\n  textarea: {\n    fontSize: '14px',\n    resize: 'vertical',\n    fontWeight: 200,\n  },\n}\n\nconst stylesFn: MentionsProps['styles'] = ({ props }) => {\n  if (props.variant === 'filled') {\n    return {\n      root: {\n        border: '1px solid #722ed1',\n      },\n      popup: {\n        border: '1px solid #722ed1',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-mentions\n      :options=\"options\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      placeholder=\"Object\"\n      :rows=\"2\"\n    />\n    <a-mentions\n      :options=\"options\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      variant=\"filled\"\n      placeholder=\"Function\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set inline flex layout, relative positioning, padding and border styles",
+          "descriptionZh": "根元素，设置行内flex布局、相对定位、内边距和边框样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'textarea', desc: t('textarea'), version: '1.0.0' },\n  { name: 'suffix', desc: t('suffix'), version: '1.0.0' },\n  { name: 'popup', desc: t('popup'), version: '1.0.0' },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst options = [\n  { value: 'afc163', label: 'afc163' },\n  { value: 'zombieJ', label: 'zombieJ' },\n  { value: 'thinkasany', label: 'thinkasany' },\n  { value: 'meet-student', label: 'meet-student' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Mentions\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <a-mentions\n          placement=\"bottom\"\n          :style=\"{ width: '100%' }\"\n          value=\"Hi, @\"\n          allow-clear\n          open\n          :get-popup-container=\"() => divRef!\"\n          :options=\"options\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "textarea",
+          "description": "Textarea element, set font, line height, text input and background styles",
+          "descriptionZh": "文本域元素，设置字体、行高、文本输入和背景样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup element, set absolute positioning, z-index, background color, border radius, shadow and dropdown options styles",
+          "descriptionZh": "弹出框元素，设置绝对定位、层级、背景色、圆角、阴影和下拉选项样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with layout and styling for suffix content like clear button, etc.",
+          "descriptionZh": "后缀元素，包含后缀内容的布局和样式，如清除按钮等"
         }
       ]
     },
@@ -13588,14 +14169,68 @@
           "description": "Use the `popupRender` prop to customize submenu popup rendering.",
           "descriptionZh": "使用 `popupRender` 属性自定义弹出菜单的渲染。",
           "code": "<script setup lang=\"ts\">\nimport type { MenuItemType, MenuProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\nimport { computed, h } from 'vue'\n\nconst { token } = theme.useToken()\n\nconst popupStyle = computed(() => ({\n  padding: `${token.value.padding}px`,\n  minWidth: '480px',\n  background: token.value.colorBgElevated,\n  borderRadius: `${token.value.borderRadiusLG}px`,\n  boxShadow: token.value.boxShadowSecondary,\n}))\n\nconst headerStyle = computed(() => ({\n  margin: 0,\n  paddingBottom: `${token.value.paddingXS}px`,\n  borderBottom: `1px solid ${token.value.colorSplit}`,\n}))\n\nconst cardStyle = computed(() => ({\n  padding: `${token.value.paddingSM}px`,\n}))\n\nconst cardItemStyle = computed(() => ({\n  borderRadius: `${token.value.borderRadius}px`,\n  transition: `all ${token.value.motionDurationSlow}`,\n  cursor: 'pointer',\n}))\n\nfunction renderMenuCard(title: string, description: string) {\n  return h('div', { class: 'menu-card', style: cardStyle.value }, [\n    h('div', { class: 'menu-card-title' }, title),\n    h('div', { class: 'menu-card-desc' }, description),\n  ])\n}\n\nconst menuItems = computed<MenuItemType[]>(() => [\n  {\n    key: 'home',\n    label: 'Home',\n  },\n  {\n    key: 'features',\n    label: 'Features',\n    children: [\n      {\n        key: 'getting-started',\n        label: renderMenuCard('Getting Started', 'Quick start guide and learn the basics.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n      {\n        key: 'components',\n        label: renderMenuCard('Components', 'Explore our component library.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n      {\n        key: 'templates',\n        label: renderMenuCard('Templates', 'Ready-to-use template designs.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n    ],\n  },\n  {\n    key: 'resources',\n    label: 'Resources',\n    children: [\n      {\n        key: 'blog',\n        label: renderMenuCard('Blog', 'Latest updates and articles.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n      {\n        key: 'community',\n        label: renderMenuCard('Community', 'Join our developer community.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n    ],\n  },\n])\n\nconst popupRender: MenuProps['popupRender'] = (node, info) => {\n  const title = info.item.title || info.item.key\n  return h('div', { class: 'menu-popup', style: popupStyle.value }, [\n    h('div', { class: 'menu-popup-title', style: headerStyle.value }, title),\n    node,\n  ])\n}\n\nconst themeConfig = {\n  components: {\n    Menu: {\n      popupBg: '#fff',\n      horizontalItemSelectedColor: '#1677ff',\n      horizontalItemHoverColor: '#1677ff',\n    },\n  },\n}\n</script>\n\n<template>\n  <a-config-provider :theme=\"themeConfig\">\n    <a-menu mode=\"horizontal\" :items=\"menuItems\" :popup-render=\"popupRender\" />\n  </a-config-provider>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with basic menu container styles and layout",
+          "descriptionZh": "根元素，包含菜单容器的基础样式和布局"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { MailOutlined } from '@antdv-next/icons'\nimport { computed, h, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst mode = ref<'horizontal' | 'vertical' | 'inline'>('horizontal')\nconst current = ref('mail')\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst semantics = computed(() => {\n  const baseLocale = [\n    { name: 'root', desc: t('root') },\n    { name: 'item', desc: t('item') },\n    { name: 'itemIcon', desc: t('itemIcon') },\n    { name: 'itemContent', desc: t('itemContent') },\n  ]\n  const subMenuLocale = [\n    { name: 'subMenu.itemTitle', desc: t('subMenu.itemTitle') },\n    { name: 'subMenu.list', desc: t('subMenu.list') },\n    { name: 'subMenu.item', desc: t('subMenu.item') },\n    { name: 'subMenu.itemIcon', desc: t('subMenu.itemIcon') },\n    { name: 'subMenu.itemContent', desc: t('subMenu.itemContent') },\n  ]\n  const groupLocale = [\n    { name: 'itemTitle', desc: t('itemTitle') },\n    { name: 'list', desc: t('list') },\n  ]\n\n  const additionalPopupLocale = mode.value !== 'inline' ? [{ name: 'popup', desc: t('popup') }] : []\n  const additionalGroupLocale = mode.value !== 'horizontal' ? groupLocale : []\n\n  return [...baseLocale, ...additionalGroupLocale, ...additionalPopupLocale, ...subMenuLocale]\n})\n\nconst items = [\n  { label: 'Navigation One', key: 'mail', icon: h(MailOutlined) },\n  {\n    key: 'SubMenu',\n    label: 'Navigation One',\n    icon: h(MailOutlined),\n    children: [\n      {\n        key: 'g1',\n        label: 'Item 1',\n        type: 'group',\n        children: [\n          { key: '1', label: 'Option 1', icon: h(MailOutlined) },\n          { key: '2', label: 'Option 2' },\n        ],\n      },\n    ],\n  },\n]\n\nconst groupItem = [\n  {\n    key: 'grp',\n    label: 'Group',\n    type: 'group',\n    children: [\n      { key: '13', label: 'Option 13' },\n      { key: '14', label: 'Option 14' },\n    ],\n  },\n]\n\nconst itemList = computed(() => {\n  return mode.value === 'horizontal' ? items : [...items, ...groupItem]\n})\n\nfunction onClick(e: { key: string }) {\n  current.value = e.key\n}\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Menu\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" vertical gap=\"middle\" align=\"center\">\n        <a-segmented\n          :options=\"['horizontal', 'vertical', 'inline']\"\n          :value=\"mode\"\n          @change=\"(val: 'horizontal' | 'vertical' | 'inline') => mode = val\"\n        />\n        <div :style=\"{ height: '360px' }\">\n          <a-menu\n            :selected-keys=\"[current]\"\n            :mode=\"mode\"\n            :items=\"itemList\"\n            :styles=\"{\n              root: { width: mode === 'horizontal' ? '310px' : '230px' },\n              popup: { root: { zIndex: 1 } },\n            }\"\n            :open-keys=\"['SubMenu']\"\n            :get-popup-container=\"() => divRef!\"\n            :classes=\"classes\"\n            @click=\"onClick\"\n          />\n        </div>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with relative positioning, block display, margins, whitespace handling, cursor styles, transitions and other basic interactive styles for menu items",
+          "descriptionZh": "条目元素，包含相对定位、块级显示、外边距、空白符处理、光标样式、过渡动画等菜单项的基础交互样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Item content element with layout and typography styles for menu item content",
+          "descriptionZh": "条目内容元素，包含菜单项内容的布局和排版样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Icon element with min-width, font-size, transitions, icon reset styles, and spacing control with text",
+          "descriptionZh": "图标元素，包含最小宽度、字体大小、过渡动画、图标重置样式，以及与文本的间距控制"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Item title element (no effect in horizontal mode) with title text styles and layout",
+          "descriptionZh": "菜单标题元素(horizontal 模式不生效)，包含标题文字的样式和布局"
+        },
+        {
+          "key": "list",
+          "description": "Menu list element (no effect in horizontal mode) with menu list layout and container styles",
+          "descriptionZh": "菜单列表元素(horizontal 模式不生效)，包含菜单列表的布局和容器样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup menu element (no effect in inline mode) with popup layer positioning, z-index, background and other styles",
+          "descriptionZh": "弹出菜单(inline 模式不生效)，包含弹出层的定位、层级、背景等样式"
+        },
+        {
+          "key": "subMenu.itemTitle",
+          "description": "Submenu title element with submenu title styles and interactive effects",
+          "descriptionZh": "子菜单标题元素，包含子菜单标题的样式和交互效果"
+        },
+        {
+          "key": "subMenu.list",
+          "description": "Submenu list element with submenu list layout and container styles",
+          "descriptionZh": "子菜单列表元素，包含子菜单列表的布局和容器样式"
+        },
+        {
+          "key": "subMenu.item",
+          "description": "Submenu item element with submenu item styles and interactive effects",
+          "descriptionZh": "子菜单单项元素，包含子菜单项的样式和交互效果"
+        },
+        {
+          "key": "subMenu.itemIcon",
+          "description": "Submenu item icon element with submenu icon size and styles",
+          "descriptionZh": "子菜单条目图标元素，包含子菜单图标的尺寸和样式"
+        },
+        {
+          "key": "subMenu.itemContent",
+          "description": "Submenu item content element with submenu content layout and typography",
+          "descriptionZh": "子菜单条目内容元素，包含子菜单内容的布局和排版"
         }
       ]
     },
@@ -13717,14 +14352,23 @@
           "description": "Static methods cannot consume Context provided by `ConfigProvider`. When enable `layer`, they may also cause style errors. Please use hooks version or `App` provided instance first.",
           "descriptionZh": "静态方法无法消费 Context，不能动态响应 ConfigProvider 提供的各项配置，启用 `layer` 时还可能导致样式异常。请优先使用 hooks 版本或者 App 组件提供的 `message` 实例。",
           "code": "<script setup lang=\"ts\">\nimport { message } from 'antdv-next'\n\nfunction info() {\n  message.info('This is an info message')\n}\n</script>\n\n<template>\n  <a-button type=\"primary\" @click=\"info\">\n    Static Method\n  </a-button>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set fixed positioning, z-index, padding, background color, border radius, shadow and animation styles",
+          "descriptionZh": "根元素，设置固定定位、层级、内边距、背景色、圆角、阴影和动画样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { message } from 'antdv-next'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { _InternalPanelDoNotUseOrYouWillBeFired: InternalPanel } = message\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Message\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <InternalPanel\n        type=\"success\"\n        content=\"Hello, Ant Design!\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element, set font size, right margin and status color styles",
+          "descriptionZh": "图标元素，设置字体大小、右边距和状态颜色样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element, set inline block layout, text color and content display styles",
+          "descriptionZh": "内容元素，设置行内块布局、文字颜色和内容展示样式"
         }
       ]
     },
@@ -14282,14 +14926,48 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Modal by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Modal 组件的 [语义化结构](#semantic-dom) 样式。",
           "code": "<script setup lang=\"ts\">\nimport type { ModalProps } from 'antdv-next'\nimport { computed, ref } from 'vue'\n\nconst modalOpen = ref(false)\nconst modalFnOpen = ref(false)\n\nconst lineStyle = {\n  lineHeight: '28px',\n}\n\nconst classNames = computed(() => ({\n  container: 'custom-modal-container',\n}))\n\nconst styles: ModalProps['styles'] = {\n  mask: {\n    backgroundImage: `linear-gradient(to top, #18181b 0, rgba(21, 21, 22, 0.2) 100%)`,\n  },\n}\n\nconst stylesFn: ModalProps['styles'] = {\n  container: {\n    borderRadius: '14px',\n    border: '1px solid #ccc',\n    padding: '0',\n    overflow: 'hidden',\n  },\n  header: {\n    padding: '16px',\n  },\n  body: {\n    padding: '16px',\n  },\n  footer: {\n    padding: '16px 10px',\n    backgroundColor: '#fafafa',\n  },\n}\n\nconst sharedProps = computed<ModalProps>(() => ({\n  centered: true,\n  classes: classNames.value,\n}))\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-button @click=\"modalOpen = true\">\n      Open Style Modal\n    </a-button>\n    <a-button type=\"primary\" @click=\"modalFnOpen = true\">\n      Open Function Modal\n    </a-button>\n\n    <a-modal\n      v-bind=\"sharedProps\"\n      v-model:open=\"modalOpen\"\n      :footer=\"null\"\n      title=\"Custom Style Modal\"\n      :styles=\"styles\"\n    >\n      <div :style=\"lineStyle\">\n        Following the Ant Design specification, we developed a React UI library antd that contains a\n        set of high quality components and demos for building rich, interactive user interfaces.\n      </div>\n      <div :style=\"lineStyle\">\n        🌈 Enterprise-class UI designed for web applications.\n      </div>\n      <div :style=\"lineStyle\">\n        📦 A set of high-quality React components out of the box.\n      </div>\n      <div :style=\"lineStyle\">\n        🛡 Written in TypeScript with predictable static types.\n      </div>\n      <div :style=\"lineStyle\">\n        ⚙️ Whole package of design resources and development tools.\n      </div>\n      <div :style=\"lineStyle\">\n        🌍 Internationalization support for dozens of languages.\n      </div>\n      <div :style=\"lineStyle\">\n        🎨 Powerful theme customization in every detail.\n      </div>\n    </a-modal>\n\n    <a-modal\n      v-bind=\"sharedProps\"\n      v-model:open=\"modalFnOpen\"\n      title=\"Custom Function Modal\"\n      :styles=\"stylesFn\"\n      :mask=\"{ enabled: true, blur: true }\"\n    >\n      <div :style=\"lineStyle\">\n        Following the Ant Design specification, we developed a React UI library antd that contains a\n        set of high quality components and demos for building rich, interactive user interfaces.\n      </div>\n      <div :style=\"lineStyle\">\n        🌈 Enterprise-class UI designed for web applications.\n      </div>\n      <div :style=\"lineStyle\">\n        📦 A set of high-quality React components out of the box.\n      </div>\n      <div :style=\"lineStyle\">\n        🛡 Written in TypeScript with predictable static types.\n      </div>\n      <div :style=\"lineStyle\">\n        ⚙️ Whole package of design resources and development tools.\n      </div>\n      <div :style=\"lineStyle\">\n        🌍 Internationalization support for dozens of languages.\n      </div>\n      <div :style=\"lineStyle\">\n        🎨 Powerful theme customization in every detail.\n      </div>\n      <template #footer>\n        <a-button\n          :style=\"{ borderColor: '#ccc', color: '#171717', backgroundColor: '#fff' }\"\n          @click=\"modalFnOpen = false\"\n        >\n          Cancel\n        </a-button>\n        <a-button\n          type=\"primary\"\n          :style=\"{ backgroundColor: '#171717' }\"\n          @click=\"modalOpen = true\"\n        >\n          Submit\n        </a-button>\n      </template>\n    </a-modal>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, top position, width, max-width, margins, bottom padding and other basic layout styles for modal container",
+          "descriptionZh": "根元素，包含相对定位、顶部位置、宽度、最大宽度、外边距、底部内边距等模态框容器的基础布局样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'mask', desc: t('mask'), version: '1.0.0' },\n  { name: 'container', desc: t('container'), version: '1.0.0' },\n  { name: 'wrapper', desc: t('wrapper'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Modal\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', inset: 0 }\">\n        <a-modal\n          title=\"Title\"\n          :closable=\"false\"\n          open\n          :get-container=\"() => divRef!\"\n          :width=\"400\"\n          :styles=\"{\n            mask: { position: 'absolute', zIndex: 1 },\n            wrapper: { position: 'absolute', zIndex: 1 },\n          }\"\n          :style=\"{ top: '50%', transform: 'translateY(-50%)', marginBottom: 0, paddingBottom: 0 }\"\n          :classes=\"classes\"\n        >\n          <p>Some contents...</p>\n        </a-modal>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "mask",
+          "description": "Mask element with fixed positioning, z-index, background color, animation transitions and other mask layer styles",
+          "descriptionZh": "遮罩层元素，包含固定定位、层级、背景色、动画过渡等遮罩层的样式"
+        },
+        {
+          "key": "wrapper",
+          "description": "Wrapper element used for motion container with animation and transition effect styles",
+          "descriptionZh": "包裹层元素，一般用于动画容器，包含动画和过渡效果的样式"
+        },
+        {
+          "key": "container",
+          "description": "Modal container element with relative positioning, background, background-clip, border, border-radius, box-shadow, pointer-events, padding and other modal body styles",
+          "descriptionZh": "Modal 容器元素，包含相对定位、背景色、背景裁剪、边框、圆角、阴影、指针事件、内边距等模态框主体样式"
+        },
+        {
+          "key": "header",
+          "description": "Header element with padding, bottom border and other header area styles",
+          "descriptionZh": "头部元素，包含头部内边距、下边框等头部区域样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with margin, color, font-weight, font-size, line-height, word-wrap and other title text styles",
+          "descriptionZh": "标题元素，包含外边距、颜色、字体权重、字体大小、行高、文字换行等标题文字样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with content area background color, padding and other content display styles",
+          "descriptionZh": "内容元素，包含内容区域的背景色、内边距等内容展示样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with footer background color, padding, top border, border-radius and other footer area styles",
+          "descriptionZh": "底部元素，包含底部的背景色、内边距、上边框、圆角等底部区域样式"
         }
       ]
     },
@@ -14471,14 +15149,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Notification by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义通知的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { notification } from 'antdv-next'\n\nconst [api, ContextHolder] = notification.useNotification()\n\nconst classes = {\n  root: 'custom-notification-root',\n}\n\nfunction styleFn(info: any) {\n  if (info.props.type === 'error') {\n    return {\n      root: {\n        backgroundColor: 'rgba(255, 200, 200, 0.3)',\n      },\n    }\n  }\n  return {}\n}\n\nfunction openDefault() {\n  api.info({\n    title: 'Notification Title',\n    description: 'This is a notification description.',\n    duration: false,\n    classes,\n    styles: {\n      root: {\n        borderRadius: '8px',\n      },\n    },\n  })\n}\n\nfunction openError() {\n  api.error({\n    title: 'Notification Title',\n    description: 'This is a notification description.',\n    duration: false,\n    classes,\n    styles: styleFn,\n  })\n}\n</script>\n\n<template>\n  <ContextHolder />\n  <a-space>\n    <a-button type=\"primary\" @click=\"openDefault\">\n      Default Notification\n    </a-button>\n    <a-button @click=\"openError\">\n      Error Notification\n    </a-button>\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set fixed positioning, z-index, padding, background color, border radius, shadow and animation styles",
+          "descriptionZh": "根元素，设置固定定位、层级、内边距、背景色、圆角、阴影和动画样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { notification } from 'antdv-next'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { _InternalPanelDoNotUseOrYouWillBeFired: InternalPanel } = notification\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Notification\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <InternalPanel\n        title=\"Hello World!\"\n        description=\"Hello World?\"\n        type=\"success\"\n        :classes=\"classes\"\n      >\n        <template #actions>\n          <a-button type=\"primary\" size=\"small\">\n            My Button\n          </a-button>\n        </template>\n      </InternalPanel>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element, set absolute positioning, font size, line height and status color styles",
+          "descriptionZh": "图标元素，设置绝对定位、字体大小、行高和状态颜色样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element, set color, font size, line height and margin styles",
+          "descriptionZh": "标题元素，设置颜色、字体大小、行高和外边距样式"
+        },
+        {
+          "key": "description",
+          "description": "Description element, set font size, color and margin styles",
+          "descriptionZh": "描述元素，设置字体大小、颜色和外边距样式"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element, set float right, top margin and action button layout styles",
+          "descriptionZh": "操作组元素，设置右浮动、上边距和操作按钮布局样式"
         }
       ]
     },
@@ -14497,7 +15194,8 @@
       "props": [],
       "tokens": [],
       "faq": [],
-      "demos": []
+      "demos": [],
+      "semanticStructure": []
     },
     {
       "name": "Pagination",
@@ -14920,14 +15618,18 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Pagination by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Pagination 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { PaginationProps } from 'antdv-next'\nimport { useCssModule } from 'vue'\n\nconst moduleStyles = useCssModule()\n\nconst classes: PaginationProps['classes'] = {\n  root: moduleStyles.root,\n}\n\nconst stylesObject: PaginationProps['styles'] = {\n  item: {\n    borderRadius: '999px',\n  },\n}\n\nconst stylesFn: PaginationProps['styles'] = ({ props }) => {\n  if (props.size === 'small') {\n    return {\n      item: {\n        backgroundColor: 'rgba(200, 200, 200, 0.3)',\n        marginInlineEnd: '4px',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-pagination :total=\"500\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-pagination :total=\"500\" size=\"small\" :classes=\"classes\" :styles=\"stylesFn\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set flex layout, alignment, flex wrap and list styles",
+          "descriptionZh": "根元素，设置flex布局、对齐方式、换行和列表样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Pagination\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-pagination :default-current=\"1\" :total=\"50\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element, set size, padding, border, background color, hover state and active state styles",
+          "descriptionZh": "页码元素，设置尺寸、内边距、边框、背景色、悬停态和激活态样式"
         }
       ]
     },
@@ -15139,14 +15841,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Popconfirm by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Popconfirm 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { PopconfirmProps } from 'antdv-next'\n\nconst classes: PopconfirmProps['classes'] = {\n  container: 'demo-popconfirm-container',\n}\n\nconst stylesObject: PopconfirmProps['styles'] = {\n  container: {\n    backgroundColor: '#eee',\n    boxShadow: 'inset 5px 5px 3px #fff, inset -5px -5px 3px #ddd, 0 0 3px rgba(0,0,0,0.2)',\n  },\n  title: {\n    color: '#262626',\n  },\n  content: {\n    color: '#262626',\n  },\n}\n\nconst stylesFn: PopconfirmProps['styles'] = (info) => {\n  if (info?.props?.arrow === false) {\n    return {\n      container: {\n        backgroundColor: 'rgba(53, 71, 125, 0.8)',\n        padding: '12px',\n        borderRadius: '4px',\n      },\n      title: {\n        color: '#fff',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-popconfirm\n      title=\"Object text\"\n      description=\"Object description\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    >\n      <a-button>Object Style</a-button>\n    </a-popconfirm>\n    <a-popconfirm\n      title=\"Function text\"\n      description=\"Function description\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n      :ok-button-props=\"{ styles: { root: { backgroundColor: 'rgba(53, 71, 125, 0.6)', color: '#fff' } } }\"\n      :cancel-button-props=\"{ styles: { root: { borderColor: 'rgba(53, 71, 125, 0.6)', backgroundColor: '#fff', color: 'rgba(53, 71, 125, 0.8)' } } }\"\n    >\n      <a-button type=\"primary\">\n        Function Style\n      </a-button>\n    </a-popconfirm>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set absolute positioning, z-index, transform origin, arrow direction and popover container styles",
+          "descriptionZh": "根元素，设置绝对定位、层级、变换原点、箭头指向和弹层容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'container', desc: t('container') },\n  { name: 'title', desc: t('title') },\n  { name: 'content', desc: t('content') },\n  { name: 'arrow', desc: t('arrow') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Popconfirm\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', marginTop: '60px' }\">\n        <a-popconfirm\n          open\n          placement=\"top\"\n          title=\"Confirm\"\n          description=\"Are you sure you want to perform this action?\"\n          :auto-adjust-overflow=\"false\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "arrow",
+          "description": "Arrow element with width, height, position, color and border styles",
+          "descriptionZh": "箭头元素，设置宽高、位置、颜色和边框样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element, set title text styles and spacing",
+          "descriptionZh": "标题元素，设置标题文本样式和间距"
+        },
+        {
+          "key": "content",
+          "description": "Description element, set content text styles and layout",
+          "descriptionZh": "描述元素，设置描述文本样式和布局"
         }
       ]
     },
@@ -15350,14 +16071,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Popover by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Popover 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { PopoverProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: PopoverProps['classes'] = {\n  container: 'demo-popover-container',\n}\n\nconst stylesObject: PopoverProps['styles'] = {\n  container: {\n    backgroundColor: '#eee',\n    boxShadow: 'inset 5px 5px 3px #fff, inset -5px -5px 3px #ddd, 0 0 3px rgba(0,0,0,0.2)',\n  },\n  title: {\n    color: '#262626',\n  },\n  content: {\n    color: '#262626',\n  },\n}\n\nconst stylesFn: PopoverProps['styles'] = (info) => {\n  if (info?.props?.arrow === false) {\n    return {\n      container: {\n        backgroundColor: 'rgba(53, 71, 125, 0.8)',\n        padding: '12px',\n        borderRadius: '4px',\n      },\n      title: {\n        color: '#fff',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-popover\n      content=\"Object text\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    >\n      <a-button>Object Style</a-button>\n    </a-popover>\n    <a-popover\n      content=\"Function text\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n    >\n      <a-button type=\"primary\">\n        Function Style\n      </a-button>\n    </a-popover>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set absolute positioning, z-index, transform origin, arrow direction and popover container styles",
+          "descriptionZh": "根元素，设置绝对定位、层级、变换原点、箭头指向和弹层容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'container', desc: t('container') },\n  { name: 'title', desc: t('title') },\n  { name: 'content', desc: t('content') },\n  { name: 'arrow', desc: t('arrow') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Popover\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', marginTop: '60px' }\">\n        <a-popover\n          open\n          placement=\"top\"\n          title=\"Hello\"\n          content=\"Ant Design love you!\"\n          :auto-adjust-overflow=\"false\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "arrow",
+          "description": "Arrow element with width, height, position, color and border styles",
+          "descriptionZh": "箭头元素，设置宽高、位置、颜色和边框样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element, set title text styles and spacing",
+          "descriptionZh": "标题元素，设置标题文本样式和间距"
+        },
+        {
+          "key": "content",
+          "description": "Content element, set content text styles and layout",
+          "descriptionZh": "内容元素，设置内容文本样式和布局"
         }
       ]
     },
@@ -15660,14 +16400,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Progress by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Progress 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { ProgressProps } from 'antdv-next'\n\nconst classes: ProgressProps['classes'] = {\n  root: 'demo-progress-root',\n  rail: 'demo-progress-rail',\n  track: 'demo-progress-track',\n}\n\nconst stylesFn: ProgressProps['styles'] = (info) => {\n  const percent = info?.props?.percent ?? 0\n  const hue = 200 - (200 * percent) / 100\n  return {\n    track: {\n      backgroundImage: `\n        linear-gradient(\n          to right,\n          hsla(${hue}, 85%, 65%, 1),\n          hsla(${hue + 30}, 90%, 55%, 0.95)\n        )`,\n      borderRadius: 8,\n      transition: 'all 0.3s ease',\n    },\n    rail: {\n      backgroundColor: 'rgba(0, 0, 0, 0.1)',\n      borderRadius: 8,\n    },\n  } as ProgressProps['styles']\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"10\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"20\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"40\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"60\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"80\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"99\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set relative positioning and basic container styles",
+          "descriptionZh": "根元素，设置相对定位和基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'body', desc: t('body') },\n  { name: 'rail', desc: t('rail') },\n  { name: 'track', desc: t('track') },\n  { name: 'indicator', desc: t('indicator') },\n])\n\nconst gradient = ref(false)\nconst type = ref('line')\n\nconst colorMap = {\n  '0%': '#108ee9',\n  '100%': '#87d068',\n}\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Progress\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical gap=\"middle\" :style=\"{ width: '100%' }\" align=\"center\">\n        <a-flex align=\"center\" gap=\"middle\">\n          <a-segmented\n            :options=\"['line', 'steps', 'circle', 'dashboard']\"\n            :value=\"type\"\n            @change=\"(val: string) => type = val\"\n          />\n          <a-switch\n            :checked=\"gradient\"\n            checked-children=\"Gradient\"\n            un-checked-children=\"Gradient\"\n            @change=\"(val: boolean) => gradient = val\"\n          />\n        </a-flex>\n        <a-flex vertical align=\"center\" :style=\"{ height: '200px', width: '100%' }\">\n          <a-progress\n            :percent=\"80\"\n            :type=\"type === 'steps' ? 'line' : type\"\n            :steps=\"type === 'steps' ? 5 : undefined\"\n            :stroke-color=\"gradient ? colorMap : undefined\"\n            :classes=\"classes\"\n          />\n        </a-flex>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "body",
+          "description": "Body element, set progress bar layout and size styles",
+          "descriptionZh": "主体元素，设置进度条的布局和尺寸样式"
+        },
+        {
+          "key": "rail",
+          "description": "Rail element, set background track color and border radius styles. Not exist in steps mode",
+          "descriptionZh": "导轨元素，设置背景轨道的颜色和圆角样式，steps 模式下没有该元素"
+        },
+        {
+          "key": "track",
+          "description": "Track element, set progress fill color and transition animation styles",
+          "descriptionZh": "轨迹元素，设置进度填充部分的颜色和过渡动画样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element, set percentage text or icon position and font styles",
+          "descriptionZh": "指示器元素，设置百分比文本或图标的位置和字体样式"
         }
       ]
     },
@@ -15888,14 +16647,18 @@
           "description": "With Popover.",
           "descriptionZh": "带气泡卡片的例子。",
           "code": "<script setup lang=\"ts\">\ndefineOptions({ name: 'Popover' })\n</script>\n\n<template>\n  <a-popover>\n    <template #content>\n      <a-qrcode value=\"https://ant.design\" :bordered=\"false\" />\n    </template>\n    <a-button type=\"primary\">\n      Hover me\n    </a-button>\n  </a-popover>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set flex layout, padding, background color, border, border radius and relative positioning styles",
+          "descriptionZh": "根元素，设置flex布局、内边距、背景色、边框、圆角和相对定位样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'cover', desc: t('cover') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"QRCode\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-qrcode value=\"https://ant.design\" status=\"loading\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "cover",
+          "description": "Cover element, set absolute positioning, z-index, background color and loading state overlay styles",
+          "descriptionZh": "遮罩层元素，设置绝对定位、层级、背景色和加载状态覆盖样式"
         }
       ]
     },
@@ -16297,14 +17060,23 @@
           "description": "Solid radio button style.",
           "descriptionZh": "实色填底的单选按钮样式。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst value = shallowRef('a')\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-radio-group v-model:value=\"value\" button-style=\"solid\">\n      <a-radio-button value=\"a\">\n        Hangzhou\n      </a-radio-button>\n      <a-radio-button value=\"b\">\n        Shanghai\n      </a-radio-button>\n      <a-radio-button value=\"c\">\n        Beijing\n      </a-radio-button>\n      <a-radio-button value=\"d\">\n        Chengdu\n      </a-radio-button>\n    </a-radio-group>\n    <a-radio-group v-model:value=\"value\" button-style=\"solid\">\n      <a-radio-button value=\"a\">\n        Hangzhou\n      </a-radio-button>\n      <a-radio-button value=\"b\" disabled>\n        Shanghai\n      </a-radio-button>\n      <a-radio-button value=\"c\">\n        Beijing\n      </a-radio-button>\n      <a-radio-button value=\"d\">\n        Chengdu\n      </a-radio-button>\n    </a-radio-group>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with layout styles, cursor styles, disabled text color and other basic container styles",
+          "descriptionZh": "根元素，包含布局样式、鼠标样式、禁用状态文字颜色等基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Radio\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-radio :classes=\"classes\">\n        Radio\n      </a-radio>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element with border radius, transition animations, border styles, hover states, focus states and other interactive styles",
+          "descriptionZh": "选中框元素，包含圆角样式、过渡动画、边框样式、悬停状态、焦点状态等交互样式"
+        },
+        {
+          "key": "label",
+          "description": "Label element with padding, text color, disabled states, alignment and other text styles",
+          "descriptionZh": "文本元素，包含内边距、文字颜色、禁用状态、对齐方式等文本样式"
         }
       ]
     },
@@ -16580,7 +17352,8 @@
           "descriptionZh": "调试使用。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst value = ref(2.5)\n</script>\n\n<template>\n  <a-config-provider\n    :theme=\"{\n      components: {\n        Rate: {\n          starColor: 'blue',\n          starSize: 40,\n          starHoverScale: 'scale(2)',\n          starBg: 'red',\n        },\n      },\n    }\"\n  >\n    <a-rate v-model:value=\"value\" allow-half />\n  </a-config-provider>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Result",
@@ -16748,14 +17521,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Result by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Result 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { ResultProps } from 'antdv-next'\n\nconst classesObject: ResultProps['classes'] = {\n  root: 'demo-result-root',\n  title: 'demo-result-title',\n  subTitle: 'demo-result-subtitle',\n  icon: 'demo-result-icon',\n  extra: 'demo-result-extra',\n  body: 'demo-result-body',\n}\n\nconst classesFn: ResultProps['classes'] = (info) => {\n  if (info.props.status === 'success') {\n    return {\n      root: 'demo-result-root--success',\n    } satisfies ResultProps['classes']\n  }\n  return {\n    root: 'demo-result-root--default',\n  } satisfies ResultProps['classes']\n}\n\nconst stylesObject: ResultProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed', padding: '16px' },\n  title: { fontStyle: 'italic', color: '#1890ff' },\n  subTitle: { fontWeight: 'bold' },\n  icon: { opacity: 0.8 },\n  extra: { backgroundColor: '#f0f0f0', padding: 'px' },\n  body: { backgroundColor: '#fafafa', padding: '12px' },\n}\n\nconst stylesFn: ResultProps['styles'] = (info) => {\n  if (info.props.status === 'error') {\n    return {\n      root: { backgroundColor: '#fff2f0', borderColor: '#ff4d4f' },\n      title: { color: '#ff4d4f' },\n    } satisfies ResultProps['styles']\n  }\n  else {\n    return {\n      root: { backgroundColor: '#f6ffed', borderColor: '#52c41a' },\n      title: { color: '#52c41a' },\n    } satisfies ResultProps['styles']\n  }\n}\n</script>\n\n<template>\n  <a-result\n    status=\"info\"\n    title=\"classes Object\"\n    sub-title=\"This is a subtitle\"\n    :styles=\"stylesObject\"\n    :classes=\"classesObject\"\n  >\n    <template #extra>\n      <a-button type=\"primary\">\n        Action\n      </a-button>\n    </template>\n    <div>Content area</div>\n  </a-result>\n  <a-result\n    status=\"success\"\n    title=\"classes Function\"\n    sub-title=\"Dynamic class names\"\n    :styles=\"stylesFn\"\n    :classes=\"classesFn\"\n  >\n    <template #extra>\n      <a-button type=\"primary\">\n        Action\n      </a-button>\n    </template>\n  </a-result>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with text alignment, layout styles and other basic container styles",
+          "descriptionZh": "根元素，包含文本对齐、布局样式等基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'subTitle', desc: t('subTitle'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Result\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-result\n        title=\"title\"\n        sub-title=\"subTitle\"\n        :classes=\"classes\"\n      >\n        <template #extra>\n          <a-button type=\"primary\">\n            extra\n          </a-button>\n        </template>\n        <div :style=\"{ textAlign: 'center' }\">\n          The Content of Result\n        </div>\n      </a-result>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "title",
+          "description": "Title element with font size, text color, line height, text alignment and other text styles",
+          "descriptionZh": "标题元素，包含字体大小、文字颜色、行高、对齐方式等文字样式"
+        },
+        {
+          "key": "subTitle",
+          "description": "Subtitle element with font size, text color, line height and other text styles",
+          "descriptionZh": "副标题元素，包含字体大小、文字颜色、行高等文字样式"
+        },
+        {
+          "key": "body",
+          "description": "Content element with margin, padding, background color and other content area styles",
+          "descriptionZh": "内容元素，包含外边距、内边距、背景色等内容区域样式"
+        },
+        {
+          "key": "extra",
+          "description": "Action area element with margin, text alignment, inner element spacing and other layout styles",
+          "descriptionZh": "操作区域元素，包含外边距、文本对齐、内部元素间距等布局样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with margin, text alignment, font size, status colors and other icon styles",
+          "descriptionZh": "图标元素，包含外边距、文本对齐、字体大小、状态颜色等图标样式"
         }
       ]
     },
@@ -17019,14 +17816,28 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Segmented by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Segmented 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { SegmentedProps } from 'antdv-next'\nimport { CloudOutlined, RocketOutlined, ThunderboltOutlined } from '@antdv-next/icons'\nimport { h } from 'vue'\n\nconst classes: SegmentedProps['classes'] = {\n  root: 'custom-segmented-root',\n}\nconst styleFn: SegmentedProps['styles'] = (info) => {\n  if (info.props.vertical) {\n    return {\n      root: {\n        border: '1px solid #77BEF0',\n        padding: '4px',\n        width: '100px',\n      },\n      icon: {\n        color: '#77BEF0',\n      },\n      item: {\n        textAlign: 'start',\n      },\n    } satisfies SegmentedProps['styles']\n  }\n  return {}\n}\n\nconst styles: SegmentedProps['styles'] = {\n  root: {\n    padding: '4px',\n    width: '260px',\n  },\n}\n\nconst options: SegmentedProps['options'] = [\n  {\n    label: 'Boost',\n    value: 'boost',\n    icon: h(RocketOutlined),\n  },\n  {\n    label: 'Stream',\n    value: 'stream',\n    icon: h(ThunderboltOutlined),\n  },\n  {\n    label: 'Cloud',\n    value: 'cloud',\n    icon: h(CloudOutlined),\n  },\n]\nconst segmentedSharedProps: SegmentedProps = {\n  options,\n  classes,\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-segmented v-bind=\"segmentedSharedProps\" :styles=\"styles\" />\n    <a-segmented v-bind=\"segmentedSharedProps\" :styles=\"styleFn\" vertical />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with inline-block layout, padding, background, border radius, transition and container styles",
+          "descriptionZh": "根元素，设置行内块布局、内边距、背景色、圆角、过渡动画和容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AppstoreOutlined, BarsOutlined } from '@antdv-next/icons'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n])\n\nconst options = [\n  { label: 'List', value: 'List', icon: h(BarsOutlined) },\n  { label: 'Kanban', value: 'Kanban', icon: h(AppstoreOutlined) },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Segmented\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-segmented :options=\"options\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Option element with relative positioning, text alignment, cursor style, transition, selected state background and hover styles",
+          "descriptionZh": "选项元素，设置相对定位、文本对齐、光标样式、过渡动画、选中态背景色和悬停态样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with icon size, color and text spacing styles",
+          "descriptionZh": "图标元素，设置图标的尺寸、颜色和与文本的间距样式"
+        },
+        {
+          "key": "label",
+          "description": "Label content element with min height, line height, padding, text ellipsis and content layout styles",
+          "descriptionZh": "标签内容元素，设置最小高度、行高、内边距、文本省略和内容布局样式"
         }
       ]
     },
@@ -17868,14 +18679,73 @@
           "description": "You can customize the semantic dom style of Select by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "您可以通过 `classes` 和 `styles` 传入对象/函数来自定义 Select 的语义化 DOM 样式。",
           "code": "<script setup lang=\"ts\">\nimport { MehOutlined } from '@antdv-next/icons'\n\nconst options = [\n  { value: 'GuangZhou', label: 'GuangZhou' },\n  { value: 'ShenZhen', label: 'ShenZhen' },\n]\n\nconst stylesObject = {\n  prefix: {\n    color: '#1890ff',\n  },\n  suffix: {\n    color: '#1890ff',\n  },\n}\n\nconst stylesFilled = {\n  prefix: {\n    color: '#722ed1',\n  },\n  suffix: {\n    color: '#722ed1',\n  },\n  popup: {\n    root: {\n      border: '1px solid #722ed1',\n    },\n  },\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-select\n      :options=\"options\"\n      :classes=\"{ root: 'custom-select' }\"\n      :styles=\"stylesObject\"\n      placeholder=\"Object\"\n    >\n      <template #prefix>\n        <MehOutlined />\n      </template>\n    </a-select>\n    <a-select\n      :options=\"options\"\n      :classes=\"{ root: 'custom-select' }\"\n      :styles=\"stylesFilled\"\n      placeholder=\"Function\"\n      variant=\"filled\"\n    >\n      <template #prefix>\n        <MehOutlined />\n      </template>\n    </a-select>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, cursor styles, transitions, border and other basic selector container styles",
+          "descriptionZh": "根元素，包含相对定位、行内 flex 布局、光标样式、过渡动画、边框等选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst mode = ref<'single' | 'multiple'>('single')\n\nconst options = [\n  { value: 'aojunhao123', label: 'aojunhao123' },\n  { value: 'thinkasany', label: 'thinkasany' },\n  { value: 'meet-student', label: 'meet-student' },\n]\n\nconst value = computed(() => {\n  if (mode.value !== 'multiple')\n    return []\n\n  return options.length > 0\n    ? [options[0]!.value]\n    : []\n})\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => {\n  const base = [\n    { name: 'root', desc: t('root') },\n    { name: 'prefix', desc: t('prefix') },\n    { name: 'content', desc: t('content') },\n    { name: 'placeholder', desc: t('placeholder') },\n    { name: 'clear', desc: t('clear') },\n    { name: 'input', desc: t('input') },\n    { name: 'suffix', desc: t('suffix') },\n    { name: 'popup.root', desc: t('popup.root') },\n    { name: 'popup.list', desc: t('popup.list') },\n    { name: 'popup.listItem', desc: t('popup.listItem') },\n  ]\n\n  if (mode.value === 'multiple') {\n    return [\n      ...base,\n      { name: 'item', desc: t('item') },\n      { name: 'itemContent', desc: t('itemContent') },\n      { name: 'itemRemove', desc: t('itemRemove') },\n    ]\n  }\n\n  return base\n})\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Select\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <div :style=\"{ display: 'flex', justifyContent: 'center', marginBottom: '12px' }\">\n          <a-segmented v-model:value=\"mode\" :options=\"['single', 'multiple']\" />\n        </div>\n        <div :style=\"{ display: 'flex', flexDirection: 'column', gap: '12px' }\">\n          <a-select\n            prefix=\"prefix\"\n            :style=\"{ width: '300px' }\"\n            :options=\"options\"\n            :value=\"value\"\n            :mode=\"mode === 'multiple' ? 'multiple' : undefined\"\n            open\n            :get-popup-container=\"() => divRef!\"\n            :classes=\"classes\"\n          />\n        </div>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with layout and styling for prefix content",
+          "descriptionZh": "前缀元素，包含前缀内容的布局和样式"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "clear",
+          "description": "Clear button element with layout, styling and interactive effects for clear button",
+          "descriptionZh": "清除按钮元素，包含清除按钮的布局、样式和交互效果"
+        },
+        {
+          "key": "input",
+          "description": "Input element with search input styling, cursor control, font inheritance and other search-related styles. Remove border styles",
+          "descriptionZh": "输入框元素，包含搜索输入框的样式、光标控制、字体继承等搜索相关样式，去除了边框样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with layout and styling for suffix content like clear button, arrow icon, etc.",
+          "descriptionZh": "后缀元素，包含后缀内容的布局和样式，如清除按钮、箭头图标等"
+        },
+        {
+          "key": "item",
+          "description": "Multiple selection item element with border, background, padding, and margin styles",
+          "descriptionZh": "多选项元素，包含边框、背景、内边距、外边距样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Multiple selection item content area with text ellipsis styles",
+          "descriptionZh": "多选项内容区域，包含文字的省略样式"
+        },
+        {
+          "key": "itemRemove",
+          "description": "Multiple selection item remove button with font-related styless",
+          "descriptionZh": "多选项移除按钮，包含字体相关样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with popup layer positioning, z-index, background, border, box-shadow and other popup container styles",
+          "descriptionZh": "弹出菜单元素，包含弹出层的定位、层级、背景、边框、阴影等弹出容器样式"
+        },
+        {
+          "key": "popup.list",
+          "description": "Popup list element with option list layout, scrolling, max-height and other list container styles",
+          "descriptionZh": "弹出菜单列表元素，包含选项列表的布局、滚动、最大高度等列表容器样式"
+        },
+        {
+          "key": "popup.listItem",
+          "description": "Popup item element with option item padding, hover effects, selected states, disabled states and other option interactive styles",
+          "descriptionZh": "弹出菜单条目元素，包含选项项的内边距、悬浮效果、选中状态、禁用状态等选项交互样式"
         }
       ]
     },
@@ -18330,22 +19200,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Skeleton by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Skeleton 组件的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nconst classes = {\n  root: 'skeleton-root',\n  header: 'skeleton-header',\n}\n\nconst styles = {\n  avatar: {\n    border: '1px solid #aaa',\n  },\n  title: {\n    border: '1px solid #aaa',\n  },\n}\n\nfunction stylesFn(info: { props: { active?: boolean } }) {\n  if (info.props?.active) {\n    return {\n      root: {\n        border: '1px solid rgba(229, 243, 254, 0.3)',\n      },\n      title: {\n        backgroundColor: 'rgba(229, 243, 254, 0.5)',\n        height: '20px',\n        borderRadius: '20px',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-skeleton\n      :classes=\"classes\"\n      :styles=\"styles\"\n      avatar\n      :paragraph=\"false\"\n    />\n    <a-skeleton\n      :classes=\"{ ...classes, paragraph: 'skeleton-paragraph' }\"\n      :styles=\"stylesFn\"\n      active\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with table display, width, animation effects, border radius and other skeleton container basic styles",
+          "descriptionZh": "根元素，包含表格显示、宽度、动画效果、圆角等骨架屏容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'avatar', desc: t('avatar'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'paragraph', desc: t('paragraph'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Skeleton\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-skeleton avatar :paragraph=\"{ rows: 4 }\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with table cell, padding, vertical alignment and other avatar placeholder area layout styles",
+          "descriptionZh": "头部元素，包含表格单元格、内边距、垂直对齐等头像占位区域的布局样式"
         },
         {
-          "name": "_semantic_element",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport type { SegmentedOptions } from 'antdv-next'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\ntype SkeletonElement = 'Avatar' | 'Button' | 'Input' | 'Image' | 'Node'\nconst internalOptions: SegmentedOptions = ['Avatar', 'Button', 'Input', 'Image', 'Node']\n\nconst element = ref<SkeletonElement>('Avatar')\n\nconst componentMap: Record<SkeletonElement, string> = {\n  Avatar: 'a-skeleton-avatar',\n  Button: 'a-skeleton-button',\n  Input: 'a-skeleton-input',\n  Image: 'a-skeleton-image',\n  Node: 'a-skeleton-node',\n}\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('element.root'), version: '1.0.0' },\n  { name: 'content', desc: t('element.content'), version: '1.0.0' },\n])\n\nconst componentName = computed(() => `Skeleton.${element.value}`)\nconst currentComponent = computed(() => componentMap[element.value])\n</script>\n\n<template>\n  <SemanticPreview\n    :component-name=\"componentName\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical :style=\"{ width: 'fit-content', marginInlineEnd: 'auto' }\">\n        <a-segmented v-model:value=\"element\" :options=\"internalOptions\" />\n        <a-divider title-placement=\"start\" plain>\n          {{ t('element.preview') }}\n        </a-divider>\n        <component :is=\"currentComponent\" :classes=\"classes\" />\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Section element with skeleton content area layout styles",
+          "descriptionZh": "区块元素，包含骨架屏内容区域的布局样式"
+        },
+        {
+          "key": "avatar",
+          "description": "Avatar element with inline-block display, vertical alignment, background color, size, border radius and other avatar placeholder styles",
+          "descriptionZh": "头像元素，包含行内块显示、垂直对齐、背景色、尺寸、圆角等头像占位的样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with width, height, background color, border radius and other title placeholder styles",
+          "descriptionZh": "标题元素，包含宽度、高度、背景色、圆角等标题占位的样式"
+        },
+        {
+          "key": "paragraph",
+          "description": "Paragraph element with padding, list item styles, background color, border radius and other paragraph placeholder styles",
+          "descriptionZh": "段落元素，包含内边距、列表项样式、背景色、圆角等段落占位的样式"
+        },
+        {
+          "key": "element.root",
+          "description": "Root element",
+          "descriptionZh": "根元素"
+        },
+        {
+          "key": "element.content",
+          "description": "Content element",
+          "descriptionZh": "内容元素"
+        },
+        {
+          "key": "element.preview",
+          "description": "Preview",
+          "descriptionZh": "预览"
         }
       ]
     },
@@ -18743,14 +19644,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Sliders by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Sliders 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst value = ref(30)\nconst valueVertical = ref(30)\n\nconst stylesObject = {\n  track: { backgroundImage: 'linear-gradient(180deg, #91caff, #1677ff)' },\n  handle: { borderColor: '#1677ff', boxShadow: '0 2px 8px #1677ff' },\n}\n\nfunction stylesFn(info: any) {\n  if (info.props.orientation === 'vertical') {\n    return {\n      root: { height: '300px' },\n      track: { backgroundImage: 'linear-gradient(180deg, #722cc0, #722ed1)' },\n      handle: { borderColor: '#722ed1', boxShadow: '0 2px 8px #722ed1' },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-slider v-model:value=\"value\" class=\"custom-slider\" :styles=\"stylesObject\" />\n    <a-slider\n      v-model:value=\"valueVertical\"\n      class=\"custom-slider-vertical\"\n      orientation=\"vertical\"\n      reverse\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, height, margin, padding, cursor style and touch action control",
+          "descriptionZh": "根元素，设置相对定位、高度、边距、内边距、光标样式和触摸事件控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'track', desc: t('track'), version: '1.0.0' },\n  { name: 'tracks', desc: t('tracks'), version: '1.0.0' },\n  { name: 'rail', desc: t('rail'), version: '1.0.0' },\n  { name: 'handle', desc: t('handle'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Slider\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-slider\n        range\n        :default-value=\"[20, 30, 50]\"\n        :style=\"{ width: '100%' }\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "track",
+          "description": "Track selection bar element with absolute positioning, background color, border radius and transition animation styles",
+          "descriptionZh": "轨道选取条元素，设置绝对定位、背景色、圆角和过渡动画样式"
+        },
+        {
+          "key": "tracks",
+          "description": "Multi-segment track container element with absolute positioning and transition animation styles",
+          "descriptionZh": "多段轨道容器元素，设置绝对定位和过渡动画样式"
+        },
+        {
+          "key": "rail",
+          "description": "Background rail element with absolute positioning, background color, border radius and transition animation styles",
+          "descriptionZh": "背景轨道元素，设置绝对定位、背景色、圆角和过渡动画样式"
+        },
+        {
+          "key": "handle",
+          "description": "Slider handle control element with absolute positioning, size, outline, user selection, background color, border shadow, border radius, cursor style and transition animation",
+          "descriptionZh": "滑块控制点元素，设置绝对定位、尺寸、轮廓线、用户选择、背景色、边框阴影、圆角、光标样式和过渡动画"
         }
       ]
     },
@@ -18958,14 +19878,23 @@
           "description": "Customize semantic structure styles and class names. Supports both object and function forms.",
           "descriptionZh": "自定义语义化结构的样式和类名。支持对象和函数两种形式。",
           "code": "<script setup lang=\"ts\">\nimport type { SpaceProps } from 'antdv-next'\n\nconst classNamesObject: SpaceProps['classes'] = {\n  root: 'demo-space-root',\n  item: 'demo-space-item',\n  separator: 'demo-space-separator',\n}\n\nconst classNamesFn: SpaceProps['classes'] = (info) => {\n  if (info.props.orientation === 'vertical') {\n    return {\n      root: 'demo-space-root--vertical',\n    } satisfies SpaceProps['classes']\n  }\n  else {\n    return {\n      root: 'demo-space-root--horizontal',\n    } satisfies SpaceProps['classes']\n  }\n}\n\nconst stylesObject: SpaceProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed', padding: '8px', marginBottom: '10px' },\n  item: { backgroundColor: '#f0f0f0', padding: '4px' },\n  separator: { color: 'red', fontWeight: 'bold' },\n}\n\nconst stylesFn: SpaceProps['styles'] = (info) => {\n  if (info.props.size === 'large') {\n    return {\n      root: {\n        backgroundColor: '#e6f7ff',\n        borderColor: '#1890ff',\n        padding: '8px',\n      },\n    } satisfies SpaceProps['styles']\n  }\n  else {\n    return {\n      root: {\n        backgroundColor: '#fff7e6',\n        borderColor: '#fa8c16',\n      },\n    } satisfies SpaceProps['styles']\n  }\n}\n</script>\n\n<template>\n  <div>\n    <a-space :styles=\"stylesObject\" :classes=\"classNamesObject\" separator=\"•\">\n      <a-button>Styled Button 1</a-button>\n      <a-button>Styled Button 2</a-button>\n      <a-button>Styled Button 3</a-button>\n    </a-space>\n    <a-space size=\"large\" :styles=\"stylesFn\" :classes=\"classNamesFn\">\n      <a-button>Large Space Button 1</a-button>\n      <a-button>Large Space Button 2</a-button>\n      <a-button>Large Space Button 3</a-button>\n    </a-space>\n  </div>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, gap settings, alignment, wrap and other spacing container basic styles",
+          "descriptionZh": "根元素，包含 flex 布局、间隙设置、对齐方式、换行等间距容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n  { name: 'separator', desc: t('separator') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Space\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-space :classes=\"classes\">\n        <template #separator>\n          <a-divider vertical />\n        </template>\n        <a-button type=\"primary\">\n          Primary\n        </a-button>\n        <a-button>Default</a-button>\n        <a-button type=\"dashed\">\n          Dashed\n        </a-button>\n      </a-space>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Wrapped item element with spacing item layout and styles, providing wrapper for each child element for inline alignment",
+          "descriptionZh": "包裹的子组件，包含间距项的布局和样式，为每个子元素提供包装用于内联对齐"
+        },
+        {
+          "key": "separator",
+          "description": "Separator element with divider styling",
+          "descriptionZh": "分隔符，包含分隔元素的样式"
         }
       ]
     },
@@ -19170,14 +20099,18 @@
           "description": "The `fullscreen` mode is perfect for creating page loaders. It adds a dimmed overlay with a centered spinner.",
           "descriptionZh": "`fullscreen` 属性非常适合创建流畅的页面加载器。它添加了半透明覆盖层，并在其中心放置了一个旋转加载符号。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst spinning = ref(false)\nconst percent = ref(0)\n\nfunction showLoader() {\n  spinning.value = true\n  let ptg = -10\n\n  const interval = setInterval(() => {\n    ptg += 5\n    percent.value = ptg\n\n    if (ptg > 120) {\n      clearInterval(interval)\n      spinning.value = false\n      percent.value = 0\n    }\n  }, 100)\n}\n</script>\n\n<template>\n  <div>\n    <a-button @click=\"showLoader\">\n      Show fullscreen\n    </a-button>\n    <a-spin :spinning=\"spinning\" :percent=\"percent\" fullscreen />\n  </div>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with absolute positioning, display control, color, font size, text alignment, vertical alignment, opacity and transition animation (effective when fullscreen is false)",
+          "descriptionZh": "根元素，设置绝对定位、显示控制、颜色、字体大小、文本对齐、垂直对齐、透明度和过渡动画(fullscreen 为 false 时才有效)"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Spin\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div\n        :style=\"{\n          position: 'relative',\n          width: '500px',\n          height: '100px',\n          display: 'flex',\n          alignItems: 'center',\n          justifyContent: 'center',\n        }\"\n      >\n        <a-spin :percent=\"0\" :classes=\"classes\" />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "indicator",
+          "description": "Indicator element with width, height, font size, inline-block display, transition animation, transform origin, line height and color",
+          "descriptionZh": "指示器元素，设置宽度、高度、字体大小、行内块显示、过渡动画、变换原点、行高和颜色"
         }
       ]
     },
@@ -19460,14 +20393,23 @@
           "description": "Customize semantic structure styles and class names. Supports both object and function forms.",
           "descriptionZh": "自定义语义化结构的样式和类名。支持对象和函数两种形式。",
           "code": "<script setup lang=\"ts\">\nimport type { SplitterProps } from 'antdv-next'\n\nconst stylesObject: SplitterProps['styles'] = {\n  root: { backgroundColor: '#fffbe6' },\n  dragger: { backgroundColor: 'rgba(194,223,252,0.4)' },\n}\n\nconst stylesFn: SplitterProps['styles'] = ({ props }) => {\n  if (props.orientation === 'horizontal') {\n    return {\n      root: {\n        borderWidth: '2px',\n        borderStyle: 'dashed',\n        marginBottom: '10px',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-splitter\n      style=\"height: 200px\"\n      root-class=\"shadow-secondary\"\n      :styles=\"stylesObject\"\n    >\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\" style=\"color: #000\">\n            First\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\" style=\"color: #000\">\n            Second\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n    </a-splitter>\n    <a-splitter\n      style=\"height: 200px\"\n      root-class=\"shadow-secondary\"\n      :styles=\"stylesFn\"\n    >\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\">\n            First\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\">\n            Second\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n    </a-splitter>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, width and height, alignment and stretch styles",
+          "descriptionZh": "根元素，设置flex布局、宽度高度、对齐方式和拉伸样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'panel', desc: t('panel'), version: '1.0.0' },\n  { name: 'dragger', desc: t('dragger'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Splitter\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-splitter\n        :style=\"{ height: '200px', boxShadow: '0 0 10px rgba(0, 0, 0, 0.1)' }\"\n        :classes=\"classes\"\n      >\n        <a-splitter-panel>\n          <div :style=\"{ display: 'flex', height: '100%', alignItems: 'center', justifyContent: 'center' }\">\n            First\n          </div>\n        </a-splitter-panel>\n        <a-splitter-panel>\n          <div :style=\"{ display: 'flex', height: '100%', alignItems: 'center', justifyContent: 'center' }\">\n            Second\n          </div>\n        </a-splitter-panel>\n      </a-splitter>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "panel",
+          "description": "Panel element with flex basis, grow ratio and panel container styles",
+          "descriptionZh": "面板元素，设置flex基础值、增长比例和面板容器样式"
+        },
+        {
+          "key": "dragger",
+          "description": "Drag control element with absolute positioning, user selection, z-index, center alignment, background color, hover and active states styles",
+          "descriptionZh": "拖拽控制元素，设置绝对定位、用户选择、层级、居中对齐、背景色、悬停态和激活态样式"
         }
       ]
     },
@@ -19668,14 +20610,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of the Statistic by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Statistic 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { StatisticProps } from 'antdv-next'\nimport { ArrowDownOutlined, ArrowUpOutlined } from '@antdv-next/icons'\n\nconst classes = {\n  root: 'custom-statistic-root',\n}\nconst styleFn: StatisticProps['styles'] = ({ props }) => {\n  const numValue = Number(props.value ?? 0)\n  const isNegative = Number.isFinite(numValue) && numValue < 0\n  if (isNegative) {\n    return {\n      title: {\n        color: '#ff4d4f',\n      },\n      content: {\n        color: '#ff7875',\n      },\n    } satisfies StatisticProps['styles']\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-statistic\n      :value=\"93241\"\n      title=\"Monthly Active Users\"\n      :classes=\"classes\"\n      :styles=\"{ title: { color: '#1890ff', fontWeight: '600px' }, content: { fontSize: '24px' } }\"\n      suffix=\"users\"\n    >\n      <template #prefix>\n        <ArrowUpOutlined />\n      </template>\n    </a-statistic>\n\n    <a-statistic\n      :value=\"-18.7\"\n      title=\"Yearly Loss\"\n      :precision=\"1\"\n      :classes=\"classes\"\n      :styles=\"styleFn\"\n      suffix=\"%\"\n    >\n      <template #prefix>\n        <ArrowDownOutlined />\n      </template>\n    </a-statistic>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with reset styles and overall container styles for statistic component",
+          "descriptionZh": "根元素，包含统计数值组件的重置样式和整体容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { ArrowUpOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'prefix', desc: t('prefix'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'suffix', desc: t('suffix'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Statistic\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ position: 'absolute' }\">\n        <a-statistic\n          title=\"Active\"\n          :value=\"11.28\"\n          :precision=\"2\"\n          :styles=\"{ content: { color: '#3f8600' } }\"\n          suffix=\"%\"\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <ArrowUpOutlined />\n          </template>\n        </a-statistic>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with bottom padding and title area layout styles",
+          "descriptionZh": "头部元素，包含下内边距和标题区域的布局样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text color, font size and other title text display styles",
+          "descriptionZh": "标题元素，包含文字颜色、字体大小等标题文字的显示样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with text color, font size, font family and other numeric content display styles",
+          "descriptionZh": "内容元素，包含文字颜色、字体大小、字体族等数值内容的展示样式"
+        },
+        {
+          "key": "prefix",
+          "description": "Prefix element with inline-block display, right margin and other prefix content layout styles",
+          "descriptionZh": "前缀元素，包含行内块显示、右外边距等前缀内容的布局样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with inline-block display, left margin and other suffix content layout styles",
+          "descriptionZh": "后缀元素，包含行内块显示、左外边距等后缀内容的布局样式"
         }
       ]
     },
@@ -19981,14 +20947,58 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Steps by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Steps 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { StepsProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: StepsProps['classes'] = {\n  root: 'steps-demo-root',\n}\n\nconst stylesObject: StepsProps['styles'] = {\n  itemIcon: {\n    borderRadius: '30%',\n  },\n  itemContent: {\n    fontStyle: 'italic',\n  },\n}\n\nconst stylesFn: StepsProps['styles'] = (info) => {\n  if (info?.props?.type === 'navigation') {\n    return {\n      root: {\n        borderColor: '#1890ff',\n      },\n    }\n  }\n  return {}\n}\n\nconst items: StepsProps['items'] = [\n  { title: 'Finished', content: 'This is a content.' },\n  { title: 'In Progress', content: 'This is a content.' },\n  { title: 'Waiting', content: 'This is a content.' },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-steps :items=\"items\" :current=\"1\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-steps\n      :items=\"items\"\n      :current=\"1\"\n      type=\"navigation\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, nowrap, alignment, CSS variables and other basic step container styles",
+          "descriptionZh": "根元素，包含 flex 布局、禁止换行、对齐方式、CSS 变量等步骤条容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemWrapper', desc: t('itemWrapper') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n  { name: 'itemHeader', desc: t('itemHeader') },\n  { name: 'itemTitle', desc: t('itemTitle') },\n  { name: 'itemSubtitle', desc: t('itemSubtitle') },\n  { name: 'itemSection', desc: t('itemSection') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'itemRail', desc: t('itemRail') },\n])\n\nconst items = [\n  { title: 'Step 1', subTitle: '00:01', content: 'This is a content.' },\n  { title: 'Step 2', subTitle: '00:02', content: 'This is a content.' },\n  { title: 'Step 3', subTitle: '00:03', content: 'This is a content.' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Steps\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical gap=\"large\" :style=\"{ width: '100%' }\">\n        <a-steps\n          :current=\"1\"\n          :style=\"{ width: '100%' }\"\n          title-placement=\"vertical\"\n          :items=\"items\"\n          :classes=\"classes\"\n        />\n        <a-steps\n          :current=\"1\"\n          :style=\"{ width: '100%' }\"\n          type=\"panel\"\n          size=\"small\"\n          title-placement=\"horizontal\"\n          :items=\"items\"\n          :classes=\"classes\"\n        />\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Step item element with flex layout, relative positioning and other basic step item container styles",
+          "descriptionZh": "步骤项元素，包含 flex 布局、相对定位等单个步骤项的基础容器样式"
+        },
+        {
+          "key": "itemWrapper",
+          "description": "Step item wrapper element with flex layout, nowrap, top padding and other step content wrapping styles",
+          "descriptionZh": "步骤项内裹元素，包含 flex 布局、禁止换行、顶部内边距等步骤项内容的包装样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Step item icon element with icon size, positioning, font-size and other icon display related styles",
+          "descriptionZh": "步骤项图标元素，包含图标的尺寸、定位、字体大小等图标显示相关样式"
+        },
+        {
+          "key": "itemHeader",
+          "description": "Step item header element with flex layout, nowrap, alignment and other header area layout styles",
+          "descriptionZh": "步骤项头部元素，包含 flex 布局、禁止换行、对齐方式等头部区域的布局样式"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Step item title element with color, font-size, line-height, word-break, transitions and other title text styles",
+          "descriptionZh": "步骤项标题元素，包含颜色、字体大小、行高、文字换行、过渡动画等标题文字样式"
+        },
+        {
+          "key": "itemSubtitle",
+          "description": "Step item subtitle element with color, font-weight, font-size, line-height, margin, word-break and other subtitle styles",
+          "descriptionZh": "步骤项副标题元素，包含颜色、字体权重、字体大小、行高、外边距、文字换行等副标题样式"
+        },
+        {
+          "key": "itemSection",
+          "description": "Step item section element with step content area layout and styling",
+          "descriptionZh": "步骤项区域元素，包含步骤项内容区域的布局和样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Step item content element with color, font-size, line-height, word-break, transitions and other content text styles",
+          "descriptionZh": "步骤项内容元素，包含颜色、字体大小、行高、文字换行、过渡动画等内容文字样式"
+        },
+        {
+          "key": "itemRail",
+          "description": "Step item rail element with border-style, border-width, transitions and other connecting line styles",
+          "descriptionZh": "步骤项连接线元素，包含边框样式、边框宽度、过渡动画等连接线的样式"
         }
       ]
     },
@@ -20287,14 +21297,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Switch by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Switch 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes = {\n  root: 'custom-switch-root',\n}\n\nconst stylesObject = {\n  root: {\n    backgroundColor: '#F5D2D2',\n  },\n}\n\nfunction stylesFn(info: any) {\n  if (info.props.size === 'default') {\n    return {\n      root: {\n        backgroundColor: '#BDE3C3',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-switch\n      size=\"small\"\n      checked-children=\"on\"\n      un-checked-children=\"off\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n    />\n    <a-switch :classes=\"classes\" size=\"default\" :styles=\"stylesFn\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with min-width, height, line-height, vertical alignment, background color, border, border radius, cursor style, transition animations, user selection and other basic switch container styles",
+          "descriptionZh": "根元素，包含最小宽度、高度、行高、垂直对齐、背景色、边框、圆角、光标样式、过渡动画、用户选择等开关容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.3' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Switch\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-switch\n        checked-children=\"on\"\n        un-checked-children=\"off\"\n        default-checked\n        disabled\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "content",
+          "description": "Content element with block display, overflow hidden, border radius, height, padding, transition animations and other switch content area layout and styles",
+          "descriptionZh": "内容元素，包含块级显示、溢出隐藏、圆角、高度、内边距、过渡动画等开关内容区域的布局和样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element with absolute positioning, width, height, background color, border radius, shadow, transition animations and other switch handle styles and interactive effects",
+          "descriptionZh": "指示器元素,包含绝对定位、宽度、高度、背景色、圆角、阴影、过渡动画等开关把手的样式和交互效果"
         }
       ]
     },
@@ -21092,14 +22111,73 @@
           "description": "Customize header and body cells via the headerCell and bodyCell slots.",
           "descriptionZh": "通过 headerCell 与 bodyCell 插槽自定义表头和单元格内容。",
           "code": "<script setup lang=\"ts\">\nimport type { TableProps } from 'antdv-next'\n\ninterface DataItem {\n  key: string\n  name: string\n  age: number\n  address: string\n}\n\nconst columns: TableProps['columns'] = [\n  {\n    title: 'Name',\n    dataIndex: 'name',\n    key: 'name',\n  },\n  {\n    title: 'Age',\n    dataIndex: 'age',\n    key: 'age',\n  },\n  {\n    title: 'Address',\n    dataIndex: 'address',\n    key: 'address',\n  },\n  {\n    title: 'Action',\n    key: 'action',\n  },\n]\n\nconst dataSource: DataItem[] = [\n  {\n    key: '1',\n    name: 'John Brown',\n    age: 32,\n    address: 'New York No. 1 Lake Park',\n  },\n  {\n    key: '2',\n    name: 'Jim Green',\n    age: 42,\n    address: 'London No. 1 Lake Park',\n  },\n  {\n    key: '3',\n    name: 'Joe Black',\n    age: 32,\n    address: 'Sydney No. 1 Lake Park',\n  },\n]\n\nfunction handleAction(record: Record<string, any>) {\n  console.log('Action:', record.name)\n}\n</script>\n\n<template>\n  <a-table :columns=\"columns\" :data-source=\"dataSource\">\n    <template #headerCell=\"{ column }\">\n      <template v-if=\"column.key === 'name'\">\n        <span class=\"table-header-strong\">{{ column.title }}</span>\n      </template>\n    </template>\n    <template #bodyCell=\"{ column, text, record }\">\n      <template v-if=\"column.key === 'name'\">\n        <a class=\"table-name\" @click.prevent=\"handleAction(record)\">{{ text }}</a>\n      </template>\n      <template v-else-if=\"column.key === 'action'\">\n        <a @click.prevent=\"handleAction(record)\">Action</a>\n      </template>\n    </template>\n  </a-table>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with font-size, background, border-radius, scrollbar-color and other basic table container styles",
+          "descriptionZh": "根元素，包含字体大小、背景色、圆角、滚动条颜色等表格容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'title', desc: t('title') },\n  { name: 'content', desc: t('content') },\n  { name: 'header.wrapper', desc: t('header.wrapper') },\n  { name: 'header.row', desc: t('header.row') },\n  { name: 'header.cell', desc: t('header.cell') },\n  { name: 'section', desc: t('section') },\n  { name: 'body.wrapper', desc: t('body.wrapper') },\n  { name: 'body.row', desc: t('body.row') },\n  { name: 'body.cell', desc: t('body.cell') },\n  { name: 'footer', desc: t('footer') },\n  { name: 'pagination.root', desc: t('pagination.root') },\n  { name: 'pagination.item', desc: t('pagination.item') },\n])\n\nconst columns = [\n  {\n    title: 'Personal Info',\n    children: [\n      { title: 'Name', dataIndex: 'name', key: 'name' },\n      { title: 'Age', dataIndex: 'age', key: 'age' },\n    ],\n  },\n  { title: 'Address', dataIndex: 'address' },\n]\n\nconst data = [\n  { key: '1', name: 'thinkasany', age: 24, address: 'New York No. 1 Lake Park' },\n  { key: '2', name: 'Jim Green', age: 42, address: 'London No. 1 Lake Park' },\n  { key: '3', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n  { key: '4', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n  { key: '5', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n  { key: '6', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Table\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-table\n        bordered\n        :style=\"{ width: '100%' }\"\n        :columns=\"columns\"\n        :data-source=\"data\"\n        size=\"middle\"\n        :pagination=\"{ pageSize: 3 }\"\n        :classes=\"classes\"\n      >\n        <template #title>\n          table title\n        </template>\n        <template #footer>\n          table footer\n        </template>\n      </a-table>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Container element with clear-fix, max-width, scrollbar background and other table wrapper styles",
+          "descriptionZh": "容器元素，包含清除浮动、最大宽度、滚动条背景等表格包装容器样式"
+        },
+        {
+          "key": "header.wrapper",
+          "description": "Header wrapper element with table header layout and container styles",
+          "descriptionZh": "头部容器元素，包含表头的布局和容器样式"
+        },
+        {
+          "key": "header.row",
+          "description": "Header row element with table header row layout and styling",
+          "descriptionZh": "头部行元素，包含表头行的布局和样式"
+        },
+        {
+          "key": "header.cell",
+          "description": "Header cell element with relative positioning, padding, word-wrap, background, text color, font-weight and other header cell styles",
+          "descriptionZh": "头部单元格元素，包含相对定位、内边距、文字换行、背景色、文字颜色、字体权重等表头单元格样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with table title styling and layout",
+          "descriptionZh": "标题元素，包含表格标题的样式和布局"
+        },
+        {
+          "key": "body.wrapper",
+          "description": "Body wrapper element with table body layout and container styles",
+          "descriptionZh": "主体容器元素，包含表格主体的布局和容器样式"
+        },
+        {
+          "key": "body.row",
+          "description": "Body row element with hover effects, selected states, expanded states and other interactive row styles",
+          "descriptionZh": "主体行元素，包含数据行的悬浮效果、选中状态、展开状态等交互样式"
+        },
+        {
+          "key": "body.cell",
+          "description": "Body cell element with relative positioning, padding, word-wrap and other basic data cell styles",
+          "descriptionZh": "主体单元格元素，包含相对定位、内边距、文字换行等数据单元格的基础样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with table footer background color, text color and other footer styles",
+          "descriptionZh": "底部元素，包含表格底部的背景色、文字颜色等样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with table content area styling and layout",
+          "descriptionZh": "内容元素，包含表格内容区域的样式和布局"
+        },
+        {
+          "key": "pagination.root",
+          "description": "Pagination root element with pagination component basic styles and layout",
+          "descriptionZh": "分页根元素，包含分页组件的基础样式和布局"
+        },
+        {
+          "key": "pagination.item",
+          "description": "Pagination item element with pagination item styling and interactive effects",
+          "descriptionZh": "分页单项元素，包含分页项的样式和交互效果"
         }
       ]
     },
@@ -21604,14 +22682,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tabs by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tabs 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TabsProps } from 'antdv-next'\n\nconst items: TabsProps['items'] = [\n  { key: '1', label: 'Tab 1', content: 'Content of Tab Pane 1' },\n  { key: '2', label: 'Tab 2', content: 'Content of Tab Pane 2' },\n  { key: '3', label: 'Tab 3', content: 'Content of Tab Pane 3' },\n]\n\nconst classes: TabsProps['classes'] = {\n  root: 'custom-tabs-root',\n}\n\nconst stylesObject: TabsProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed', padding: '16px', marginBottom: '10px' },\n  header: { backgroundColor: 'rgba(245,245,245,0.5)' },\n  item: { fontWeight: 'bold', color: '#1890ff', padding: `6px 10px` },\n  indicator: { backgroundColor: 'rgba(255,77,79, 0.3)', height: '4px' },\n  content: { backgroundColor: 'rgba(230,247,255,0.8)', padding: '16px' },\n}\n\nconst stylesFn: TabsProps['styles'] = (info) => {\n  if (info.props.type === 'card') {\n    return {\n      root: { backgroundColor: 'rgba(250,250,250, 0.8)', borderColor: '#d9d9d9' },\n      header: { textAlign: 'start' },\n    } satisfies TabsProps['styles']\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-tabs :items=\"items\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-tabs type=\"card\" :items=\"items\" :classes=\"classes\" :styles=\"stylesFn\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with basic tab container styles, layout and direction control",
+          "descriptionZh": "根元素，包含标签页容器的基础样式、布局和方向控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'header', desc: t('header') },\n  { name: 'item', desc: t('item') },\n  { name: 'indicator', desc: t('indicator') },\n  { name: 'content', desc: t('content') },\n  { name: 'popup.root', desc: t('popup.root') },\n])\n\nconst items = computed(() =>\n  Array.from({ length: 30 }, (_, i) => {\n    const id = String(i)\n    return {\n      label: `Tab-${id}`,\n      key: id,\n      disabled: i === 28,\n      children: `Content of tab ${id}`,\n    }\n  }),\n)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tabs\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-tabs\n        default-active-key=\"1\"\n        :style=\"{ height: '220px', width: '100%' }\"\n        :styles=\"{\n          popup: {\n            root: { background: '#fff' },\n          },\n        }\"\n        :items=\"items\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with relative positioning, padding, colors, text ellipsis, border-radius, transitions and other tab item styles and interactive effects",
+          "descriptionZh": "Item 元素，包含相对定位、内边距、颜色、文本省略、圆角、过渡动画等标签项的样式和交互效果"
+        },
+        {
+          "key": "header",
+          "description": "Header element with tab navigation header layout, background, borders and other styles",
+          "descriptionZh": "头部元素，包含标签页头部导航的布局、背景、边框等样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element with indicator bar color, position, dimensions, transitions and other active state indication styles",
+          "descriptionZh": "指示器元素，包含指示条的颜色、位置、尺寸、过渡动画等活跃状态指示样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with tab content panel layout, padding and other content display styles",
+          "descriptionZh": "内容元素，包含标签页内容面板的布局、内边距等内容展示样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup menu element with dropdown absolute positioning, z-index, display control, max-height, scrolling and other styles",
+          "descriptionZh": "弹出菜单元素，包含下拉菜单的绝对定位、层级、显示控制、最大高度、滚动等样式"
         }
       ]
     },
@@ -21923,14 +23025,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tag by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tag 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { CheckCircleOutlined, CloseCircleOutlined } from '@antdv-next/icons'\n\nconst tagStyles = {\n  root: {\n    backgroundColor: '#e6f7ff',\n  },\n  icon: {\n    color: '#52c41a',\n  },\n  content: {\n    color: '#262626',\n  },\n}\n\nconst filledTagStyles = {\n  root: {\n    backgroundColor: '#F5EFFF',\n  },\n  icon: {\n    color: '#8F87F1',\n  },\n  content: {\n    color: '#8F87F1',\n  },\n}\n\nconst groupStyles = {\n  root: {\n    gap: '12px',\n    padding: '8px 12px',\n    backgroundColor: 'rgba(82, 196, 26, 0.08)',\n    borderRadius: '8px',\n  },\n  item: {\n    backgroundColor: 'rgba(82, 196, 26, 0.1)',\n    borderColor: 'rgba(82, 196, 26, 0.3)',\n    color: '#52c41a',\n  },\n}\n\nconst multipleGroupStyles = {\n  root: {\n    gap: '16px',\n    padding: '8px 12px',\n    backgroundColor: 'rgba(143, 135, 241, 0.08)',\n    borderRadius: '8px',\n  },\n  item: {\n    backgroundColor: 'rgba(143, 135, 241, 0.1)',\n    borderColor: 'rgba(143, 135, 241, 0.3)',\n    color: '#8F87F1',\n    fontWeight: 500,\n  },\n}\n\nconst options1 = ['React', 'Vue', 'Angular']\nconst options2 = ['meet-student', 'thinkasany']\n</script>\n\n<template>\n  <a-space size=\"large\" vertical>\n    <a-flex gap=\"middle\">\n      <a-tag :classes=\"{ root: 'custom-tag-root' }\" :styles=\"tagStyles\">\n        <template #icon>\n          <CheckCircleOutlined />\n        </template>\n        Object\n      </a-tag>\n      <a-tag\n        variant=\"filled\"\n        :classes=\"{ root: 'custom-tag-root' }\"\n        :styles=\"filledTagStyles\"\n      >\n        <template #icon>\n          <CloseCircleOutlined />\n        </template>\n        Function\n      </a-tag>\n    </a-flex>\n    <a-flex vertical gap=\"middle\">\n      <a-checkable-tag-group\n        :classes=\"{ root: 'custom-tag-root' }\"\n        :styles=\"groupStyles\"\n        :options=\"options1\"\n      />\n      <a-checkable-tag-group\n        :classes=\"{ root: 'custom-tag-root' }\"\n        :styles=\"multipleGroupStyles\"\n        :options=\"options2\"\n        multiple\n      />\n    </a-flex>\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with inline-block display, auto height, padding, font size, line height, nowrap, background color, border, border radius, opacity, transition animations, text alignment, relative positioning and other basic tag styles",
+          "descriptionZh": "根元素，包含行内块布局、自动高度、内边距、字体大小、行高、禁止换行、背景色、边框、圆角、透明度、过渡动画、文本对齐、相对定位等标签的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AntDesignOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tag\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-tag :classes=\"classes\">\n        <template #icon>\n          <AntDesignOutlined />\n        </template>\n        Ant Design\n      </a-tag>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element with font size, color, cursor style, transition animations and other icon display styles",
+          "descriptionZh": "图标元素，包含字体大小、颜色、光标样式、过渡动画等图标的显示样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with text content color, font styles and other content area styles",
+          "descriptionZh": "内容元素，包含文本内容的颜色、字体样式等内容区域的样式"
         }
       ]
     },
@@ -22077,14 +23188,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of TimePicker by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 TimePicker 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TimePickerProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { useToken } = theme\nconst { token } = useToken()\n\nconst customClasses = {\n  root: 'custom-timepicker-root',\n}\n\nconst stylesObject: TimePickerProps['styles'] = {\n  root: {\n    borderColor: '#d9d9d9',\n  },\n}\n\nconst stylesFn: TimePickerProps['styles'] = (info) => {\n  if (info.props.size === 'large') {\n    return {\n      root: {\n        borderColor: '#722ed1',\n      },\n      suffix: {\n        color: '#722ed1',\n      },\n      popup: {\n        container: { border: '1px solid #722ed1', borderRadius: '8px' },\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-time-picker :classes=\"customClasses\" :styles=\"stylesObject\" placeholder=\"Object\" />\n    <a-time-picker :classes=\"customClasses\" :styles=\"stylesFn\" placeholder=\"Function\" size=\"large\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, padding, border-radius, transition animations and other basic styles for time picker container",
+          "descriptionZh": "根元素，包含相对定位、行内flex布局、内边距、边框圆角、过渡动画等时间选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { SmileOutlined } from '@antdv-next/icons'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'popup.root', desc: t('popup') },\n  { name: 'popup.container', desc: t('popup.container') },\n  { name: 'popup.content', desc: t('popup.content') },\n  { name: 'popup.item', desc: t('popup.item') },\n  { name: 'popup.footer', desc: t('popup.footer') },\n])\n\nconst type = ref<'Single' | 'Multiple'>('Single')\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    :component-name=\"type === 'Single' ? 'TimePicker' : 'TimePicker.RangePicker'\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" vertical :style=\"{ alignSelf: 'flex-start' }\" gap=\"middle\" align=\"center\">\n        <a-segmented\n          :options=\"['Single', 'Multiple']\"\n          :value=\"type\"\n          @change=\"(val: 'Single' | 'Multiple') => type = val\"\n        />\n        <a-time-picker\n          v-if=\"type === 'Single'\"\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-time-picker>\n        <a-time-range-picker\n          v-else\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-time-range-picker>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with flex layout and margin styles for prefix content layout",
+          "descriptionZh": "前缀元素，包含flex布局、右外边距等前缀内容的布局样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with relative positioning, width, color, font, line-height, transition animations and other core interactive styles for input field",
+          "descriptionZh": "输入框元素，包含相对定位、宽度、颜色、字体、行高、过渡动画等输入框的核心交互样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with flex layout, color, line-height, pointer events, transition animations and other styles for suffix content",
+          "descriptionZh": "后缀元素，包含flex布局、颜色、行高、指针事件、过渡动画等后缀内容的样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup element",
+          "descriptionZh": "弹出框元素"
+        },
+        {
+          "key": "popup.container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "popup.content",
+          "description": "Popup content element with width, border, cell and other content display styles for time list",
+          "descriptionZh": "弹出框内容元素，包含时间列表的宽度、边框、单元格等内容展示样式"
+        },
+        {
+          "key": "popup.item",
+          "description": "Popup item element with size, background, border-radius, hover state, selected state and other interactive styles for time cells",
+          "descriptionZh": "弹出框单项元素，包含时间单元格的尺寸、背景色、边框圆角、悬停态、选中态等交互样式"
+        },
+        {
+          "key": "popup.footer",
+          "description": "Popup footer element with layout styles for bottom operation area including confirm/cancel buttons",
+          "descriptionZh": "弹出框底部元素，包含确认取消按钮等底部操作区域的布局样式"
         }
       ]
     },
@@ -22313,14 +23463,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Timeline by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Timeline 的[语义化结构](#semantic-dom)样式。",
           "code": "<script lang=\"ts\" setup>\nconst classes = {\n  root: 'custom-timeline-root',\n}\n\nconst styles = {\n  itemIcon: {\n    borderColor: '#1890ff',\n  },\n}\n\nfunction stylesFn(info: any) {\n  if (info.props.orientation === 'vertical') {\n    return {\n      root: {\n        padding: '10px 6px',\n        border: '1px solid #A294F9',\n      },\n      itemIcon: {\n        borderColor: '#A294F9',\n      },\n    }\n  }\n  return {}\n}\n\nconst items = [\n  {\n    title: '2015-09-01',\n    content: 'Create a services site',\n  },\n  {\n    title: '2015-09-01 09:12:11',\n    content: 'Solve initial network problems',\n  },\n  {\n    content: 'Technical testing',\n  },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-timeline :items=\"items\" orientation=\"horizontal\" :styles=\"styles\" :classes=\"classes\" />\n    <a-timeline :items=\"items\" orientation=\"vertical\" :styles=\"stylesFn\" :classes=\"classes\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with timeline container list style reset, vertical layout, dot icon, outlined style, alternate layout and other basic container styles",
+          "descriptionZh": "根元素，设置时间轴容器的列表样式重置、垂直布局、点状图标、轮廓样式、交替布局等基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemWrapper', desc: t('itemWrapper') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n  { name: 'itemSection', desc: t('itemSection') },\n  { name: 'itemHeader', desc: t('itemHeader') },\n  { name: 'itemTitle', desc: t('itemTitle') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'itemRail', desc: t('itemRail') },\n])\n\nconst items = [\n  { title: '2015-09-01', content: 'Create a services' },\n  { title: '2015-09-01 09:12:11', content: 'Solve initial network problems' },\n  { content: 'Technical testing' },\n  { title: '2015-09-01 09:12:11', content: 'Network problems being solved' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Timeline\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-timeline :items=\"items\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with single timeline node relative positioning, margin, padding, font size, finish state, color theme, layout direction and other node basic styles",
+          "descriptionZh": "节点元素，设置单个时间节点的相对定位、外边距、内边距、字体大小、完成状态、颜色主题、布局方向等节点基础样式"
+        },
+        {
+          "key": "itemWrapper",
+          "description": "Item wrapper element with timeline node content wrapping container styles",
+          "descriptionZh": "节点包装元素，设置时间节点内容的包装容器样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Item icon element with node head icon absolute positioning, width/height size, background color, border, border radius, wave animation and other icon styles",
+          "descriptionZh": "节点图标元素，设置节点头部图标的绝对定位、宽高尺寸、背景色、边框、圆角、波纹动画等图标样式"
+        },
+        {
+          "key": "itemHeader",
+          "description": "Item header element with header area layout containing title and rail, alignment, text direction and other styles",
+          "descriptionZh": "节点头部元素，设置包含标题和连接线的头部区域布局、对齐方式、文本方向等样式"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Item title element with node title text font size, line height, color and other text styles",
+          "descriptionZh": "节点标题元素，设置节点标题文字的字体大小、行高、颜色等文本样式"
+        },
+        {
+          "key": "itemSection",
+          "description": "Item section element with section container containing header and content flex layout, wrap, gap and other layout styles",
+          "descriptionZh": "节点区域元素，设置包含头部和内容的区域容器的Flex布局、换行、间距等布局样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Item content element with node detail content relative positioning, top offset, left margin, text color, word break and other content styles",
+          "descriptionZh": "节点内容元素，设置节点详细内容的相对定位、顶部偏移、左侧外边距、文字颜色、词汇换行等内容样式"
+        },
+        {
+          "key": "itemRail",
+          "description": "Item rail element with timeline node connection track line absolute positioning, top offset, left offset, height, border color, width, style and other connection line styles",
+          "descriptionZh": "节点连接线元素，设置连接时间节点的轨道线条的绝对定位、顶部偏移、左侧偏移、高度、边框颜色、宽度、样式等连接线样式"
         }
       ]
     },
@@ -22689,14 +23878,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tooltip by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tooltip 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TooltipProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: TooltipProps['classes'] = {\n  container: 'demo-tooltip-container',\n}\n\nconst stylesObject: TooltipProps['styles'] = {\n  container: {\n    borderRadius: '12px',\n    boxShadow: 'inset 0 0 8px #ccc',\n  },\n}\n\nconst stylesFn: TooltipProps['styles'] = (info) => {\n  if (info?.props?.arrow === false) {\n    return {\n      container: {\n        backgroundColor: 'rgba(53, 71, 125, 0.8)',\n        padding: '12px',\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-tooltip title=\"Object text\" :classes=\"classes\" :styles=\"stylesObject\" :arrow=\"false\">\n      <a-button>Object Style</a-button>\n    </a-tooltip>\n    <a-tooltip title=\"Function text\" :classes=\"classes\" :styles=\"stylesFn\" :arrow=\"false\">\n      <a-button type=\"primary\">\n        Function Style\n      </a-button>\n    </a-tooltip>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element (including arrows, content elements) with absolute positioning, z-index, block display, max width, visibility, transform origin and arrow background color",
+          "descriptionZh": "根元素 (包含箭头、内容元素)，设置绝对定位、层级、块级显示、最大宽度、可见性、变换原点和箭头背景色"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'container', desc: t('container') },\n  { name: 'arrow', desc: t('arrow') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tooltip\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', marginTop: '60px' }\">\n        <a-tooltip\n          open\n          placement=\"top\"\n          title=\"tooltip prompt text\"\n          :auto-adjust-overflow=\"false\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "container",
+          "description": "Content element with min width and height, padding, color, text alignment, background color, border radius, shadow and border styles",
+          "descriptionZh": "内容元素，设置最小宽度高度、内边距、颜色、文本对齐、背景色、圆角、阴影和边框样式"
+        },
+        {
+          "key": "arrow",
+          "description": "Arrow element with width, height, position, color and border styles",
+          "descriptionZh": "箭头元素，设置宽高、位置、颜色和边框样式"
         }
       ]
     },
@@ -22998,14 +24196,63 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tour by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tour 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TourProps, TourStepItem } from 'antdv-next'\nimport { computed, h, shallowRef } from 'vue'\n\nconst ref1 = shallowRef()\nconst ref2 = shallowRef()\nconst ref3 = shallowRef()\nconst open = shallowRef(false)\nconst openFn = shallowRef(false)\n\nconst btnProps = {\n  nextButtonProps: {\n    style: {\n      border: '1px solid #CDC1FF',\n      color: '#CDC1FF',\n    },\n  },\n  prevButtonProps: {\n    style: {\n      backgroundColor: '#CDC1FF',\n      color: '#fff',\n    },\n  },\n}\n\nconst coverNode = h('img', {\n  alt: 'tour.png',\n  src: 'https://user-images.githubusercontent.com/5378891/197385811-55df8480-7ff4-44bd-9d43-a7dade598d70.png',\n})\n\nconst steps: TourStepItem[] = [\n  {\n    title: 'Upload File',\n    description: 'Put your files here.',\n    cover: coverNode,\n    target: ref1,\n    prevButtonProps: {},\n  },\n  {\n    title: 'Save',\n    description: 'Save your changes.',\n    target: ref2,\n  },\n  {\n    title: 'Other Actions',\n    description: 'Click to see other actions.',\n    target: ref3,\n  },\n]\n\nconst stepsWithButtonProps = computed(() => steps.map(step => ({ ...step, ...btnProps })))\n\nconst classes: TourProps['classes'] = {\n  root: 'custom-tour-root',\n  section: 'custom-tour-section',\n}\n\nconst stylesObject: TourProps['styles'] = {\n  mask: {\n    backgroundColor: 'rgba(0, 0, 0, 0.3)',\n  },\n  section: {\n    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',\n    border: '2px solid #4096ff',\n  },\n  cover: {\n    borderRadius: '12px 12px 0 0',\n  },\n}\n\nconst stylesFn: TourProps['styles'] = (info) => {\n  if (info.props.type === 'primary') {\n    return {\n      mask: {\n        backgroundColor: 'rgba(0, 0, 0, 0.3)',\n      },\n      section: {\n        backgroundColor: 'rgba(205, 193, 255, 0.8)',\n        boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',\n      },\n      cover: {\n        borderRadius: '12px 12px 0 0',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-flex gap=\"middle\">\n      <a-button type=\"primary\" @click=\"open = true\">\n        Begin Tour Object\n      </a-button>\n      <a-button type=\"primary\" @click=\"openFn = true\">\n        Begin Tour Function\n      </a-button>\n    </a-flex>\n    <a-divider />\n    <a-tour\n      v-model:open=\"open\"\n      :steps=\"steps\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    />\n    <a-tour\n      v-model:open=\"openFn\"\n      :steps=\"stepsWithButtonProps\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n      type=\"primary\"\n    />\n    <a-space>\n      <a-button ref=\"ref1\" type=\"primary\">\n        Upload\n      </a-button>\n      <a-button ref=\"ref2\">\n        Save\n      </a-button>\n      <a-button ref=\"ref3\" type=\"dashed\">\n        Other Actions\n      </a-button>\n    </a-space>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Tour root container with absolute positioning, z-index control, max width, visibility, arrow background color variable, theme styles and other container styles",
+          "descriptionZh": "引导根容器，设置绝对定位、层级控制、最大宽度、可见性、箭头背景色变量、主题样式等容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'mask', desc: t('mask'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'cover', desc: t('cover'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n  { name: 'indicators', desc: t('indicators'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n])\n\nconst open = ref(true)\nconst createBtnRef = ref<HTMLButtonElement | null>(null)\n\nconst steps = [\n  {\n    title: 'Hello World!',\n    description: 'Hello World?!',\n    target: () => createBtnRef.value!,\n    mask: true,\n  },\n  {\n    title: 'Save',\n    description: 'Save your changes.',\n    target: () => createBtnRef.value!,\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tour\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div\n        :style=\"{\n          width: '100%',\n          height: '825px',\n          display: 'flex',\n          alignItems: 'center',\n          justifyContent: 'center',\n          position: 'relative',\n          overflow: 'hidden',\n        }\"\n      >\n        <a-button ref=\"createBtnRef\" @click=\"open = true\">\n          Show\n        </a-button>\n        <a-tour\n          v-model:open=\"open\"\n          :z-index=\"1\"\n          :default-current=\"0\"\n          :get-popup-container=\"false\"\n          :steps=\"steps\"\n          :classes=\"classes\"\n        >\n          <template #coverRender=\"{ index }\">\n            <template v-if=\"index === 0\">\n              <img src=\"https://user-images.githubusercontent.com/5378891/197385811-55df8480-7ff4-44bd-9d43-a7dade598d70.png\" alt=\"img\">\n            </template>\n          </template>\n        </a-tour>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "cover",
+          "description": "Card cover area with text center alignment, padding, image width and other image display styles",
+          "descriptionZh": "卡片封面区域，设置文本居中对齐、内边距、图片宽度等图片展示样式"
+        },
+        {
+          "key": "section",
+          "description": "Card main content area with text alignment, border radius, box shadow, relative positioning, background color, border, background clip and other card styles",
+          "descriptionZh": "卡片主要内容区域，设置文本对齐、边框圆角、盒阴影、相对定位、背景色、边框、背景裁剪等卡片样式"
+        },
+        {
+          "key": "footer",
+          "description": "Card bottom action area with padding, text right alignment, border radius, flex layout and other bottom container styles",
+          "descriptionZh": "卡片底部操作区域，设置内边距、文本右对齐、边框圆角、Flex布局等底部容器样式"
+        },
+        {
+          "key": "actions",
+          "description": "Action button group container with left auto margin, button spacing and other button group layout styles",
+          "descriptionZh": "操作按钮组容器，设置左侧自动外边距、按钮间距等按钮组布局样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Single indicator element with width/height size, inline-block display, border radius, background color, right margin, active state and other dot styles",
+          "descriptionZh": "单个指示器元素，设置宽高尺寸、行内块显示、圆角、背景色、右外边距、激活状态等圆点样式"
+        },
+        {
+          "key": "indicators",
+          "description": "Indicator group container with inline-block display and other indicator container styles",
+          "descriptionZh": "指示器组容器，设置行内块显示等指示器容器样式"
+        },
+        {
+          "key": "header",
+          "description": "Card header area with padding, width calculation, word break and other header container styles",
+          "descriptionZh": "卡片头部区域，设置内边距、宽度计算、词汇换行等头部容器样式"
+        },
+        {
+          "key": "title",
+          "description": "Guide title text with font weight and other title text styles",
+          "descriptionZh": "引导标题文字，设置字体粗细等标题文本样式"
+        },
+        {
+          "key": "description",
+          "description": "Guide description text with padding, word wrap and other description text styles",
+          "descriptionZh": "引导描述文字，设置内边距、词汇换行等描述文本样式"
+        },
+        {
+          "key": "mask",
+          "description": "Mask layer element with fixed positioning, full screen coverage, z-index, pointer events, transition animation and other mask styles",
+          "descriptionZh": "遮罩层元素，设置固定定位、全屏覆盖、层级、指针事件、过渡动画等遮罩样式"
         }
       ]
     },
@@ -23337,14 +24584,63 @@
           "description": "Custom the labels for select all checkboxes.",
           "descriptionZh": "自定义穿梭框全选按钮的文字。",
           "code": "<script setup lang=\"ts\">\nimport type { TransferEmits, TransferProps } from 'antdv-next'\nimport { ref } from 'vue'\n\ninterface RecordType {\n  key: string\n  title: string\n  description: string\n}\n\nconst mockData = Array.from({ length: 10 }).map<RecordType>((_, i) => ({\n  key: i.toString(),\n  title: `content${i + 1}`,\n  description: `description of content${i + 1}`,\n}))\n\nconst oriTargetKeys = mockData.filter(item => Number(item.key) % 3 > 1).map(item => item.key)\n\nconst selectAllLabels: TransferProps['selectAllLabels'] = [\n  'Select All',\n  ({ selectedCount, totalCount }) => `${selectedCount}/${totalCount}`,\n]\n\nconst targetKeys = ref(oriTargetKeys)\n\nconst handleChange: TransferEmits['change'] = (newTargetKeys) => {\n  targetKeys.value = newTargetKeys\n}\n</script>\n\n<template>\n  <a-transfer\n    v-model:target-keys=\"targetKeys\"\n    :data-source=\"mockData\"\n    :render=\"(item: RecordType) => item.title\"\n    :select-all-labels=\"selectAllLabels\"\n    @change=\"handleChange\"\n  />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, transfer container base styles and layout control",
+          "descriptionZh": "根元素，设置flex布局、穿梭框容器的基础样式和布局控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'section', desc: t('section') },\n  { name: 'header', desc: t('header') },\n  { name: 'title', desc: t('title') },\n  { name: 'body', desc: t('body') },\n  { name: 'list', desc: t('list') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'footer', desc: t('footer') },\n  { name: 'actions', desc: t('actions') },\n])\n\nconst mockData = Array.from({ length: 20 }).map((_, i) => ({\n  key: i,\n  title: `content ${i + 1}`,\n}))\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Transfer\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-transfer\n        show-search\n        :titles=\"['Source', 'Target']\"\n        :data-source=\"mockData\"\n        :selected-keys=\"[]\"\n        :target-keys=\"[3, 9]\"\n        :render=\"(item: any) => item.title\"\n        :styles=\"{\n          section: { height: '250px', width: '200px' },\n        }\"\n        :classes=\"classes\"\n      >\n        <template #footer>\n          <div :style=\"{ padding: '8px' }\">\n            Custom Footer\n          </div>\n        </template>\n      </a-transfer>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Section element with flex layout, width, height, min height, border, border radius and other single-side transfer container styles",
+          "descriptionZh": "区域元素，设置flex布局、宽度、高度、最小高度、边框、圆角等单侧穿梭框的容器样式"
+        },
+        {
+          "key": "header",
+          "description": "Header element with flex layout, alignment, height, padding, color, background color, bottom border, border radius and other header area styles",
+          "descriptionZh": "头部元素，设置flex布局、对齐方式、高度、内边距、颜色、背景色、下边框、圆角等头部区域的样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text ellipsis, flex ratio, text alignment, auto left margin and other title text layout and styles",
+          "descriptionZh": "标题元素，设置文本省略、flex占比、文本对齐、自动左边距等标题文字的布局和样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with list main area container styles and layout control",
+          "descriptionZh": "内容元素，设置列表主体区域的容器样式和布局控制"
+        },
+        {
+          "key": "list",
+          "description": "List element with list content styles, layout and scroll control",
+          "descriptionZh": "列表元素，设置列表内容的样式、布局和滚动控制"
+        },
+        {
+          "key": "item",
+          "description": "List item element with relative positioning, padding, border, hover state, selected state, disabled state and other list item interaction styles",
+          "descriptionZh": "列表项元素，设置相对定位、内边距、边框、悬停态、选中态、禁用态等列表项的交互样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "List item icon element with checkbox and other icon styles and interaction states",
+          "descriptionZh": "列表项图标元素，设置复选框等图标的样式和交互状态"
+        },
+        {
+          "key": "itemContent",
+          "description": "List item content element with text ellipsis, padding and other list item text content display styles",
+          "descriptionZh": "列表项内容元素，设置文本省略、内边距等列表项文本内容的展示样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with bottom operation area styles and layout",
+          "descriptionZh": "页脚元素，设置底部操作区域的样式和布局"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element with transfer button group styles, layout and interaction states",
+          "descriptionZh": "操作元素，设置穿梭按钮组的样式、布局和交互状态"
         }
       ]
     },
@@ -24039,14 +25335,28 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tree by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tree 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TreeDataNode, TreeProps } from 'antdv-next'\nimport { ref } from 'vue'\n\nconst treeData: TreeDataNode[] = [\n  {\n    title: 'parent 1',\n    key: '0-0',\n    children: [\n      {\n        title: 'parent 1-0',\n        key: '0-0-0',\n        children: [\n          {\n            title: 'leaf',\n            key: '0-0-0-0',\n          },\n          {\n            title: 'leaf',\n            key: '0-0-0-1',\n          },\n        ],\n      },\n      {\n        title: 'parent 1-1',\n        key: '0-0-1',\n        children: [\n          {\n            title: 'leaf',\n            key: '0-0-1-0',\n          },\n        ],\n      },\n    ],\n  },\n]\n\nconst styles: TreeProps['styles'] = {\n  root: { border: '2px solid #d9d9d9' },\n  item: { margin: '2px 0' },\n}\n\nconst stylesFn: TreeProps['styles'] = (info) => {\n  if (!info.props.checkable) {\n    return {\n      root: {\n        border: `2px solid #E5D9F2`,\n        borderRadius: '4px',\n      },\n    }\n  }\n  return {}\n}\n\nconst expandedKeys = ref(['0-0-0', '0-0-1'])\nconst selectedKeys = ref(['0-0-1'])\nconst checkedKeys = ref(['0-0-0', '0-0-1'])\nconst classes = {\n  root: 'root',\n  item: 'item',\n  itemTitle: 'itemTitle',\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-tree\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      auto-expand-parent\n      checkable\n      :styles=\"styles\"\n    />\n    <a-tree\n      v-model:expanded-keys=\"expandedKeys\"\n      v-model:selected-keys=\"selectedKeys\"\n      v-model:checked-keys=\"checkedKeys\"\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      auto-expand-parent\n      :checkable=\"false\"\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with tree control base styles, layout and container control",
+          "descriptionZh": "根元素，设置树形控件的基础样式、布局和容器控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { DownOutlined, FrownFilled, FrownOutlined, MehOutlined, SmileOutlined } from '@antdv-next/icons'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'itemIcon', desc: t('itemIcon'), version: '1.0.0' },\n  { name: 'itemTitle', desc: t('itemTitle'), version: '1.0.0' },\n])\n\nconst treeData = [\n  {\n    title: 'parent 1',\n    key: '0-0',\n    icon: h(SmileOutlined),\n    children: [\n      { title: 'leaf', key: '0-0-0', icon: h(MehOutlined) },\n      { title: 'leaf', key: '0-0-1', icon: ({ selected }: { selected: boolean }) => selected ? h(FrownFilled) : h(FrownOutlined) },\n    ],\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tree\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-tree\n        show-icon\n        default-expand-all\n        :default-selected-keys=\"['0-0-0']\"\n        :tree-data=\"treeData\"\n        :classes=\"classes\"\n      >\n        <template #switcherIcon>\n          <DownOutlined />\n        </template>\n      </a-tree>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with tree node base styles, drag state, role attributes, indentation, switcher, content wrapper and other node structure",
+          "descriptionZh": "条目元素，设置树节点的基础样式、拖拽状态、角色属性、缩进、切换器、内容包装器等节点结构"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Title element with tree node title text display styles and text content",
+          "descriptionZh": "标题元素，设置树节点标题文字的显示样式和文本内容"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Icon element with tree node icon styles, size and state display",
+          "descriptionZh": "图标元素，设置树节点图标的样式、尺寸和状态显示"
         }
       ]
     },
@@ -24629,14 +25939,68 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of TreeSelect by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 TreeSelect 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TreeSelectProps } from 'antdv-next'\n\nconst classes: TreeSelectProps['classes'] = {\n  root: 'custom-tree-select',\n}\n\nconst stylesObject: TreeSelectProps['styles'] = {\n  input: {\n    fontSize: 16,\n  },\n  suffix: {\n    color: '#1890ff',\n  },\n  popup: {\n    root: {\n      border: '1px solid #1890ff',\n    },\n  },\n}\n\nconst stylesFn: TreeSelectProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      suffix: {\n        color: '#722ed1',\n      },\n      popup: {\n        item: {\n          color: '#722ed1',\n        },\n      },\n    }\n  }\n  return {}\n}\n\nconst treeData: TreeSelectProps['treeData'] = [\n  {\n    value: 'parent 1',\n    title: 'parent 1',\n    children: [\n      {\n        value: 'parent 1-0',\n        title: 'parent 1-0',\n        children: [\n          {\n            value: 'leaf1',\n            title: 'leaf1',\n          },\n          {\n            value: 'leaf2',\n            title: 'leaf2',\n          },\n        ],\n      },\n      {\n        value: 'parent 1-1',\n        title: 'parent 1-1',\n        children: [\n          {\n            value: 'leaf3',\n            title: 'leaf3',\n          },\n        ],\n      },\n    ],\n  },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-tree-select\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      placeholder=\"Object\"\n    />\n    <a-tree-select\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      placeholder=\"Function\"\n      size=\"middle\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with tree selector base styles, border, border radius container styles",
+          "descriptionZh": "根元素，设置树选择器的基础样式、边框、圆角容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst mode = ref<'single' | 'multiple'>('single')\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => {\n  const base = [\n    { name: 'root', desc: t('root') },\n    { name: 'prefix', desc: t('prefix') },\n    { name: 'placeholder', desc: t('placeholder') },\n  ]\n\n  if (mode.value === 'multiple') {\n    base.push(\n      ...[\n        { name: 'content', desc: t('content') },\n        { name: 'item', desc: t('item') },\n        { name: 'itemContent', desc: t('itemContent') },\n        { name: 'itemRemove', desc: t('itemRemove') },\n      ],\n    )\n  }\n\n  base.push(\n    ...[\n      { name: 'input', desc: t('input') },\n      { name: 'suffix', desc: t('suffix') },\n      { name: 'popup.root', desc: t('popup.root') },\n      { name: 'popup.item', desc: t('popup.item') },\n      { name: 'popup.itemTitle', desc: t('popup.itemTitle') },\n    ],\n  )\n\n  return base\n})\n\nconst treeValue = ref<string[]>([])\nconsole.log(treeValue)\nfunction handleResetValue(newMode: string | number) {\n  if (newMode === 'multiple') {\n    treeValue.value = ['aojunhao123']\n  }\n  else {\n    treeValue.value = []\n  }\n}\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst treeData = [\n  {\n    value: 'contributors',\n    title: 'contributors',\n    children: [\n      { value: 'aojunhao123', title: 'aojunhao123' },\n      { value: 'thinkasany', title: 'thinkasany' },\n      { value: 'meet-student', title: 'meet-student' },\n    ],\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"TreeSelect\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <div :style=\"{ display: 'flex', justifyContent: 'center', marginBottom: '12px' }\">\n          <a-segmented v-model:value=\"mode\" :options=\"['single', 'multiple']\" @change=\"handleResetValue\" />\n        </div>\n\n        <a-tree-select\n          v-model:value=\"treeValue\"\n          prefix=\"prefix\"\n          :style=\"{ width: '300px' }\"\n          :tree-data=\"treeData\"\n          tree-default-expand-all\n          :multiple=\"mode === 'multiple'\"\n          show-search\n          max-tag-count=\"responsive\"\n          placeholder=\"Please select\"\n          allow-clear\n          open\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with prefix content layout and styles",
+          "descriptionZh": "前缀元素，设置前缀内容的布局和样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "input",
+          "description": "Input element with text input, search, selected value display and other input core interaction styles",
+          "descriptionZh": "输入框元素，设置文本输入、搜索、选择值显示等输入框的核心交互样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with suffix content, clear button, dropdown arrow and other suffix area styles",
+          "descriptionZh": "后缀元素，设置后缀内容、清除按钮、下拉箭头等后缀区域的样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with dropdown tree selection panel positioning, z-index, background, border, shadow and other popup layer styles",
+          "descriptionZh": "弹出菜单元素，设置下拉树形选择面板的定位、层级、背景、边框、阴影等弹层样式"
+        },
+        {
+          "key": "popup.item",
+          "description": "Popup item element with tree node option styles, hover state, selected state and other interaction states",
+          "descriptionZh": "弹出菜单条目元素，设置树节点选项的样式、悬停态、选中态等交互状态"
+        },
+        {
+          "key": "popup.itemTitle",
+          "description": "Popup title element with tree node title text display styles",
+          "descriptionZh": "弹出菜单标题元素，设置树节点标题文字的显示样式"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "item",
+          "description": "Multiple selection item element with border, background, padding, and margin styles",
+          "descriptionZh": "多选项元素，包含边框、背景、内边距、外边距样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Multiple selection item content area with text ellipsis styles",
+          "descriptionZh": "多选项内容区域，包含文字的省略样式"
+        },
+        {
+          "key": "itemRemove",
+          "description": "Multiple selection item remove button with font-related styles",
+          "descriptionZh": "多选项移除按钮，包含字体相关样式"
         }
       ]
     },
@@ -25149,7 +26513,8 @@
           "descriptionZh": "添加后缀的省略。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst rows = ref(1)\n\nconst article = `To be, or not to be, that is the question: Whether it is nobler in the mind to suffer. The slings and arrows of outrageous fortune Or to take arms against a sea of troubles, And by opposing end them? To die: to sleep; No more; and by a sleep to say we end The heart-ache and the thousand natural shocks That flesh is heir to, 'tis a consummation Devoutly to be wish'd. To die, to sleep To sleep- perchance to dream: ay, there's the rub! For in that sleep of death what dreams may come When we have shuffled off this mortal coil, Must give us pause. There 's the respect That makes calamity of so long life`\n\nfunction onEllipsis(ellipsis: boolean) {\n  console.log('Ellipsis changed:', ellipsis)\n}\n</script>\n\n<template>\n  <div>\n    <a-slider v-model:value=\"rows\" :min=\"1\" :max=\"10\" />\n    <a-typography-paragraph\n      :ellipsis=\"{\n        rows,\n        expandable: true,\n        suffix: '--William Shakespeare',\n        onEllipsis,\n      }\"\n      :title=\"`${article}--William Shakespeare`\"\n    >\n      {{ article }}\n    </a-typography-paragraph>\n  </div>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Upload",
@@ -25605,14 +26970,23 @@
           "description": "Component Token Debug.",
           "descriptionZh": "Component Token Debug.",
           "code": "<script setup lang=\"ts\">\nimport type { UploadEmits, UploadFile } from 'antdv-next'\nimport { UploadOutlined } from '@antdv-next/icons'\n\nconst defaultFileList: UploadFile[] = [\n  {\n    uid: '1',\n    name: 'xxx.png',\n    status: 'uploading',\n    url: 'http://www.baidu.com/xxx.png',\n    percent: 33,\n  },\n  {\n    uid: '2',\n    name: 'yyy.png',\n    status: 'done',\n    url: 'http://www.baidu.com/yyy.png',\n  },\n  {\n    uid: '3',\n    name: 'zzz.png',\n    status: 'error',\n    response: 'Server Error 500',\n    url: 'http://www.baidu.com/zzz.png',\n  },\n]\n\nconst handleChange: UploadEmits['change'] = ({ file, fileList }) => {\n  if (file.status !== 'uploading') {\n    console.log(file, fileList)\n  }\n}\n</script>\n\n<template>\n  <a-config-provider\n    :theme=\"{\n      components: {\n        Upload: {\n          actionsColor: 'yellow',\n        },\n      },\n    }\"\n  >\n    <a-upload\n      action=\"https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload\"\n      :default-file-list=\"defaultFileList\"\n      @change=\"handleChange\"\n    >\n      <a-button>\n        <template #icon>\n          <UploadOutlined />\n        </template>\n        Upload\n      </a-button>\n    </a-upload>\n  </a-config-provider>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root container element with layout styles, disabled text color, user-select control, cursor styles and other basic styles",
+          "descriptionZh": "根元素容器，包含布局样式、禁用状态文字颜色、用户选择控制、鼠标样式等基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { UploadOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'list', desc: t('list'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n])\n\nconst defaultFileList = [\n  { uid: '1', name: 'xxx.png', status: 'uploading', url: 'http://www.baidu.com/xxx.png', percent: 33 },\n  { uid: '2', name: 'yyy.png', status: 'done', url: 'http://www.baidu.com/yyy.png' },\n  { uid: '3', name: 'zzz.png', status: 'error', response: 'Server Error 500', url: 'http://www.baidu.com/zzz.png' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Upload\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-upload\n        action=\"https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload\"\n        :default-file-list=\"defaultFileList\"\n        :classes=\"classes\"\n      >\n        <a-button>\n          <template #icon>\n            <UploadOutlined />\n          </template>\n          Upload\n        </a-button>\n      </a-upload>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "list",
+          "description": "File list container with layout arrangement, transition animations, spacing control and other styles",
+          "descriptionZh": "文件列表容器，包含布局排列、过渡动画、间距控制等样式"
+        },
+        {
+          "key": "item",
+          "description": "File item element with padding, background color, border styles, hover effects, status colors, transition animations and other styles",
+          "descriptionZh": "文件项元素，包含内边距、背景色、边框样式、悬停效果、状态颜色、过渡动画等样式"
         }
       ]
     },
@@ -25759,7 +27133,8 @@
           "descriptionZh": "在 Modal 与 Drawer 中使用。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst showModal = shallowRef(false)\nconst showDrawer = shallowRef(false)\nconst showDrawer2 = shallowRef(false)\n\nconst placeholderStyle = {\n  height: '300px',\n  display: 'flex',\n  justifyContent: 'center',\n  alignItems: 'center',\n  backgroundColor: 'rgba(150, 150, 150, 0.2)',\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-button type=\"primary\" @click=\"showModal = true\">\n      Show in Modal\n    </a-button>\n    <a-button type=\"primary\" @click=\"showDrawer = true\">\n      Show in Drawer\n    </a-button>\n    <a-button type=\"primary\" @click=\"showDrawer2 = true\">\n      Not Show in Drawer\n    </a-button>\n  </a-flex>\n  <a-watermark content=\"Antdv Next\">\n    <a-modal\n      v-model:open=\"showModal\"\n      destroy-on-hidden\n      title=\"Modal\"\n      @ok=\"showModal = false\"\n      @cancel=\"showModal = false\"\n    >\n      <div :style=\"placeholderStyle\">\n        A mock height\n      </div>\n    </a-modal>\n    <a-drawer\n      v-model:open=\"showDrawer\"\n      destroy-on-hidden\n      title=\"Drawer\"\n      @close=\"showDrawer = false\"\n    >\n      <div :style=\"placeholderStyle\">\n        A mock height\n      </div>\n    </a-drawer>\n  </a-watermark>\n  <a-watermark content=\"Antdv Next\" :inherit=\"false\">\n    <a-drawer\n      v-model:open=\"showDrawer2\"\n      destroy-on-hidden\n      title=\"Drawer\"\n      @close=\"showDrawer2 = false\"\n    >\n      <div :style=\"placeholderStyle\">\n        A mock height\n      </div>\n    </a-drawer>\n  </a-watermark>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     }
   ],
   "changelog": [

--- a/data/v1.3.7.json
+++ b/data/v1.3.7.json
@@ -1833,7 +1833,8 @@
           "descriptionZh": "用 `target` 设置 `Affix` 需要监听其滚动事件的元素，默认为 `window`。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst container = shallowRef()\n</script>\n\n<template>\n  <div ref=\"container\" style=\"width: 100%;height: 100px;overflow: auto;box-shadow: 0 0 0 1px #1677ff;scrollbar-width: thin;scrollbar-gutter: stable\">\n    <div style=\"width: 100%;height: 1000px\">\n      <a-affix :target=\"() => container\">\n        <a-button type=\"primary\">\n          Fixed at the top of container\n        </a-button>\n      </a-affix>\n    </div>\n  </div>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Alert",
@@ -2130,14 +2131,43 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Alert by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Alert 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { AlertProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: AlertProps['classes'] = {\n  root: 'demo-alert-root',\n}\n\nconst stylesObject: AlertProps['styles'] = {\n  icon: {\n    fontSize: '18px',\n  },\n  section: {\n    fontWeight: 500,\n  },\n}\n\nconst stylesFn: AlertProps['styles'] = (info) => {\n  if (info?.props?.type === 'success') {\n    return {\n      root: {\n        backgroundColor: 'rgba(82, 196, 26, 0.1)',\n        borderColor: '#b7eb8f',\n      },\n      icon: {\n        color: '#52c41a',\n      },\n    }\n  }\n  if (info?.props?.type === 'warning') {\n    return {\n      root: {\n        backgroundColor: 'rgba(250, 173, 20, 0.1)',\n        borderColor: '#ffe58f',\n      },\n      icon: {\n        color: '#faad14',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"small\">\n    <a-alert\n      title=\"Object styles\"\n      type=\"info\"\n      show-icon\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n    >\n      <template #action>\n        <a-button size=\"small\">\n          Action\n        </a-button>\n      </template>\n    </a-alert>\n    <a-alert\n      title=\"Function styles\"\n      type=\"success\"\n      show-icon\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with border, background, padding, border-radius, and positioning styles for the alert container",
+          "descriptionZh": "根元素，包含边框、背景色、内边距、圆角、位置布局等警告提示框的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Alert\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-alert\n        closable\n        title=\"Info Text\"\n        show-icon\n        description=\"Info Description Info Description Info Description Info Description\"\n        type=\"info\"\n        :classes=\"classes\"\n      >\n        <template #action>\n          <a-flex vertical gap=\"small\" :style=\"{ minWidth: '80px' }\">\n            <a-button size=\"small\" type=\"primary\" block>\n              Accept\n            </a-button>\n            <a-button size=\"small\" danger ghost block>\n              Decline\n            </a-button>\n          </a-flex>\n        </template>\n      </a-alert>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Content element with flex layout controlling content area typography and minimum width",
+          "descriptionZh": "内容元素，采用 flex 布局控制内容区域的排版和最小宽度"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with color, line-height, and margin styles, supporting different status icon types",
+          "descriptionZh": "图标元素，包含图标的颜色、行高、外边距等样式，支持不同类型的状态图标"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text color and font styling for the alert title",
+          "descriptionZh": "标题元素，包含标题文字的颜色、字体等样式"
+        },
+        {
+          "key": "description",
+          "description": "Description element with font-size and line-height styles for additional content",
+          "descriptionZh": "描述元素，包含描述文字的字体大小、行高等排版样式"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element with layout and spacing styles for action buttons",
+          "descriptionZh": "操作组元素，包含操作按钮的布局和间距样式"
+        },
+        {
+          "key": "close",
+          "description": "Close button element with basic button styling",
+          "descriptionZh": "关闭按钮元素，包含按钮的基础样式"
         }
       ]
     },
@@ -2375,14 +2405,28 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Anchor by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "您可以通过 `classes` 和 `styles` 传入对象/函数可以自定义 Anchor 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { AnchorProps } from 'antdv-next'\n\nconst classesObject: AnchorProps['classes'] = {\n  root: 'demo-anchor-root',\n  item: 'demo-anchor-item',\n  itemTitle: 'demo-anchor-title',\n  indicator: 'demo-anchor-indicator',\n}\n\nconst stylesFn: AnchorProps['styles'] = (info) => {\n  if (info.props.direction === 'vertical') {\n    return {\n      root: {\n        backgroundColor: 'rgba(255,251,230,0.5)',\n        height: '100vh',\n      },\n    }\n  }\n  return {}\n}\n\nconst items: NonNullable<AnchorProps['items']> = [\n  {\n    key: 'part-1',\n    href: '#part-1',\n    title: 'Part 1',\n  },\n  {\n    key: 'part-2',\n    href: '#part-2',\n    title: 'Part 2',\n  },\n  {\n    key: 'part-3',\n    href: '#part-3',\n    title: 'Part 3',\n  },\n]\n</script>\n\n<template>\n  <a-row>\n    <a-col :span=\"16\">\n      <div id=\"part-1\" style=\"height: 100vh; background: rgba(255, 0, 0, 0.08)\" />\n      <div id=\"part-2\" style=\"height: 100vh; background: rgba(0, 255, 0, 0.08)\" />\n      <div id=\"part-3\" style=\"height: 100vh; background: rgba(0, 0, 255, 0.08)\" />\n    </a-col>\n    <a-col :span=\"8\">\n      <a-anchor replace :items=\"items\" :styles=\"stylesFn\" :classes=\"classesObject\" />\n    </a-col>\n  </a-row>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with layout positioning, padding, margin, background color and other basic styles",
+          "descriptionZh": "根元素，包含布局定位、内边距、边距、背景色等基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'itemTitle', desc: t('itemTitle'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n])\n\nconst items = [\n  {\n    key: 'api',\n    href: '#api',\n    title: 'API',\n    children: [\n      { key: '4', href: '#anchor-props', title: 'Anchor Props' },\n      { key: '5', href: '#link-props', title: 'Link Props' },\n    ],\n  },\n  { key: '1', href: '#anchor-demo-basic', title: 'Basic demo' },\n  { key: '2', href: '#anchor-demo-static', title: 'Static demo' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Anchor\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-anchor :affix=\"false\" :items=\"items\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Link item element with padding, text color, hover states, transition animations and other styles",
+          "descriptionZh": "链接项元素，包含内边距、文字颜色、悬停状态、过渡动画等样式"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Title text element with font styles, color changes, text decoration, transition effects and other styles",
+          "descriptionZh": "标题文字元素，包含字体样式、颜色变化、文本装饰、过渡效果等样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element with width, height, background color, position changes, transition animations and other styles",
+          "descriptionZh": "指示器元素，包含宽度、高度、背景色、位置变化、过渡动画等样式"
         }
       ]
     },
@@ -2445,7 +2489,8 @@
           "descriptionZh": "对 `message`、`notification` 进行配置。。",
           "code": "<script setup lang=\"ts\">\nimport MyPage2 from './myPage2.vue'\n</script>\n\n<template>\n  <a-app :message=\"{ maxCount: 1 }\" :notification=\"{ placement: 'bottomLeft' }\">\n    <MyPage2 />\n  </a-app>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "AutoComplete",
@@ -2770,14 +2815,53 @@
           "description": "Disabled custom input debug.",
           "descriptionZh": "禁用自定义输入组件 Debug。",
           "code": "<script setup lang=\"ts\">\n</script>\n\n<template>\n  <a-flex :gap=\"12\" wrap>\n    <a-input disabled placeholder=\"Regular Input\" />\n    <a-auto-complete disabled>\n      <a-textarea disabled />\n    </a-auto-complete>\n    <a-select disabled :options=\"[]\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, cursor styles, transitions, border and other basic selector container styles",
+          "descriptionZh": "根元素，包含相对定位、行内 flex 布局、光标样式、过渡动画、边框等选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'placeholder', desc: t('placeholder') },\n  { name: 'content', desc: t('content') },\n  { name: 'clear', desc: t('clear') },\n  { name: 'popup.root', desc: t('popup.root') },\n  { name: 'popup.list', desc: t('popup.list') },\n  { name: 'popup.listItem', desc: t('popup.listItem') },\n])\n\nconst options = ref([\n  { value: 'aojunhao123', label: 'aojunhao123' },\n  { value: 'thinkasany', label: 'thinkasany' },\n  { value: 'meet-student', label: 'meet-student' },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"AutoComplete\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <a-auto-complete\n          prefix=\"prefix\"\n          :style=\"{ width: '200px' }\"\n          :options=\"options\"\n          placeholder=\"input here\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with layout and styling for prefix content",
+          "descriptionZh": "前缀元素，包含前缀内容的布局和样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with search input styling, cursor control, font inheritance and other search-related styles. Remove border styles",
+          "descriptionZh": "输入框元素，包含搜索输入框的样式、光标控制、字体继承等搜索相关样式，去除了边框样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "clear",
+          "description": "Clear button element with layout, styling and interactive effects for clear button",
+          "descriptionZh": "清除按钮元素，包含清除按钮的布局、样式和交互效果"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with popup layer positioning, z-index, background, border, box-shadow and other popup container styles",
+          "descriptionZh": "弹出菜单元素，包含弹出层的定位、层级、背景、边框、阴影等弹出容器样式"
+        },
+        {
+          "key": "popup.list",
+          "description": "Popup list element with option list layout, scrolling, max-height and other list container styles",
+          "descriptionZh": "弹出菜单列表元素，包含选项列表的布局、滚动、最大高度等列表容器样式"
+        },
+        {
+          "key": "popup.listItem",
+          "description": "Popup item element with option item padding, hover effects, selected states, disabled states and other option interactive styles",
+          "descriptionZh": "弹出菜单条目元素，包含选项项的内边距、悬浮效果、选中状态、禁用状态等选项交互样式"
         }
       ]
     },
@@ -3066,7 +3150,8 @@
           "descriptionZh": "头像大小可以根据屏幕大小自动调整。",
           "code": "<script setup lang=\"ts\">\nimport { AntDesignOutlined } from '@antdv-next/icons'\n</script>\n\n<template>\n  <a-avatar\n    :size=\"{ xs: 24, sm: 32, md: 40, lg: 64, xl: 80, xxl: 100 }\"\n  >\n    <template #icon>\n      <AntDesignOutlined />\n    </template>\n  </a-avatar>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Badge",
@@ -3343,22 +3428,33 @@
           "description": "The badge will display `title` when hovered over, instead of `count`.",
           "descriptionZh": "设置鼠标放在状态点上时显示的文字。",
           "code": "<script setup lang=\"ts\">\n</script>\n\n<template>\n  <a-space size=\"large\">\n    <a-badge :count=\"5\" title=\"Custom hover text\">\n      <a-avatar shape=\"square\" size=\"large\" />\n    </a-badge>\n    <a-badge :count=\"-5\" title=\"Negative\">\n      <a-avatar shape=\"square\" size=\"large\" />\n    </a-badge>\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-block display, and fit-content width for basic layout",
+          "descriptionZh": "根元素，包含相对定位、行内块布局、适应内容宽度等基础布局样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Badge\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-badge :count=\"5\" :classes=\"classes\">\n        <a-avatar shape=\"square\" size=\"large\" />\n      </a-badge>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "indicator",
+          "description": "Indicator element with positioning, z-index, dimensions, colors, fonts, text alignment, background, border-radius, box-shadow, and transition animations for complete badge styling",
+          "descriptionZh": "指示器元素，包含定位、层级、尺寸、颜色、字体、文本对齐、背景、圆角、阴影、过渡动画等完整的徽标样式"
         },
         {
-          "name": "_semantic_ribbon",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('ribbonRoot'), version: '1.0.0' },\n  { name: 'indicator', desc: t('ribbonIndicator'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <div style=\"display: flex; flex-direction: column; gap: 24px;\">\n    <SemanticPreview\n      component-name=\"Badge\"\n      :semantics=\"semantics\"\n    >\n      <template #default=\"{ classes }\">\n        <div style=\"width: 100%;\">\n          <a-badge-ribbon text=\"Hippies\" color=\"magenta\" :classes=\"classes\">\n            <a-card title=\"Pushes open the window\" size=\"small\">\n              and raises the spyglass.\n            </a-card>\n          </a-badge-ribbon>\n        </div>\n      </template>\n    </SemanticPreview>\n  </div>\n</template>"
+          "key": "ribbonRoot",
+          "description": "Root element, set relative positioning and wrapper container styles",
+          "descriptionZh": "根元素，设置相对定位和包装容器样式"
+        },
+        {
+          "key": "ribbonIndicator",
+          "description": "Indicator element, set absolute positioning, padding, background color, border radius and ribbon styles",
+          "descriptionZh": "指示器元素，设置绝对定位、内边距、背景色、圆角和缎带样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element, set text color and ribbon content display styles",
+          "descriptionZh": "文本元素，设置文本颜色和缎带内容显示样式"
         }
       ]
     },
@@ -3442,7 +3538,8 @@
           "descriptionZh": "通过 `ConfigProvider` 的 theme.components 可以覆盖 BorderBeam 的 `lineWidth` token，从而调整流光的线宽。",
           "code": "<script setup lang=\"ts\">\nconst customTheme = {\n  components: {\n    BorderBeam: { lineWidth: 3 },\n  },\n}\n</script>\n\n<template>\n  <a-flex :gap=\"24\" wrap>\n    <div :style=\"{ width: '320px' }\">\n      <a-border-beam>\n        <a-card title=\"Default line width\">\n          <a-typography-text type=\"secondary\">\n            Uses the default global lineWidth token from the current theme.\n          </a-typography-text>\n        </a-card>\n      </a-border-beam>\n    </div>\n    <a-config-provider :theme=\"customTheme\">\n      <div :style=\"{ width: '320px' }\">\n        <a-border-beam>\n          <a-card title=\"Custom line width\">\n            <a-typography-text type=\"secondary\">\n              Override lineWidth from theme.token.\n            </a-typography-text>\n          </a-card>\n        </a-border-beam>\n      </div>\n    </a-config-provider>\n  </a-flex>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Breadcrumb",
@@ -3630,14 +3727,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Breadcrumb by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Breadcrumb 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { BreadcrumbProps } from 'antdv-next'\n\nconst classesObject = {\n  root: 'demo-breadcrumb-root',\n  item: 'demo-breadcrumb-item',\n  separator: 'demo-breadcrumb-separator',\n}\n\nconst stylesObject: BreadcrumbProps['styles'] = {\n  root: { border: '1px solid #f0f0f0', padding: '8px', borderRadius: '4px' },\n  item: { color: '#1890ff' },\n  separator: { color: 'rgba(0, 0, 0, 0.45)' },\n}\n\nconst stylesFn: BreadcrumbProps['styles'] = (info) => {\n  const items = info.props.items || []\n  if (items.length > 2) {\n    return {\n      root: { border: '1px solid #F5EFFF', padding: '8px', borderRadius: '4px' },\n      item: { color: '#8F87F1' },\n    }\n  }\n  return {}\n}\n\nconst items = [\n  { title: 'Antdv Next' },\n  { title: 'Component' },\n  { title: 'Breadcrumb' },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-breadcrumb\n      :classes=\"classesObject\"\n      :items=\"items.slice(0, 2)\"\n      :styles=\"stylesObject\"\n      aria-label=\"Breadcrumb with Object\"\n    />\n    <a-breadcrumb\n      :classes=\"classesObject\"\n      :items=\"items\"\n      :styles=\"stylesFn\"\n      aria-label=\"Breadcrumb with Function\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with text color, font size, icon size and other basic styles, using flex layout with ordered list",
+          "descriptionZh": "根元素，包含文字颜色、字体大小、图标尺寸等基础样式，内部使用 flex 布局的有序列表"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { HomeOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'separator', desc: t('separator'), version: '1.0.0' },\n])\n\nconst items = [\n  { href: '', title: h(HomeOutlined) },\n  { href: '', title: [h(UserOutlined), h('span', 'Application List')] },\n  { title: 'Application' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Breadcrumb\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-breadcrumb :items=\"items\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with text color, link color transitions, hover effects, padding, border-radius, height, and margin styles",
+          "descriptionZh": "Item 元素，包含文字颜色、链接的颜色变化、悬浮效果、内边距、圆角、高度、外边距等样式"
+        },
+        {
+          "key": "separator",
+          "description": "Separator element with margin and color styles for the divider",
+          "descriptionZh": "分隔符元素，包含分隔符的外边距和颜色样式"
         }
       ]
     },
@@ -4158,20 +4264,29 @@
           "code": "<script setup lang=\"ts\">\nimport type { ButtonProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: ButtonProps['classes'] = {\n  root: 'demo-button-root',\n  content: 'demo-button-content',\n}\n\nconst stylesObject: ButtonProps['styles'] = {\n  root: {\n    boxShadow: '0 1px 2px 0 rgba(0,0,0,0.05)',\n  },\n}\n\nconst stylesFn: ButtonProps['styles'] = (info) => {\n  if (info?.props?.type === 'primary') {\n    return {\n      root: {\n        backgroundColor: '#171717',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"small\">\n    <a-button type=\"default\" :classes=\"classes\" :styles=\"stylesObject\">\n      Object\n    </a-button>\n    <a-button type=\"primary\" :classes=\"classes\" :styles=\"stylesFn\">\n      Function\n    </a-button>\n  </a-flex>\n</template>"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AntDesignOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Button\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-button type=\"primary\" :classes=\"classes\">\n        <template #icon>\n          <AntDesignOutlined />\n        </template>\n        Antdv Next\n      </a-button>\n    </template>\n  </SemanticPreview>\n</template>"
-        },
-        {
           "name": "chinese-space",
           "title": "",
           "titleZh": "移除两个汉字之间的空格",
           "description": "We add a space between two Chinese characters by default, which can be removed by setting `autoInsertSpace` to `false`.",
           "descriptionZh": "我们默认在两个汉字之间添加空格，可以通过设置 `autoInsertSpace` 为 `false` 关闭。",
           "code": "<template>\n  <a-flex gap=\"small\" wrap>\n    <a-button type=\"primary\" :auto-insert-space=\"false\">\n      确定\n    </a-button>\n    <a-button type=\"primary\" auto-insert-space>\n      确定\n    </a-button>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with comprehensive button styling including border, background, padding, border-radius, box-shadow, transitions, cursor, font-weight, alignment, and layout properties",
+          "descriptionZh": "根元素，包含边框样式、背景色、内边距、圆角、阴影效果、过渡动画、光标样式、文字权重、对齐方式等完整的按钮外观样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element that wraps button text with typography styles including nowrap, text-align center, and Chinese character spacing optimization",
+          "descriptionZh": "内容元素，包装按钮文本内容，控制文本的不换行显示、居中对齐、中文字符间距优化等文本排版样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with font-size, color inheritance, and SVG style reset for proper icon display",
+          "descriptionZh": "图标元素，包含图标的字体大小、颜色继承、SVG 样式重置等图标显示相关样式"
         }
       ]
     },
@@ -4459,14 +4574,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Calendar by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Calendar 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CalendarProps } from 'antdv-next'\nimport type { Dayjs } from 'dayjs'\n\nconst classes = {\n  root: 'custom-calendar-root',\n}\n\nconst stylesObject: CalendarProps<Dayjs>['styles'] = {\n  root: {\n    borderRadius: '8px',\n    width: '600px',\n  },\n}\n\nconst stylesFunction: CalendarProps<Dayjs>['styles'] = (info) => {\n  if (info.props.fullscreen) {\n    return {\n      root: {\n        border: '2px solid #BDE3C3',\n        borderRadius: '10px',\n        backgroundColor: 'rgba(189,227,195, 0.3)',\n      },\n    } satisfies CalendarProps<Dayjs>['styles']\n  }\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-calendar :fullscreen=\"false\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-calendar :classes=\"classes\" :styles=\"stylesFunction\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element containing background, border, border-radius and overall layout structure of the calendar component",
+          "descriptionZh": "根元素，包含日历组件的背景色、边框、圆角等基础样式和整体布局结构"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'itemContent', desc: t('itemContent'), version: '1.3.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Calendar\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-calendar :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with layout and style control for year selector, month selector and mode switcher",
+          "descriptionZh": "头部元素，包含年份选择器、月份选择器、模式切换器的布局和样式控制"
+        },
+        {
+          "key": "body",
+          "description": "Body element with padding and layout control for the calendar table that contains the calendar grid",
+          "descriptionZh": "主体元素，包含日历表格的内边距、布局控制等样式，用于容纳日历网格"
+        },
+        {
+          "key": "content",
+          "description": "Content element with width, height and table styling control for the calendar table",
+          "descriptionZh": "内容元素，包含日历表格的宽度、高度等尺寸控制和表格样式"
+        },
+        {
+          "key": "item",
+          "description": "Item element with background, border, hover state, selected state and other interactive styles for calendar cells",
+          "descriptionZh": "条目元素，包含日历单元格的背景色、边框、悬停态、选中态等交互样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Item content element with layout and styles for the calendar cell content area",
+          "descriptionZh": "条目内容元素，包含日历单元格内容区域的布局和样式"
         }
       ]
     },
@@ -4944,14 +5083,43 @@
           "description": "",
           "descriptionZh": "",
           "code": "<script setup lang=\"ts\">\nconst cover = 'https://api.dicebear.com/7.x/miniavs/svg?seed=8'\n</script>\n\n<template>\n  <a-card style=\"width: 300px\">\n    <template #cover>\n      <img alt=\"example\" :src=\"cover\">\n    </template>\n    <template #actions>\n      <span key=\"setting\">setting</span>\n      <span key=\"edit\">edit</span>\n    </template>\n  </a-card>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Card root element with positioning, background, border, border-radius, box-shadow, padding and other container styles",
+          "descriptionZh": "卡片根元素，包含位置定位、背景色、边框、圆角、阴影、内边距等卡片容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, EllipsisOutlined, SettingOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'cover', desc: t('cover'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Card\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ position: 'absolute' }\">\n        <a-card\n          title=\"Card title\"\n          extra=\"More\"\n          :style=\"{ width: '300px' }\"\n          :classes=\"classes\"\n        >\n          <template #cover>\n            <img\n              draggable=\"false\"\n              alt=\"example\"\n              src=\"https://gw.alipayobjects.com/zos/rmsportal/JiqGstEfoWAOHiTxclqi.png\"\n            >\n          </template>\n          <template #actions>\n            <SettingOutlined key=\"setting\" />\n            <EditOutlined key=\"edit\" />\n            <EllipsisOutlined key=\"ellipsis\" />\n          </template>\n          <a-card-meta\n            title=\"Card Meta title\"\n            description=\"This is the description\"\n          >\n            <template #avatar>\n              <a-avatar src=\"https://api.dicebear.com/7.x/miniavs/svg?seed=8\" />\n            </template>\n          </a-card-meta>\n        </a-card>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Card header area with flex layout, min-height, padding, text color, font-weight, font-size, background, bottom border and top border-radius",
+          "descriptionZh": "卡片头部区域，包含 flex 布局、最小高度、内边距、文字颜色、字体权重、字体大小、背景色、下边框、顶部圆角等样式"
+        },
+        {
+          "key": "body",
+          "description": "Card content area with padding, font-size and other content display styles",
+          "descriptionZh": "卡片内容区域，包含内边距、字体大小等内容展示的基础样式"
+        },
+        {
+          "key": "extra",
+          "description": "Card extra operation area in top-right corner with text color and layout styles for additional content",
+          "descriptionZh": "卡片右上角的操作区域，包含额外内容的文字颜色和布局样式"
+        },
+        {
+          "key": "title",
+          "description": "Card title with inline-block display, flex-grow, text ellipsis and other title display styles",
+          "descriptionZh": "卡片标题，包含行内块布局、flex 占比、文本省略等标题显示样式"
+        },
+        {
+          "key": "actions",
+          "description": "Card bottom action group with flex layout, list-style reset, background, top border and bottom border-radius for action buttons container",
+          "descriptionZh": "卡片底部操作组，包含 flex 布局、列表样式重置、背景色、上边框、底部圆角等操作按钮容器样式"
+        },
+        {
+          "key": "cover",
+          "description": "Title cover with styles for cover image display and layout",
+          "descriptionZh": "标题封面，包含封面图片的显示和布局样式"
         }
       ]
     },
@@ -5217,7 +5385,8 @@
           "descriptionZh": "展示指示点的进度。",
           "code": "<template>\n  <a-carousel :autoplay=\"{ dotDuration: true }\" :autoplay-speed=\"5000\">\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        1\n      </h3>\n    </div>\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        2\n      </h3>\n    </div>\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        3\n      </h3>\n    </div>\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        4\n      </h3>\n    </div>\n  </a-carousel>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Cascader",
@@ -5609,14 +5778,6 @@
           "code": "<script setup lang=\"ts\">\nimport type { CascaderEmits } from 'antdv-next'\nimport { ref } from 'vue'\n\ninterface Option {\n  value: string | number\n  label: string\n  children?: Option[]\n}\n\nconst options: Option[] = [\n  {\n    value: 'zhejiang',\n    label: 'Zhejiang',\n    children: [\n      {\n        value: 'hangzhou',\n        label: 'Hangzhou',\n        children: [\n          {\n            value: 'xihu',\n            label: 'West Lake',\n          },\n        ],\n      },\n    ],\n  },\n  {\n    value: 'jiangsu',\n    label: 'Jiangsu',\n    children: [\n      {\n        value: 'nanjing',\n        label: 'Nanjing',\n        children: [\n          {\n            value: 'zhonghuamen',\n            label: 'Zhong Hua Men',\n          },\n        ],\n      },\n    ],\n  },\n]\n\nconst disabled = ref(false)\n\nconst onChange: CascaderEmits['change'] = (value) => {\n  console.log(value)\n}\n\nconst onMultipleChange: CascaderEmits['change'] = (value) => {\n  console.log(value)\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"small\" align=\"flex-start\">\n    <a-switch\n      v-model:checked=\"disabled\"\n      checked-children=\"Enabled\"\n      un-checked-children=\"Disabled\"\n      aria-label=\"disabled switch\"\n    />\n    <a-cascader-panel :options=\"options\" :disabled=\"disabled\" @change=\"onChange\" />\n    <a-cascader-panel multiple :options=\"options\" :disabled=\"disabled\" @change=\"onMultipleChange\" />\n    <a-cascader-panel />\n  </a-flex>\n</template>"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst mode = ref<'single' | 'multiple'>('single')\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => {\n  const base = [\n    { name: 'root', desc: t('root') },\n    { name: 'prefix', desc: t('prefix') },\n    { name: 'content', desc: t('content') },\n    { name: 'placeholder', desc: t('placeholder') },\n    { name: 'clear', desc: t('clear') },\n    { name: 'input', desc: t('input') },\n    { name: 'suffix', desc: t('suffix') },\n    { name: 'popup.root', desc: t('popup.root') },\n    { name: 'popup.list', desc: t('popup.list') },\n    { name: 'popup.listItem', desc: t('popup.listItem') },\n  ]\n\n  if (mode.value === 'multiple') {\n    return [\n      ...base,\n      { name: 'item', desc: t('item') },\n      { name: 'itemContent', desc: t('itemContent') },\n      { name: 'itemRemove', desc: t('itemRemove') },\n    ]\n  }\n\n  return base\n})\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst options = [\n  {\n    value: 'contributors',\n    label: 'contributors',\n    children: [\n      { value: 'aojunhao123', label: 'aojunhao123' },\n      { value: 'thinkasany', label: 'thinkasany' },\n      { value: 'meet-student', label: 'meet-student' },\n    ],\n  },\n]\n\nconst value = computed(() => {\n  if (mode.value !== 'multiple')\n    return ['contributors', 'thinkasany']\n\n  return [['contributors', 'aojunhao123']]\n})\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Cascader\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <div :style=\"{ display: 'flex', justifyContent: 'center', marginBottom: '12px' }\">\n          <a-segmented v-model:value=\"mode\" :options=\"['single', 'multiple']\" />\n        </div>\n        <div :style=\"{ display: 'flex', flexDirection: 'column', gap: '12px' }\">\n          <a-cascader\n            prefix=\"prefix\"\n            :style=\"{ width: '300px' }\"\n            :options=\"options\"\n            :value=\"value\"\n            :multiple=\"mode === 'multiple'\"\n            open\n            :get-popup-container=\"() => divRef!\"\n            :classes=\"classes\"\n          />\n        </div>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
-        },
-        {
           "name": "basic",
           "title": "",
           "titleZh": "基本",
@@ -5663,6 +5824,73 @@
           "description": "Allows the selection of only parent options.",
           "descriptionZh": "这种交互允许只选中父级选项。",
           "code": "<script setup lang=\"ts\">\nimport type { CascaderEmits } from 'antdv-next'\nimport { shallowRef } from 'vue'\n\ninterface Option {\n  value: string\n  label: string\n  children?: Option[]\n}\n\nconst options: Option[] = [\n  {\n    value: 'zhejiang',\n    label: 'Zhejiang',\n    children: [\n      {\n        value: 'hangzhou',\n        label: 'Hanzhou',\n        children: [\n          {\n            value: 'xihu',\n            label: 'West Lake',\n          },\n        ],\n      },\n    ],\n  },\n  {\n    value: 'jiangsu',\n    label: 'Jiangsu',\n    children: [\n      {\n        value: 'nanjing',\n        label: 'Nanjing',\n        children: [\n          {\n            value: 'zhonghuamen',\n            label: 'Zhong Hua Men',\n          },\n        ],\n      },\n    ],\n  },\n]\n\nconst onChange: CascaderEmits['change'] = (value) => {\n  console.log(value)\n}\nconst value = shallowRef()\n</script>\n\n<template>\n  <a-cascader v-model:value=\"value\" :options=\"options\" change-on-select @change=\"onChange\" />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, cursor styles, transitions, border and other basic selector container styles",
+          "descriptionZh": "根元素，包含相对定位、行内 flex 布局、光标样式、过渡动画、边框等选择器容器的基础样式"
+        },
+        {
+          "key": "prefix",
+          "description": "Prefix element with layout and styling for prefix content",
+          "descriptionZh": "前缀元素，包含前缀内容的布局和样式"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "clear",
+          "description": "Clear button element with layout, styling and interactive effects for clear button式",
+          "descriptionZh": "清除按钮元素，包含清除按钮的布局、样式和交互效果"
+        },
+        {
+          "key": "item",
+          "description": "Multiple selection item element with border, background, padding, and margin styles",
+          "descriptionZh": "多选项元素，包含边框、背景、内边距、外边距样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Multiple selection item content area with text ellipsis styles",
+          "descriptionZh": "多选项内容区域，包含文字的省略样式"
+        },
+        {
+          "key": "itemRemove",
+          "description": "Multiple selection item remove button with font-related styles式",
+          "descriptionZh": "多选项移除按钮，包含字体相关样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with search input styling, cursor control, font inheritance and other search-related styles. Remove border styles",
+          "descriptionZh": "输入框元素，包含搜索输入框的样式、光标控制、字体继承等搜索相关样式，去除了边框样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with layout and styling for suffix content like clear button, arrow icon, etc.",
+          "descriptionZh": "后缀元素，包含后缀内容的布局和样式，如清除按钮、箭头图标等"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with popup layer positioning, z-index, background, border, box-shadow and other popup container styles",
+          "descriptionZh": "弹出菜单元素，包含弹出层的定位、层级、背景、边框、阴影等弹出容器样式"
+        },
+        {
+          "key": "popup.list",
+          "description": "Popup list element with option list layout, scrolling, max-height and other list container styles",
+          "descriptionZh": "弹出菜单列表元素，包含选项列表的布局、滚动、最大高度等列表容器样式"
+        },
+        {
+          "key": "popup.listItem",
+          "description": "Popup item element with option item padding, hover effects, selected states, disabled states and other option interactive styles",
+          "descriptionZh": "弹出菜单条目元素，包含选项项的内边距、悬浮效果、选中状态、禁用状态等选项交互样式式"
         }
       ]
     },
@@ -5891,14 +6119,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Checkbox by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Checkbox 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CheckboxProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\nimport { ref } from 'vue'\n\nconst checked = ref(true)\nconst { token } = theme.useToken()\n\n// Object styles — 静态样式对象\nconst stylesObject: CheckboxProps['styles'] = {\n  icon: {\n    borderRadius: '6px',\n  },\n  label: {\n    color: 'blue',\n  },\n}\n\n// Function classes — 根据 checked 状态动态返回类名\nconst classesFn: CheckboxProps['classes'] = (info) => {\n  const base: Record<string, string> = {\n    root: 'checkbox-demo-root',\n    icon: 'checkbox-demo-icon',\n    label: 'checkbox-demo-label',\n  }\n  if (info.props.checked) {\n    return {\n      root: base.root,\n      icon: `${base.icon} checkbox-demo-icon-checked`,\n      label: `${base.label} checkbox-demo-label-checked`,\n    }\n  }\n  return base\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-checkbox :styles=\"stylesObject\">\n      Object styles\n    </a-checkbox>\n    <a-checkbox\n      v-model:checked=\"checked\"\n      :classes=\"classesFn\"\n    >\n      Function classes\n    </a-checkbox>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with inline-flex layout, baseline alignment, cursor style, reset styles and other basic checkbox container styles",
+          "descriptionZh": "根元素，包含行内 flex 布局、基线对齐、光标样式、重置样式等复选框容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Checkbox\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-checkbox :classes=\"classes\">\n        Checkbox\n      </a-checkbox>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Checkbox icon element with size, direction, background, border, border-radius, transitions, and checked state checkmark styles",
+          "descriptionZh": "选中框元素，包含尺寸、方向、背景色、边框、圆角、过渡动画，以及选中状态的勾选标记样式"
+        },
+        {
+          "key": "label",
+          "description": "Label text element with padding and spacing styles relative to the checkbox",
+          "descriptionZh": "文本元素，包含文本的内边距和与复选框的间距样式"
         }
       ]
     },
@@ -6246,14 +6483,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Collapse by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Collapse 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CollapseProps } from 'antdv-next'\nimport { h } from 'vue'\n\nconst text\n  = 'A dog is a type of domesticated animal. Known for its loyalty and faithfulness, it can be found as a welcome guest in many households across the world.'\n\nconst element = h('p', text)\n\nconst items = [\n  {\n    key: '1',\n    label: 'This is panel header 1',\n    content: element,\n  },\n  {\n    key: '2',\n    label: 'This is panel header 2',\n    content: element,\n  },\n  {\n    key: '3',\n    label: 'This is panel header 3',\n    content: element,\n  },\n]\n\nconst classes: CollapseProps['classes'] = {\n  root: 'demo-collapse-root',\n}\n\nconst stylesObject: CollapseProps['styles'] = {\n  root: {\n    backgroundColor: '#fafafa',\n    border: '1px solid #e0e0e0',\n    borderRadius: '8px',\n  },\n  header: {\n    backgroundColor: '#f0f0f0',\n    padding: '12px 16px',\n    color: '#141414',\n  },\n}\n\nconst stylesFn: CollapseProps['styles'] = (info) => {\n  if (info?.props?.size === 'large') {\n    return {\n      root: {\n        backgroundColor: '#fff',\n        border: '1px solid #696FC7',\n        borderRadius: '8px',\n      },\n      header: {\n        backgroundColor: '#F5EFFF',\n        padding: '12px 16px',\n        color: '#141414',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-collapse :items=\"items\" :classes=\"classes\" :styles=\"stylesObject\" :default-active-key=\"['1']\" />\n    <a-collapse :items=\"items\" :classes=\"classes\" :styles=\"stylesFn\" size=\"large\" :default-active-key=\"['2']\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with border, border-radius, background color and container styles that control the overall layout and appearance of collapse panels",
+          "descriptionZh": "根元素，包含折叠面板的边框、圆角、背景色等容器样式，控制面板的整体布局和外观"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { theme } from 'antdv-next'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n])\n\nconst { token } = theme.useToken()\n\nconst items = computed(() => [\n  {\n    key: '1',\n    label: 'This is panel header',\n    children: 'This is panel body',\n  },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Collapse\"\n    items-a-p-i=\"items\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ position: 'absolute', inset: 0, margin: `${token.marginXL}px` }\">\n        <a-collapse\n          :items=\"items\"\n          :default-active-key=\"['1']\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with flex layout, padding, color, line-height, cursor style, transition animations and other interactive styles for panel headers",
+          "descriptionZh": "头部元素，包含flex布局、内边距、颜色、行高、光标样式、过渡动画等面板头部的交互和样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with flex auto layout and margin styles for title text layout and typography",
+          "descriptionZh": "标题元素，包含flex自适应布局、右边距等标题文字的布局和排版样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with padding, color, background color and other styles for panel content area display",
+          "descriptionZh": "内容元素，包含内边距、颜色、背景色等面板内容区域的展示样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with font size, transition animations, rotation transforms and other styles and animations for expand/collapse arrows",
+          "descriptionZh": "图标元素，包含字体大小、过渡动画、旋转变换等展开收起箭头的样式和动效"
         }
       ]
     },
@@ -6601,14 +6857,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of ColorPicker by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或函数可以自定义 ColorPicker 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst classes = { root: 'custom-color-picker' }\n\nconst color = shallowRef('#1677ff')\nconst colorLarge = shallowRef('#722ed1')\n\nconst stylesObject = {\n  popup: {\n    root: {\n      border: '1px solid #fff',\n    },\n  },\n}\n\nfunction stylesFn(info: any) {\n  if (info?.props?.size === 'large') {\n    return {\n      popup: {\n        root: {\n          border: '1px solid #722ed1',\n        },\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-space size=\"middle\" wrap>\n    <a-color-picker\n      v-model:value=\"color\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    />\n    <a-color-picker\n      v-model:value=\"colorLarge\"\n      size=\"large\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n    />\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Trigger container with border styles, transition animations, size controls, displaying color block and text content",
+          "descriptionZh": "触发器容器，包含边框样式、过渡动画、尺寸控制等样式，显示颜色块和文本内容"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'body', desc: t('body') },\n  { name: 'content', desc: t('content') },\n  { name: 'description', desc: t('description') },\n  { name: 'popup.root', desc: t('popup.root') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\nconst body = document?.body\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"ColorPicker\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" :style=\"{ height: '300px' }\" align=\"flex-start\" gap=\"small\">\n        <a-color-picker\n          default-value=\"#1677ff\"\n          open\n          show-text\n          :get-popup-container=\"() => divRef || body\"\n          :styles=\"{ popup: { root: { zIndex: 1 } } }\"\n          :classes=\"classes\"\n        />\n        <a-color-picker :open=\"false\" allow-clear :classes=\"classes\" />\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "popup.root",
+          "description": "Popup panel root container with background color, shadow effects, color selection panel, slider controls and preset colors",
+          "descriptionZh": "弹出面板根容器，包含背景色、阴影效果、色彩选择面板、滑块控制和预设颜色等样式"
+        },
+        {
+          "key": "body",
+          "description": "Color block container with background color, border styles",
+          "descriptionZh": "色块容器，包含底色、边框等样式"
+        },
+        {
+          "key": "content",
+          "description": "Color block element with actual selected color styles",
+          "descriptionZh": "色块颜色元素，包含实际选择的颜色样式"
+        },
+        {
+          "key": "description",
+          "description": "Description text content with font styles and color",
+          "descriptionZh": "描述文本内容，包含字体样式、颜色等样式"
         }
       ]
     },
@@ -6822,7 +7097,8 @@
           "descriptionZh": "获取父级 `Provider` 的值。如 `DisabledContextProvider`、`SizeContextProvider`。",
           "code": "<script setup lang=\"ts\">\nimport type { ConfigProviderProps } from 'antdv-next'\nimport { ref } from 'vue'\nimport ConfigDisplay from './use-config-display.vue'\n\ntype SizeType = ConfigProviderProps['componentSize']\n\nconst componentSize = ref<SizeType>('small')\nconst disabled = ref(true)\n</script>\n\n<template>\n  <div>\n    <a-space>\n      <a-radio-group v-model:value=\"componentSize\">\n        <a-radio-button value=\"small\">\n          Small\n        </a-radio-button>\n        <a-radio-button value=\"middle\">\n          Middle\n        </a-radio-button>\n        <a-radio-button value=\"large\">\n          Large\n        </a-radio-button>\n      </a-radio-group>\n      <a-checkbox v-model:checked=\"disabled\">\n        Form disabled\n      </a-checkbox>\n    </a-space>\n    <a-divider />\n    <a-config-provider :component-size=\"componentSize\">\n      <div class=\"example\">\n        <a-form :disabled=\"disabled\">\n          <ConfigDisplay />\n        </a-form>\n      </div>\n    </a-config-provider>\n  </div>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "DatePicker",
@@ -7449,14 +7725,63 @@
           "description": "Custom `prefix` and `suffixIcon`.",
           "descriptionZh": "自定义前缀 `prefix` 和后缀图标 `suffixIcon`。",
           "code": "<script setup lang=\"ts\">\nimport type { Dayjs } from 'dayjs'\nimport { SmileOutlined } from '@antdv-next/icons'\nimport { h } from 'vue'\n\nconst smileIcon = h(SmileOutlined)\n\nfunction handleChange(date: Dayjs | (Dayjs | null)[] | null, dateString: string | string[] | null) {\n  console.log(date, dateString)\n}\n</script>\n\n<template>\n  <a-space vertical :size=\"12\">\n    <a-date-picker :suffix-icon=\"smileIcon\" @change=\"handleChange\" />\n    <a-date-picker :suffix-icon=\"smileIcon\" picker=\"month\" @change=\"handleChange\" />\n    <a-range-picker :suffix-icon=\"smileIcon\" @change=\"handleChange\" />\n    <a-date-picker :suffix-icon=\"smileIcon\" picker=\"week\" @change=\"handleChange\" />\n    <a-date-picker suffix-icon=\"ab\" @change=\"handleChange\" />\n    <a-date-picker suffix-icon=\"ab\" picker=\"month\" @change=\"handleChange\" />\n    <a-range-picker suffix-icon=\"ab\" @change=\"handleChange\" />\n    <a-date-picker suffix-icon=\"ab\" picker=\"week\" @change=\"handleChange\" />\n    <a-date-picker :prefix=\"smileIcon\" picker=\"week\" @change=\"handleChange\" />\n    <a-date-picker prefix=\"Event Period\" picker=\"week\" @change=\"handleChange\" />\n    <a-range-picker :prefix=\"smileIcon\" picker=\"week\" @change=\"handleChange\" />\n    <a-range-picker prefix=\"Event Period\" picker=\"week\" @change=\"handleChange\" />\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, padding, border-radius, transition animations and other basic styles for date picker container",
+          "descriptionZh": "根元素，包含相对定位、行内flex布局、内边距、边框圆角、过渡动画等日期选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { SmileOutlined } from '@antdv-next/icons'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'popup.root', desc: t('popup') },\n  { name: 'popup.container', desc: t('popup.container') },\n  { name: 'popup.header', desc: t('popup.header') },\n  { name: 'popup.body', desc: t('popup.body') },\n  { name: 'popup.content', desc: t('popup.content') },\n  { name: 'popup.item', desc: t('popup.item') },\n  { name: 'popup.footer', desc: t('popup.footer') },\n])\n\nconst type = ref<'Single' | 'Multiple'>('Single')\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    :component-name=\"type === 'Single' ? 'DatePicker' : 'DatePicker.RangePicker'\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" vertical :style=\"{ alignSelf: 'flex-start' }\" gap=\"middle\" align=\"center\">\n        <a-segmented\n          :options=\"['Single', 'Multiple']\"\n          :value=\"type\"\n          @change=\"(val: 'Single' | 'Multiple') => type = val\"\n        />\n        <a-date-picker\n          v-if=\"type === 'Single'\"\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-date-picker>\n        <a-range-picker\n          v-else\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-range-picker>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with flex layout and margin styles for prefix content layout",
+          "descriptionZh": "前缀元素，包含flex布局、右外边距等前缀内容的布局样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with relative positioning, width, color, font, line-height, transition animations and other core interactive styles for input field",
+          "descriptionZh": "输入框元素，包含相对定位、宽度、颜色、字体、行高、过渡动画等输入框的核心交互样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with flex layout, color, line-height, pointer events, transition animations and other styles for suffix content",
+          "descriptionZh": "后缀元素，包含flex布局、颜色、行高、指针事件、过渡动画等后缀内容的样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup element",
+          "descriptionZh": "弹出框元素"
+        },
+        {
+          "key": "popup.container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "popup.header",
+          "description": "Popup header element with navigation buttons, month/year selectors and other header control area layout and styles",
+          "descriptionZh": "弹出框头部元素，包含导航按钮、月份年份选择器等头部控制区域的布局和样式"
+        },
+        {
+          "key": "popup.body",
+          "description": "Popup body element with container layout and styles for date panel table",
+          "descriptionZh": "弹出框主体元素，包含日期面板表格的容器布局和样式"
+        },
+        {
+          "key": "popup.content",
+          "description": "Popup content element with width, border, cell and other content display styles for date table",
+          "descriptionZh": "弹出框内容元素，包含日期表格的宽度、边框、单元格等内容展示样式"
+        },
+        {
+          "key": "popup.item",
+          "description": "Popup item element with size, background, border-radius, hover state, selected state and other interactive styles for date cells",
+          "descriptionZh": "弹出框单项元素，包含日期单元格的尺寸、背景色、边框圆角、悬停态、选中态等交互样式"
+        },
+        {
+          "key": "popup.footer",
+          "description": "Popup footer element with layout styles for bottom operation area including confirm/cancel buttons and shortcuts",
+          "descriptionZh": "弹出框底部元素，包含确认取消按钮、快捷选择等底部操作区域的布局样式"
         }
       ]
     },
@@ -7710,14 +8035,38 @@
           "description": "Display of the entire line.",
           "descriptionZh": "整行的展示。",
           "code": "<script setup lang=\"ts\">\nimport type { DescriptionsItemType } from 'antdv-next'\n\nconst items: DescriptionsItemType[] = [\n  {\n    label: 'UserName',\n    content: 'Zhou Maomao',\n  },\n  {\n    label: 'Live',\n    span: 'filled', // span = 2\n    content: 'Hangzhou, Zhejiang',\n  },\n  {\n    label: 'Remark',\n    span: 'filled', // span = 3\n    content: 'empty',\n  },\n  {\n    label: 'Address',\n    span: 1, // span will be 3 and warning for span is not align to the end\n    content: 'No. 18, Wantang Road, Xihu District, Hangzhou, Zhejiang, China',\n  },\n]\n</script>\n\n<template>\n  <a-descriptions title=\"User Info\" :items=\"items\" bordered />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with basic styles, reset styles, border styles, layout direction and other overall styles for description list container",
+          "descriptionZh": "根元素，包含描述列表容器的基础样式、重置样式、边框样式、布局方向等整体样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n\nconst bordered = ref(false)\n\nconst items = [\n  { key: '1', label: 'Telephone', content: '1810000000' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Descriptions\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ width: '100%', height: '100%' }\">\n        <a-switch v-model:checked=\"bordered\" />\n        Toggle Border\n        <a-divider />\n        <a-descriptions\n          title=\"User Info\"\n          :items=\"items\"\n          :bordered=\"bordered\"\n          :classes=\"classes\"\n        >\n          <template #extra>\n            <a-button type=\"primary\">\n              Edit\n            </a-button>\n          </template>\n        </a-descriptions>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with flex layout, alignment, bottom margin and other layout and style controls for header area",
+          "descriptionZh": "头部元素，包含flex布局、对齐方式、下边距等头部区域的布局和样式控制"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text ellipsis, flex ratio, color, font weight, font size, line height and other title text styles",
+          "descriptionZh": "标题元素，包含文本省略、flex占比、颜色、字体权重、字体大小、行高等标题文字样式"
+        },
+        {
+          "key": "extra",
+          "description": "Extra content element with left margin, color, font size and other styles for additional operation area",
+          "descriptionZh": "额外内容元素，包含左边距、颜色、字体大小等额外操作区域的样式"
+        },
+        {
+          "key": "label",
+          "description": "Label element with color, font weight, font size, line height, text align, colon styles and other label text styles",
+          "descriptionZh": "标签元素，包含颜色、字体权重、字体大小、行高、文本对齐、冒号样式等标签文字的样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with table cell layout, color, font size, line height, word break and other content display styles",
+          "descriptionZh": "内容元素，包含表格单元格布局、颜色、字体大小、行高、文字换行等内容展示样式"
         }
       ]
     },
@@ -7886,14 +8235,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of divider by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义分割线的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { DividerProps } from 'antdv-next'\n\nconst classesObject: DividerProps['classes'] = {\n  root: 'demo-divider-root',\n  content: 'demo-divider-content',\n  rail: 'demo-divider-rail',\n}\n\nconst classesFn: DividerProps['classes'] = (info) => {\n  if (info?.props?.titlePlacement === 'start') {\n    return {\n      root: 'demo-divider-root--start',\n    }\n  }\n  return {\n    root: 'demo-divider-root--default',\n  }\n}\n\nconst stylesObject: DividerProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed' },\n  content: { fontStyle: 'italic' },\n  rail: { opacity: 0.85 },\n}\n\nconst stylesFn: DividerProps['styles'] = (info) => {\n  if (info?.props?.size === 'small') {\n    return {\n      root: { opacity: 0.6, cursor: 'default' },\n    }\n  }\n  return {\n    root: { backgroundColor: '#fafafa', borderColor: '#d9d9d9' },\n  }\n}\n</script>\n\n<template>\n  <div>\n    <a-divider :classes=\"classesObject\">\n      classes Object\n    </a-divider>\n    <a-divider title-placement=\"start\" :classes=\"classesFn\">\n      classes Function\n    </a-divider>\n    <a-divider :styles=\"stylesObject\">\n      styles Object\n    </a-divider>\n    <a-divider size=\"small\" :styles=\"stylesFn\">\n      styles Function\n    </a-divider>\n  </div>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with border-top style, divider styling and other basic divider container styles",
+          "descriptionZh": "根元素，包含边框顶部样式、分隔线样式等分割线容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'rail', desc: t('rail') },\n  { name: 'content', desc: t('content') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Divider\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div>\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider :classes=\"classes\" />\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider :classes=\"classes\">\n          Solid\n        </a-divider>\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider title-placement=\"left\" variant=\"dotted\" :classes=\"classes\">\n          Dotted\n        </a-divider>\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider title-placement=\"right\" variant=\"dashed\" :classes=\"classes\">\n          Dashed\n        </a-divider>\n        These\n        <a-divider orientation=\"vertical\" :classes=\"classes\" />\n        are\n        <a-divider orientation=\"vertical\" :classes=\"classes\" />\n        vertical\n        <a-divider orientation=\"vertical\" :classes=\"classes\" />\n        Dividers\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "content",
+          "description": "Content element with inline-block display, padding and other divider text content styles",
+          "descriptionZh": "内容元素，包含行内块显示、内边距等分割线文本内容的样式"
+        },
+        {
+          "key": "rail",
+          "description": "Background rail element with border-top style and other divider connection line styles",
+          "descriptionZh": "背景条元素，包含边框顶部样式等分割线连接条的样式"
         }
       ]
     },
@@ -8270,14 +8628,58 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Drawer by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Drawer 组件的 [语义化结构](#semantic-dom) 样式。",
           "code": "<script setup lang=\"ts\">\nimport type { DrawerProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\nimport { ref } from 'vue'\n\nconst { token } = theme.useToken()\nconst open = ref(false)\nconst openFn = ref(false)\n\nconst classes: DrawerProps['classes'] = {\n  header: 'demo-drawer-header',\n  body: 'demo-drawer-body',\n}\n\nconst stylesObject: DrawerProps['styles'] = {\n  body: {\n    backgroundColor: '#f5f5f5',\n  },\n  footer: {\n    backgroundColor: '#fafafa',\n  },\n}\n\nconst stylesFn: DrawerProps['styles'] = (info) => {\n  if (info?.props?.placement === 'right') {\n    return {\n      mask: {\n        backgroundColor: 'rgba(0, 0, 0, 0.2)',\n      },\n      wrapper: {\n        boxShadow: '0 8px 24px rgba(0, 0, 0, 0.15)',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-button @click=\"open = true\">\n      Object Style\n    </a-button>\n    <a-button type=\"primary\" @click=\"openFn = true\">\n      Function Style\n    </a-button>\n  </a-flex>\n\n  <a-drawer\n    v-model:open=\"open\"\n    title=\"Custom Style Drawer\"\n    :classes=\"classes\"\n    :styles=\"stylesObject\"\n    @close=\"open = false\"\n  >\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n  </a-drawer>\n\n  <a-drawer\n    v-model:open=\"openFn\"\n    title=\"Custom Function Drawer\"\n    :classes=\"classes\"\n    :styles=\"stylesFn\"\n    @close=\"openFn = false\"\n  >\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n  </a-drawer>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with fixed positioning, z-index control, pointer events, color and other basic styles and layout control for drawer container",
+          "descriptionZh": "根元素，包含固定定位、层级控制、指针事件、颜色等抽屉容器的基础样式和布局控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'mask', desc: t('mask'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n  { name: 'dragger', desc: t('dragger'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Drawer\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-drawer\n        title=\"Title\"\n        placement=\"right\"\n        open\n        :get-container=\"false\"\n        :size=\"300\"\n        :resizable=\"{}\"\n        :classes=\"classes\"\n      >\n        <template #footer>\n          <a-typography-link>Footer</a-typography-link>\n        </template>\n        <template #extra>\n          <a-button>Cancel</a-button>\n        </template>\n        <p>Some contents...</p>\n      </a-drawer>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "mask",
+          "description": "Mask element with absolute positioning, z-index, background color, pointer events and other mask layer styles and interaction controls",
+          "descriptionZh": "遮罩层元素，包含绝对定位、层级、背景色、指针事件等遮罩层的样式和交互控制"
+        },
+        {
+          "key": "section",
+          "description": "Drawer container element with flex layout, width/height, overflow control, background color, pointer events and other drawer body styles",
+          "descriptionZh": "Drawer 容器元素，包含flex布局、宽高、溢出控制、背景色、指针事件等抽屉主体的样式"
+        },
+        {
+          "key": "header",
+          "description": "Header element with flex layout, alignment, padding, font size, line height, bottom border and other header area styles",
+          "descriptionZh": "头部元素，包含flex布局、对齐方式、内边距、字体大小、行高、下边框等头部区域的样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with flex ratio, minimum size, padding, overflow scroll and other content area display and layout styles",
+          "descriptionZh": "内容元素，包含flex占比、最小尺寸、内边距、溢出滚动等内容区域的展示和布局样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with flex shrink, padding, top border and other bottom operation area styles",
+          "descriptionZh": "底部元素，包含flex收缩、内边距、上边框等底部操作区域的样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with flex ratio, margin, font weight, font size, line height and other title text styles",
+          "descriptionZh": "标题元素，包含flex占比、外边距、字体权重、字体大小、行高等标题文字的样式"
+        },
+        {
+          "key": "extra",
+          "description": "Extra element with flex fixed layout and other additional operation content style controls",
+          "descriptionZh": "额外元素，包含flex固定布局等额外操作内容的样式控制"
+        },
+        {
+          "key": "dragger",
+          "description": "Dragger element used to resize the drawer, with absolute positioning, transparent background, pointer events control, hover state styles, and dragging state styles",
+          "descriptionZh": "拖拽元素，用于调整抽屉大小的拖拽手柄，包含绝对定位、背景透明、指针事件控制、hover状态样式、拖拽状态样式等"
+        },
+        {
+          "key": "close",
+          "description": "Close button element with basic button styling",
+          "descriptionZh": "关闭按钮元素，包含按钮的基础样式"
         }
       ]
     },
@@ -8634,14 +9036,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of the Dropdown by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Dropdown 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { DropdownProps, MenuItemType } from 'antdv-next'\nimport { DownOutlined, LogoutOutlined, SettingOutlined } from '@antdv-next/icons'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst items: MenuItemType[] = [\n  {\n    key: '1',\n    label: 'Profile',\n  },\n  {\n    key: '2',\n    label: 'Settings',\n    icon: SettingOutlined,\n  },\n  {\n    type: 'divider',\n  },\n  {\n    key: '3',\n    label: 'Logout',\n    icon: LogoutOutlined,\n    danger: true,\n  },\n]\n\nconst classes: DropdownProps['classes'] = {\n  root: 'demo-dropdown-root',\n}\n\nconst objectStyles: DropdownProps['styles'] = {\n  root: {\n    backgroundColor: '#ffffff',\n    border: '1px solid #d9d9d9',\n    borderRadius: '4px',\n  },\n  item: {\n    padding: '8px 12px',\n    fontSize: '14px',\n  },\n  itemTitle: {\n    fontWeight: '500',\n  },\n  itemIcon: {\n    color: '#1890ff',\n    marginRight: '8px',\n  },\n  itemContent: {\n    backgroundColor: 'transparent',\n  },\n}\n\nconst functionStyles: DropdownProps['styles'] = (info) => {\n  const isClick = info.props.trigger?.includes('click')\n  if (isClick) {\n    return {\n      root: {\n        borderColor: '#1890ff',\n        borderRadius: '8px',\n      },\n    }\n  }\n  return {}\n}\n\nconst sharedProps: DropdownProps = {\n  menu: { items },\n  placement: 'bottomLeft',\n  classes,\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\" wrap=\"wrap\">\n    <a-space direction=\"vertical\" size=\"large\">\n      <a-dropdown v-bind=\"sharedProps\" :styles=\"objectStyles\">\n        <a-button>\n          <a-space>\n            Object Style\n            <DownOutlined />\n          </a-space>\n        </a-button>\n      </a-dropdown>\n\n      <a-dropdown v-bind=\"sharedProps\" :styles=\"functionStyles\" :trigger=\"['click']\">\n        <a-button type=\"primary\">\n          <a-space>\n            Function Style\n            <DownOutlined />\n          </a-space>\n        </a-button>\n      </a-dropdown>\n    </a-space>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element of dropdown, sets positioning, z-index and container styles",
+          "descriptionZh": "dropdown 的根元素，设置定位、层级和容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { DeleteOutlined, DownOutlined, EditOutlined, SaveOutlined } from '@antdv-next/icons'\nimport { computed, h, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'itemTitle', desc: t('itemTitle') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst items: any[] = [\n  {\n    key: '1',\n    type: 'group',\n    label: 'Group title',\n    children: [\n      { key: '1-1', label: '1st menu item', icon: h(SaveOutlined) },\n      { key: '1-2', label: '2nd menu item', icon: h(EditOutlined) },\n    ],\n  },\n  {\n    key: 'SubMenu',\n    label: 'SubMenu',\n    children: [\n      {\n        key: 'g1',\n        label: 'Item 1',\n        type: 'group',\n        children: [\n          { key: '1', label: 'Option 1' },\n          { key: '2', label: 'Option 2' },\n        ],\n      },\n    ],\n  },\n  { key: '3', type: 'divider' },\n  { key: '4', label: 'Delete', icon: h(DeleteOutlined), danger: true },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Dropdown\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ height: '120px', position: 'absolute', top: '50px' }\">\n        <a-dropdown\n          open\n          :menu=\"{ items }\"\n          :styles=\"{ root: { width: '200px', zIndex: 1 } }\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        >\n          <a @click.prevent>\n            <a-space>\n              Hover me\n              <DownOutlined />\n            </a-space>\n          </a>\n        </a-dropdown>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "itemTitle",
+          "description": "Title content area of dropdown option, sets layout and text styles",
+          "descriptionZh": "dropdown 选项的标题内容区域，设置布局和文字样式"
+        },
+        {
+          "key": "item",
+          "description": "Individual dropdown option element, sets interaction states and background styles",
+          "descriptionZh": "dropdown 的单个选项元素，设置选项的交互状态和背景样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Main content area of dropdown option, sets content layout and link styles",
+          "descriptionZh": "dropdown 选项的主要内容区域，设置内容布局和链接样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Icon area of dropdown option, sets icon size and spacing styles",
+          "descriptionZh": "dropdown 选项的图标区域，设置图标的尺寸和间距样式"
         }
       ]
     },
@@ -8751,14 +9172,28 @@
           "description": "Hide default description.",
           "descriptionZh": "隐藏默认描述。",
           "code": "<template>\n  <a-empty :description=\"false\" />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets text alignment, font and line height styles",
+          "descriptionZh": "根元素，设置文本对齐、字体和行高样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'image', desc: t('image'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Empty\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-empty\n        :image=\"1\"\n        :styles=\"{ image: { height: '60px' } }\"\n        :classes=\"classes\"\n      >\n        <template #description>\n          <a-typography-text>\n            Customize <a href=\"#API\">Description</a>\n          </a-typography-text>\n        </template>\n        <a-button type=\"primary\">\n          Create Now\n        </a-button>\n      </a-empty>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "image",
+          "description": "Image element, sets height, opacity, margin and image styles",
+          "descriptionZh": "图标元素，设置高度、透明度、边距和图片样式"
+        },
+        {
+          "key": "description",
+          "description": "Description element, sets text color styles",
+          "descriptionZh": "描述元素，设置文本颜色样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element, sets top margin and action button styles",
+          "descriptionZh": "底部元素，设置顶部边距和操作按钮样式"
         }
       ]
     },
@@ -8868,7 +9303,8 @@
           "descriptionZh": "嵌套使用，可以实现更复杂的布局。",
           "code": "<script setup lang=\"ts\">\nimport type { CSSProperties } from 'vue'\n\nconst cardStyle: CSSProperties = {\n  width: '620px',\n}\nconst imgStyle: CSSProperties = {\n  display: 'block',\n  width: '273px',\n}\n</script>\n\n<template>\n  <a-card :style=\"cardStyle\" :styles=\"{ body: { padding: 0, overflow: 'hidden' } }\">\n    <a-flex justify=\"space-between\">\n      <img\n        alt=\"avatar\"\n        src=\"https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png\"\n        :style=\"imgStyle\"\n      >\n      <a-flex vertical align=\"flex-end\" justify=\"space-between\" :style=\"{ padding: '32px' }\">\n        <a-typography>\n          <a-typography-title :level=\"3\">\n            “antd is an enterprise-class UI design language and Vue UI library.”\n          </a-typography-title>\n        </a-typography>\n        <a-button type=\"primary\" href=\"https://antdv.com\" target=\"_blank\">\n          Get Start\n        </a-button>\n      </a-flex>\n    </a-flex>\n  </a-card>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "FloatButton",
@@ -9277,22 +9713,63 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of FloatButton by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 FloatButton 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { FloatButtonProps } from 'antdv-next'\nimport { QuestionCircleOutlined } from '@antdv-next/icons'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: FloatButtonProps['classes'] = {\n  root: 'demo-float-button-root',\n  content: 'demo-float-button-content',\n}\n\nconst stylesObject: FloatButtonProps['styles'] = {\n  root: {\n    boxShadow: '0 1px 2px 0 rgba(0,0,0,0.05)',\n  },\n}\n\nconst stylesFn: FloatButtonProps['styles'] = (info) => {\n  if (info?.props?.type === 'primary') {\n    return {\n      root: {\n        backgroundColor: '#171717',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-float-button-group shape=\"circle\" style=\"inset-inline-end: 94px;\">\n    <a-float-button\n      type=\"primary\"\n      :classes=\"classes\"\n      href=\"https://ant.design/index-cn\"\n      :styles=\"stylesFn\"\n    >\n      <template #tooltip>\n        <div>custom style class</div>\n      </template>\n    </a-float-button>\n    <a-float-button\n      type=\"default\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n    >\n      <template #icon>\n        <QuestionCircleOutlined />\n      </template>\n    </a-float-button>\n  </a-float-button-group>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with float button base styles, shape size, type theme, fixed positioning, z-index, shadow, spacing and other container styles",
+          "descriptionZh": "根元素，设置悬浮按钮的基础样式、形状尺寸、类型主题、固定定位、层级、阴影、间距等容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { QuestionCircleOutlined } from '@antdv-next/icons'\nimport { FloatButton } from 'antdv-next'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst PurePanel = (FloatButton as any)._InternalPanelDoNotUseOrYouWillBeFired\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'icon', desc: t('icon') },\n  { name: 'content', desc: t('content') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"FloatButton\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <PurePanel\n        type=\"primary\"\n        shape=\"square\"\n        content=\"HELP\"\n        :classes=\"classes\"\n      >\n        <template #icon>\n          <QuestionCircleOutlined />\n        </template>\n      </PurePanel>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "content",
+          "description": "Content element with button text content font size, color, alignment, line wrap and other text display styles",
+          "descriptionZh": "内容元素，设置按钮内文字内容的字体大小、颜色、对齐、换行等文本显示样式"
         },
         {
-          "name": "_semantic_group",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AlertOutlined, BugOutlined, BulbOutlined } from '@antdv-next/icons'\nimport { FloatButton } from 'antdv-next'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst PurePanel = (FloatButton as any)._InternalPanelDoNotUseOrYouWillBeFired\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('group.root') },\n  { name: 'list', desc: t('group.list') },\n  { name: 'item', desc: t('group.item') },\n  { name: 'itemIcon', desc: t('group.itemIcon') },\n  { name: 'itemContent', desc: t('group.itemContent') },\n  { name: 'trigger', desc: t('group.trigger') },\n  { name: 'triggerIcon', desc: t('group.triggerIcon') },\n  { name: 'triggerContent', desc: t('group.triggerContent') },\n])\n\nconst items = [\n  {\n    icon: h(AlertOutlined),\n    content: 'warn',\n  },\n  {\n    icon: h(BugOutlined),\n    content: 'bug',\n  },\n  {\n    icon: h(BulbOutlined),\n    content: 'idea',\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"FloatButton\"\n    :semantics=\"semantics\"\n    :style=\"{ paddingTop: '100px' }\"\n  >\n    <template #default=\"{ classes }\">\n      <PurePanel\n        type=\"primary\"\n        shape=\"square\"\n        :items=\"items\"\n        trigger=\"hover\"\n        :open=\"true\"\n        content=\"back\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element with button icon size, color, line height, alignment and other icon display styles",
+          "descriptionZh": "图标元素，设置按钮内图标的尺寸、颜色、行高、对齐等图标显示样式"
+        },
+        {
+          "key": "group.root",
+          "description": "Root element with float button group container styles, fixed positioning, z-index, padding, gap, direction mode and other combined layout styles",
+          "descriptionZh": "根元素，设置悬浮按钮组的容器样式、固定定位、层级、内边距、间距、方向模式等组合布局样式"
+        },
+        {
+          "key": "group.list",
+          "description": "List element with button group list flex layout, border radius, shadow, animation transition, vertical alignment and other list container styles",
+          "descriptionZh": "列表元素，设置按钮组列表的Flex布局、圆角、阴影、动画过渡、垂直对齐等列表容器样式"
+        },
+        {
+          "key": "group.item",
+          "description": "Item element with individual float button styles, size, shape, type, state, icon content and other button base styles",
+          "descriptionZh": "列表项元素，设置单个悬浮按钮的样式、尺寸、形状、类型、状态、图标内容等按钮基础样式"
+        },
+        {
+          "key": "group.itemIcon",
+          "description": "Item icon element with float button icon size, color, alignment and other icon display styles",
+          "descriptionZh": "列表项图标元素，设置悬浮按钮内图标的尺寸、颜色、对齐等图标显示样式"
+        },
+        {
+          "key": "group.itemContent",
+          "description": "Item content element with float button text content, badge, description and other content area styles",
+          "descriptionZh": "列表项内容元素，设置悬浮按钮内文字内容、徽标、描述等内容区域样式"
+        },
+        {
+          "key": "group.trigger",
+          "description": "Trigger element with menu mode trigger button styles, shape, icon, hover state, expand/collapse state and other interaction styles",
+          "descriptionZh": "触发元素，设置菜单模式下触发按钮的样式、形状、图标、悬停态、展开收起状态等交互样式"
+        },
+        {
+          "key": "group.triggerIcon",
+          "description": "Trigger icon element with trigger button icon styles, rotation animation, toggle state and other icon interaction styles",
+          "descriptionZh": "触发图标元素，设置触发按钮内图标的样式、旋转动画、切换状态等图标交互样式"
+        },
+        {
+          "key": "group.triggerContent",
+          "description": "Trigger content element with trigger button content area text, identifier, state indicator and other content styles",
+          "descriptionZh": "触发内容元素，设置触发按钮内容区域的文字、标识、状态指示等内容样式"
         }
       ]
     },
@@ -10306,14 +10783,38 @@
           "description": "Label ellipsis debug.",
           "descriptionZh": "label 省略展示调试。",
           "code": "<script setup lang=\"ts\">\nimport { reactive } from 'vue'\n\nconst model = reactive({\n  username: '',\n  password: '',\n})\n</script>\n\n<template>\n  <a-form\n    name=\"label-ellipsis\"\n    :model=\"model\"\n    :label-col=\"{ span: 8 }\"\n    :wrapper-col=\"{ span: 16 }\"\n    style=\"max-width: 600px\"\n  >\n    <a-form-item name=\"username\">\n      <template #label>\n        <a-typography-text ellipsis>\n          longtextlongtextlongtextlongtextlongtextlongtextlongtext\n        </a-typography-text>\n      </template>\n      <a-input v-model:value=\"model.username\" />\n    </a-form-item>\n\n    <a-form-item name=\"password\">\n      <template #label>\n        <a-typography-text ellipsis>\n          longtext longtext longtext longtext longtext longtext longtext\n        </a-typography-text>\n      </template>\n      <a-input-password v-model:value=\"model.password\" />\n    </a-form-item>\n  </a-form>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with form item margin-bottom, vertical-align, transitions, hidden states, error/warning states and other basic form item container styles",
+          "descriptionZh": "根元素，包含表单项的底边距、垂直对齐、过渡动画、隐藏状态、错误警告状态等表单项容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport type { FormInstance } from 'antdv-next'\nimport { computed, onMounted, shallowRef } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst formRef = shallowRef<FormInstance>()\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'help', desc: t('help'), version: '1.3.0' },\n  { name: 'helpItem', desc: t('helpItem'), version: '1.3.0' },\n  { name: 'extra', desc: t('extra'), version: '1.3.0' },\n])\n\nonMounted(() => {\n  formRef.value?.setFields?.([\n    {\n      name: 'password',\n      errors: ['Please input your password!', 'Use at least 8 characters.'],\n    },\n  ])\n})\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Form\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-form\n        ref=\"formRef\"\n        name=\"basic\"\n        :label-col=\"{ span: 8 }\"\n        :wrapper-col=\"{ span: 16 }\"\n        :style=\"{ maxWidth: '600px' }\"\n        :initial-values=\"{ remember: true }\"\n        autocomplete=\"off\"\n        :classes=\"classes\"\n      >\n        <a-form-item\n          label=\"Username\"\n          name=\"username\"\n          help=\"Use 4 to 16 characters.\"\n          :rules=\"[{ required: true, message: 'Please input your username!' }]\"\n        >\n          <a-input />\n        </a-form-item>\n        <a-form-item\n          label=\"Password\"\n          name=\"password\"\n          extra=\"Password must contain letters and numbers.\"\n          :rules=\"[\n            { required: true, message: 'Please input your password!' },\n            { min: 8, message: 'Use at least 8 characters.' },\n          ]\"\n        >\n          <a-input-password />\n        </a-form-item>\n      </a-form>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "label",
+          "description": "Label element with flex layout, overflow hidden, whitespace nowrap, text alignment, vertical alignment, plus label color, font size, height, required marks and other label display styles",
+          "descriptionZh": "标签元素，包含 flex 布局、溢出隐藏、文本不换行、文本对齐、垂直对齐，以及标签的颜色、字体大小、高度、必填标记等标签显示样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with form content area layout, styling and control container related styles",
+          "descriptionZh": "内容元素，包含表单内容区域的布局、样式和控件容器的相关样式"
+        },
+        {
+          "key": "help",
+          "description": "Help container element with spacing, motion, and presentation styles for help and validation areas",
+          "descriptionZh": "帮助信息容器元素，包含帮助文案与校验信息区域的间距、过渡与展示样式"
+        },
+        {
+          "key": "helpItem",
+          "description": "Single help message item with typography styles for prompt, error, and warning text",
+          "descriptionZh": "帮助信息单项元素，包含错误、警告与提示文案的排版样式"
+        },
+        {
+          "key": "extra",
+          "description": "Extra prompt container element with spacing, color, and typography styles for supplementary text",
+          "descriptionZh": "额外提示容器元素，包含补充说明文案的间距、颜色与排版样式"
         }
       ]
     },
@@ -10591,7 +11092,8 @@
           "descriptionZh": "使用 `useBreakpoint` Hook 实现个性化布局，其中 `xs` 仅当满足最小宽度时生效。",
           "code": "<script setup lang=\"ts\">\nimport { useBreakpoint } from 'antdv-next'\nimport { computed } from 'vue'\n\nconst screens = useBreakpoint()\nconst screenKeys = computed(() => Object.entries(screens.value ?? {}).filter(screen => !!screen[1]))\n</script>\n\n<template>\n  Current break point:\n  <div class=\"gap-2 inline-flex\">\n    <template v-for=\"item in screenKeys\" :key=\"item[0]\">\n      <a-tag color=\"blue\">\n        {{ item[0] }}\n      </a-tag>\n    </template>\n  </div>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Icon",
@@ -10654,7 +11156,8 @@
           "descriptionZh": "`scriptUrl` 可引用多个资源，用户可灵活的管理 [iconfont.cn](http://iconfont.cn/) 图标。如果资源的图标出现重名，会按照数组顺序进行覆盖。",
           "code": "<script setup lang=\"ts\">\nimport { createFromIconfontCN } from '@antdv-next/icons'\n\nconst IconFont = createFromIconfontCN({\n  scriptUrl: [\n    '//at.alicdn.com/t/font_1788044_0dwu4guekcwr.js', // icon-javascript, icon-java, icon-shoppingcart (overridden)\n    '//at.alicdn.com/t/font_1788592_a5xf2bdic3u.js', // icon-shoppingcart, icon-python\n  ],\n})\n</script>\n\n<template>\n  <a-space>\n    <IconFont type=\"icon-javascript\" />\n    <IconFont type=\"icon-java\" />\n    <IconFont type=\"icon-shoppingcart\" />\n    <IconFont type=\"icon-python\" />\n  </a-space>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Image",
@@ -10881,14 +11384,53 @@
           "description": "Nested in the modal.",
           "descriptionZh": "嵌套在弹框当中使用。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst show1 = ref(false)\nconst show2 = ref(false)\nconst show3 = ref(false)\n\nfunction handlePreviewGroupChange(current: number, prev: number) {\n  console.log(`current index: ${current}, prev index: ${prev}`)\n}\n</script>\n\n<template>\n  <a-button @click=\"show1 = true\">\n    showModal\n  </a-button>\n  <a-modal\n    v-model:open=\"show1\"\n    @cancel=\"show1 = false\"\n    @ok=\"show1 = false\"\n  >\n    <a-button @click=\"show2 = true\">\n      test2\n    </a-button>\n    <a-modal\n      v-model:open=\"show2\"\n      @cancel=\"show2 = false\"\n      @ok=\"show2 = false\"\n    >\n      <a-button @click=\"show3 = true\">\n        test3\n      </a-button>\n      <a-modal\n        v-model:open=\"show3\"\n        @cancel=\"show3 = false\"\n        @ok=\"show3 = false\"\n      >\n        <a-image\n          :width=\"200\"\n          alt=\"svg image\"\n          src=\"https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg\"\n        />\n        <a-divider />\n        <a-image-preview-group\n          :preview=\"{\n            onChange: handlePreviewGroupChange,\n          }\"\n        >\n          <a-image\n            :width=\"200\"\n            alt=\"svg image\"\n            src=\"https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg\"\n          />\n          <a-image\n            :width=\"200\"\n            src=\"https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg\"\n          />\n        </a-image-preview-group>\n      </a-modal>\n    </a-modal>\n  </a-modal>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets relative positioning and inline-block layout styles",
+          "descriptionZh": "根元素，设置相对定位和行内块布局样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { theme } from 'antdv-next'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'image', desc: t('image') },\n  { name: 'cover', desc: t('cover') },\n  { name: 'popup.root', desc: t('popup.root') },\n  { name: 'popup.mask', desc: t('popup.mask') },\n  { name: 'popup.body', desc: t('popup.body') },\n  { name: 'popup.footer', desc: t('popup.footer') },\n  { name: 'popup.actions', desc: t('popup.actions') },\n  { name: 'popup.close', desc: t('popup.close'), version: '1.3.0' },\n])\n\nconst { token } = theme.useToken()\nconst holderRef = ref<HTMLDivElement | null>(null)\n\nconst previewItems = [\n  'https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg',\n  'https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg',\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Image\"\n    :padding=\"false\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical align=\"center\" :style=\"{ minHeight: '100%', width: '100%' }\">\n        <a-flex :style=\"{ padding: `${token.padding}px`, flex: 'none' }\" justify=\"center\">\n          <a-image\n            :width=\"200\"\n            src=\"https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png\"\n            :classes=\"classes\"\n          />\n        </a-flex>\n        <div ref=\"holderRef\" :style=\"{ flex: 1, position: 'relative', minHeight: '500px', width: '100%' }\">\n          <a-image-preview-group\n            :items=\"previewItems\"\n            :classes=\"classes\"\n            :styles=\"{ popup: { root: { position: 'absolute' } } }\"\n            :preview=\"{ getContainer: () => holderRef!, open: true, focusTrap: false }\"\n          />\n        </div>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "image",
+          "description": "Image element, sets width, height and vertical alignment styles",
+          "descriptionZh": "图片元素，设置宽度、高度和垂直对齐样式"
+        },
+        {
+          "key": "cover",
+          "description": "Image hover display prompt element, sets absolute positioning, background color, opacity and transition animation styles",
+          "descriptionZh": "悬浮图片显示的提示元素，设置绝对定位、背景色、透明度和过渡动画样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Preview root element, sets fixed positioning, z-index and background mask styles",
+          "descriptionZh": "预览根元素，设置固定定位、层级和背景遮罩样式"
+        },
+        {
+          "key": "popup.mask",
+          "description": "Preview mask element, sets absolute positioning and semi-transparent background styles",
+          "descriptionZh": "预览遮罩元素，设置绝对定位和半透明背景样式"
+        },
+        {
+          "key": "popup.body",
+          "description": "Preview body element, sets flex layout, center alignment and pointer event styles",
+          "descriptionZh": "预览内容元素，设置flex布局、居中对齐和指针事件样式"
+        },
+        {
+          "key": "popup.footer",
+          "description": "Preview footer element, sets absolute positioning, center layout and bottom operation area styles",
+          "descriptionZh": "预览页脚元素，设置绝对定位、居中布局和底部操作区域样式"
+        },
+        {
+          "key": "popup.actions",
+          "description": "Preview actions group element, sets flex layout, background color, border radius and action button styles",
+          "descriptionZh": "预览操作组元素，设置flex布局、背景色、圆角和操作按钮样式"
+        },
+        {
+          "key": "popup.close",
+          "description": "Preview close button element, sets basic button styles",
+          "descriptionZh": "预览关闭按钮元素，设置按钮的基础样式"
         }
       ]
     },
@@ -11611,46 +12153,73 @@
           "description": "You can customize the [semantic dom](#semantic-input) style of Input by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Input 的[语义化结构](#semantic-input)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { InputOTPProps, InputPasswordProps, InputProps, InputSearchProps, TextAreaProps } from 'antdv-next'\n\nconst classes: InputProps['classes'] = {\n  root: 'effect',\n}\n\nconst stylesFn: InputProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      root: {\n        borderColor: '#696FC7',\n      },\n    } satisfies InputProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnTextArea: TextAreaProps['styles'] = (info) => {\n  if (info.props.showCount) {\n    return {\n      root: { borderColor: '#BDE3C3' },\n      textarea: { resize: 'none' },\n      count: { color: '#BDE3C3' },\n    } satisfies TextAreaProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnPassword: InputPasswordProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      root: {\n        borderColor: '#F5D3C4',\n      },\n    } satisfies InputPasswordProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnOTP: InputOTPProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      root: {\n        borderWidth: 0,\n      },\n      input: {\n        borderColor: '#6E8CFB',\n        width: '32px',\n      },\n    } satisfies InputOTPProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnSearch: InputSearchProps['styles'] = (info) => {\n  if (info.props.size === 'large') {\n    return {\n      root: { color: '#4DA8DA', borderWidth: 0 },\n      input: { color: '#4DA8DA', borderColor: '#4DA8DA' },\n      prefix: { color: '#4DA8DA' },\n      suffix: { color: '#4DA8DA' },\n      count: { color: '#4DA8DA' },\n      button: {\n        root: { color: '#4DA8DA', borderColor: '#4DA8DA' },\n        icon: { color: '#4DA8DA' },\n      },\n    } satisfies InputSearchProps['styles']\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-input :classes=\"classes\" placeholder=\"Object\" name=\"input-object\" />\n    <a-input :classes=\"classes\" :styles=\"stylesFn\" placeholder=\"Function\" size=\"middle\" name=\"input-fn\" />\n    <a-textarea :classes=\"classes\" :styles=\"stylesFnTextArea\" placeholder=\"Textarea\" show-count name=\"textarea-fn\" />\n    <a-input-password :classes=\"classes\" :styles=\"stylesFnPassword\" placeholder=\"Password\" size=\"middle\" name=\"password-fn\" />\n    <a-input-otp :classes=\"classes\" :styles=\"stylesFnOTP\" size=\"middle\" :length=\"6\" separator=\"*\" name=\"otp-fn\" />\n    <a-input-search :classes=\"classes\" :styles=\"stylesFnSearch\" placeholder=\"Search\" size=\"large\" name=\"search-fn\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-block display, width, min-width, padding, colors, fonts, line-height, border-radius, transitions and other input container basic styles",
+          "descriptionZh": "根元素，包含相对定位、行内块布局、宽度、最小宽度、内边距、颜色、字体、行高、圆角、过渡动画等输入框容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'count', desc: t('count') },\n  { name: 'clear', desc: t('clear'), version: '1.3.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Input\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-input\n          default-value=\"Hello, Antdv-Next\"\n          show-count\n          allow-clear\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <UserOutlined />\n          </template>\n          <template #suffix>\n            <EditOutlined />\n          </template>\n        </a-input>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "input",
+          "description": "Input element with core interactive styles and text input related styling",
+          "descriptionZh": "输入框元素，包含输入框的核心交互样式和文本输入相关的样式"
         },
         {
-          "name": "_semantic-textarea",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('TextAreaRoot') },\n  { name: 'textarea', desc: t('textarea') },\n  { name: 'count', desc: t('TextAreaCount') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"TextArea\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-textarea\n          default-value=\"Hello, Antdv-Next\"\n          :maxlength=\"100\"\n          show-count\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix wrapper element with layout and styling for prefix content",
+          "descriptionZh": "前缀的包裹元素，包含前缀内容的布局和样式"
         },
         {
-          "name": "_semantic-search",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'count', desc: t('count') },\n  { name: 'button.root', desc: t('button.root') },\n  { name: 'button.icon', desc: t('button.icon') },\n  { name: 'button.content', desc: t('button.content') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputSearch\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-input-search\n          default-value=\"Hello, Antdv-Next\"\n          enter-button=\"Searching...\"\n          loading\n          show-count\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <UserOutlined />\n          </template>\n          <template #suffix>\n            <EditOutlined />\n          </template>\n        </a-input-search>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "suffix",
+          "description": "Suffix wrapper element with layout and styling for suffix content",
+          "descriptionZh": "后缀的包裹元素，包含后缀内容的布局和样式"
         },
         {
-          "name": "_semantic-password",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'count', desc: t('count') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputPassword\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-input-password\n          default-value=\"Hello, Antdv-Next\"\n          show-count\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <UserOutlined />\n          </template>\n          <template #suffix>\n            <EditOutlined />\n          </template>\n        </a-input-password>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "count",
+          "description": "Character count element with font and color styles for count display",
+          "descriptionZh": "文字计数元素，包含字符计数显示的字体和颜色样式"
         },
         {
-          "name": "_semantic-otp",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'input', desc: t('input') },\n  { name: 'separator', desc: t('OTPSeparator') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputOTP\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-input-otp\n        :length=\"6\"\n        separator=\"-\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "clear",
+          "description": "Clear button element with color, size, hover state and transition animation styles",
+          "descriptionZh": "清除按钮元素，包含清除按钮的颜色、尺寸、悬浮态和过渡动画等样式"
+        },
+        {
+          "key": "TextAreaRoot",
+          "description": "Root element with textarea wrapper styles, border, border radius, transition animation and state control",
+          "descriptionZh": "根元素，设置文本域包装器的样式、边框、圆角、过渡动画和状态控制"
+        },
+        {
+          "key": "textarea",
+          "description": "Textarea element with font, line height, padding, color, background, border, text input and multi-line text display styles",
+          "descriptionZh": "文本域元素，设置字体、行高、内边距、颜色、背景、边框、文本输入和多行文本展示样式"
+        },
+        {
+          "key": "TextAreaCount",
+          "description": "Count element with character count display position, font, color and numeric statistics styles",
+          "descriptionZh": "文字计数元素，设置字符计数显示的位置、字体、颜色和数值统计样式"
+        },
+        {
+          "key": "button.root",
+          "description": "Search button root element with button styles, hover effects and click interactions",
+          "descriptionZh": "搜索按钮的根元素，设置按钮的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "button.icon",
+          "description": "Search button icon element with icon styles, hover effects and click interactions",
+          "descriptionZh": "搜索按钮的图标元素，设置图标的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "button.content",
+          "description": "Search button content element with text styles, hover effects and click interactions",
+          "descriptionZh": "搜索按钮的内容元素，设置文本的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "OTPSeparator",
+          "description": "Separator element, set separator display styles between OTP input boxes",
+          "descriptionZh": "分隔符元素，设置OTP输入框之间的分隔符显示样式"
         }
       ]
     },
@@ -12224,14 +12793,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of the InputNumber by passing objects/functions through",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 InputNumber 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { InputNumberProps } from 'antdv-next'\n\nconst shardStyle = {\n  root: 'shard',\n}\nconst styleObject: InputNumberProps['styles'] = {\n  input: {\n    fontSize: '14px',\n  },\n}\nconst styleFn: InputNumberProps['styles'] = ({ props }) => {\n  if (props.size === 'large') {\n    return {\n      root: {\n        backgroundColor: 'rgba(250,250,250, 0.5)',\n        borderColor: '#722ed1',\n      },\n    } satisfies InputNumberProps['styles']\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-input-number :classes=\"shardStyle\" :styles=\"styleObject\" placeholder=\"Object\" />\n    <a-input-number :classes=\"shardStyle\" :styles=\"styleFn\" placeholder=\"Function\" size=\"large\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets inline-block layout, width, border radius and reset styles",
+          "descriptionZh": "根元素，设置行内块布局、宽度、边框圆角和重置样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'actions', desc: t('actions') },\n  { name: 'action', desc: t('action') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputNumber\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ display: 'flex', flexDirection: 'column', gap: '16px' }\">\n        <a-input-number\n          prefix=\"￥\"\n          suffix=\"RMB\"\n          :default-value=\"100\"\n          :style=\"{ width: '200px' }\"\n          :styles=\"{ actions: { opacity: 1, width: '24px' }, suffix: { marginRight: '28px' } }\"\n          :classes=\"classes\"\n        />\n        <a-input-number\n          :default-value=\"100\"\n          :style=\"{ width: '200px' }\"\n          :styles=\"{ actions: { opacity: 1, width: '24px' }, suffix: { marginRight: '28px' } }\"\n          mode=\"spinner\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "input",
+          "description": "Input element, sets font, line height, text input and interaction styles",
+          "descriptionZh": "输入框元素，设置字体、行高、文本输入和交互样式"
+        },
+        {
+          "key": "prefix",
+          "description": "Prefix wrapper element, sets flex layout, alignment and right margin styles",
+          "descriptionZh": "前缀的包裹元素，设置flex布局、对齐方式和右边距样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix wrapper element, sets flex layout, margin and transition animation styles",
+          "descriptionZh": "后缀的包裹元素，设置flex布局、边距和过渡动画样式"
+        },
+        {
+          "key": "action",
+          "description": "Single action button element, sets button styling, hover effects and click interactions",
+          "descriptionZh": "单个操作按钮元素，设置按钮的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element, sets absolute positioning, width, flex layout and number adjustment button styles",
+          "descriptionZh": "操作元素，设置绝对定位、宽度、flex布局和数值调节按钮样式"
         }
       ]
     },
@@ -12543,7 +13136,8 @@
           "descriptionZh": "当内容较长时，使用固定侧边栏可以提供更好的体验。",
           "code": "<script setup lang=\"ts\">\nimport type { MenuItemType } from 'antdv-next'\nimport type { CSSProperties } from 'vue'\nimport {\n  AppstoreOutlined,\n  BarChartOutlined,\n  CloudOutlined,\n  ShopOutlined,\n  TeamOutlined,\n  UploadOutlined,\n  UserOutlined,\n  VideoCameraOutlined,\n} from '@antdv-next/icons'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\nconst year = new Date().getFullYear()\n\nconst siderStyle: CSSProperties = {\n  overflow: 'auto',\n  height: '100vh',\n  position: 'sticky',\n  insetInlineStart: 0,\n  top: 0,\n  scrollbarWidth: 'thin',\n  scrollbarGutter: 'stable',\n}\n\nconst items: MenuItemType[] = [\n  UserOutlined,\n  VideoCameraOutlined,\n  UploadOutlined,\n  BarChartOutlined,\n  CloudOutlined,\n  AppstoreOutlined,\n  TeamOutlined,\n  ShopOutlined,\n].map((icon, index) => ({\n  key: String(index + 1),\n  icon,\n  label: `nav ${index + 1}`,\n}))\n</script>\n\n<template>\n  <a-layout :has-sider=\"true\">\n    <a-layout-sider :style=\"siderStyle\">\n      <div class=\"demo-logo-vertical\" />\n      <a-menu\n        theme=\"dark\"\n        mode=\"inline\"\n        :default-selected-keys=\"['4']\"\n        :items=\"items\"\n      />\n    </a-layout-sider>\n    <a-layout>\n      <a-layout-header class=\"fixed-header\" :style=\"{ background: token.colorBgContainer }\" />\n      <a-layout-content class=\"fixed-content\">\n        <div\n          class=\"fixed-content-box\"\n          :style=\"{\n            background: token.colorBgContainer,\n            borderRadius: `${token.borderRadiusLG}px`,\n          }\"\n        >\n          <p>long content</p>\n          <template v-for=\"index in 100\" :key=\"index\">\n            {{ index % 20 === 0 && index !== 0 ? 'more' : '...' }}\n            <br>\n          </template>\n        </div>\n      </a-layout-content>\n      <a-layout-footer class=\"fixed-footer\">\n        Antdv Next ©{{ year }} Created by Ant UED\n      </a-layout-footer>\n    </a-layout>\n  </a-layout>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Masonry",
@@ -12665,14 +13259,18 @@
           "description": "When `fresh` is enabled, the masonry will continuously monitor size changes of child items and automatically re-layout. Click on cards to change their height.",
           "descriptionZh": "开启 `fresh` 属性后，瀑布流会持续监听子项的尺寸变化并自动重新布局。点击卡片可以改变其高度。",
           "code": "<script setup lang=\"ts\">\nimport { Card } from 'antdv-next'\nimport { defineComponent, h, ref } from 'vue'\n\nconst RandomHeightCard = defineComponent({\n  props: {\n    index: {\n      type: Number,\n      required: true,\n    },\n    defaultHeight: {\n      type: Number,\n      required: true,\n    },\n  },\n  setup(props) {\n    const height = ref(props.defaultHeight)\n\n    const handleClick = () => {\n      height.value = Math.floor(Math.random() * 100) + 50\n    }\n\n    return () =>\n      h(\n        Card,\n        {\n          size: 'small',\n          style: { height: `${height.value}px`, transition: 'height 0.3s' },\n          onClick: handleClick,\n        },\n        () => `${props.index + 1} - Click`,\n      )\n  },\n})\n\nconst heights = [150, 50, 90, 70, 110, 150, 130, 80, 50, 90, 100, 150, 60, 50, 80].map(\n  (height, index) => {\n    const item: {\n      key: string\n      data: number\n      column?: number\n    } = {\n      key: `item-${index}`,\n      data: height,\n    }\n\n    if (index === 4) {\n      item.column = 0\n    }\n\n    return item\n  },\n)\n</script>\n\n<template>\n  <a-masonry\n    fresh\n    :columns=\"4\"\n    :gutter=\"16\"\n    :items=\"heights\"\n  >\n    <template #itemRender=\"{ data, index }\">\n      <RandomHeightCard :index=\"index\" :default-height=\"data\" />\n    </template>\n  </a-masonry>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets relative positioning, flex layout and masonry container styles",
+          "descriptionZh": "根元素，设置相对定位、flex布局和瀑布流容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n])\n\nconst heights = [75, 50, 70, 60, 85, 75, 50].map((height, index) => ({\n  key: `item-${index}`,\n  data: height,\n}))\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Masonry\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-masonry\n        :columns=\"3\"\n        :gutter=\"16\"\n        :items=\"heights\"\n        style=\"width: 100%\"\n        :classes=\"classes\"\n      >\n        <template #itemRender=\"{ data, index }\">\n          <a-card size=\"small\" :style=\"{ height: data }\">\n            {{ index + 1 }}\n          </a-card>\n        </template>\n      </a-masonry>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element, sets absolute positioning, width calculation, transition animation and masonry item styles",
+          "descriptionZh": "条目元素，设置绝对定位、宽度计算、过渡动画和瀑布流项目样式"
         }
       ]
     },
@@ -13063,14 +13661,28 @@
           "description": "autoSize debug",
           "descriptionZh": "autoSize debug",
           "code": "<script setup lang=\"ts\">\nimport type { MentionsEmits, MentionsProps } from 'antdv-next'\n\nconst options: MentionsProps['options'] = [\n  {\n    value: 'afc163',\n    label: 'afc163',\n  },\n  {\n    value: 'zombieJ',\n    label: 'zombieJ',\n  },\n  {\n    value: 'yesmeck',\n    label: 'yesmeck',\n  },\n]\n\nconst handleChange: MentionsEmits['change'] = (value) => {\n  console.log('Change:', value)\n}\n\nconst handleSelect: MentionsEmits['select'] = (option) => {\n  console.log('select', option)\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-mentions\n      placeholder=\"can resize\"\n      :options=\"options\"\n      @change=\"handleChange\"\n      @select=\"handleSelect\"\n    />\n    <a-mentions\n      placeholder=\"disable resize\"\n      :options=\"options\"\n      :style=\"{ resize: 'none' }\"\n      @change=\"handleChange\"\n      @select=\"handleSelect\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set inline flex layout, relative positioning, padding and border styles",
+          "descriptionZh": "根元素，设置行内flex布局、相对定位、内边距和边框样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'textarea', desc: t('textarea'), version: '1.0.0' },\n  { name: 'suffix', desc: t('suffix'), version: '1.0.0' },\n  { name: 'popup', desc: t('popup'), version: '1.0.0' },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst options = [\n  { value: 'afc163', label: 'afc163' },\n  { value: 'zombieJ', label: 'zombieJ' },\n  { value: 'thinkasany', label: 'thinkasany' },\n  { value: 'meet-student', label: 'meet-student' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Mentions\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <a-mentions\n          placement=\"bottom\"\n          :style=\"{ width: '100%' }\"\n          value=\"Hi, @\"\n          allow-clear\n          open\n          :get-popup-container=\"() => divRef!\"\n          :options=\"options\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "textarea",
+          "description": "Textarea element, set font, line height, text input and background styles",
+          "descriptionZh": "文本域元素，设置字体、行高、文本输入和背景样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup element, set absolute positioning, z-index, background color, border radius, shadow and dropdown options styles",
+          "descriptionZh": "弹出框元素，设置绝对定位、层级、背景色、圆角、阴影和下拉选项样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with layout and styling for suffix content like clear button, etc.",
+          "descriptionZh": "后缀元素，包含后缀内容的布局和样式，如清除按钮等"
         }
       ]
     },
@@ -13812,14 +14424,68 @@
           "description": "Use the `popupRender` prop to customize submenu popup rendering.",
           "descriptionZh": "使用 `popupRender` 属性自定义弹出菜单的渲染。",
           "code": "<script setup lang=\"ts\">\nimport type { MenuItemType, MenuProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\nimport { computed, h } from 'vue'\n\nconst { token } = theme.useToken()\n\nconst popupStyle = computed(() => ({\n  padding: `${token.value.padding}px`,\n  minWidth: '480px',\n  background: token.value.colorBgElevated,\n  borderRadius: `${token.value.borderRadiusLG}px`,\n  boxShadow: token.value.boxShadowSecondary,\n}))\n\nconst headerStyle = computed(() => ({\n  margin: 0,\n  paddingBottom: `${token.value.paddingXS}px`,\n  borderBottom: `1px solid ${token.value.colorSplit}`,\n}))\n\nconst cardStyle = computed(() => ({\n  padding: `${token.value.paddingSM}px`,\n}))\n\nconst cardItemStyle = computed(() => ({\n  borderRadius: `${token.value.borderRadius}px`,\n  transition: `all ${token.value.motionDurationSlow}`,\n  cursor: 'pointer',\n}))\n\nfunction renderMenuCard(title: string, description: string) {\n  return h('div', { class: 'menu-card', style: cardStyle.value }, [\n    h('div', { class: 'menu-card-title' }, title),\n    h('div', { class: 'menu-card-desc' }, description),\n  ])\n}\n\nconst menuItems = computed<MenuItemType[]>(() => [\n  {\n    key: 'home',\n    label: 'Home',\n  },\n  {\n    key: 'features',\n    label: 'Features',\n    children: [\n      {\n        key: 'getting-started',\n        label: renderMenuCard('Getting Started', 'Quick start guide and learn the basics.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n      {\n        key: 'components',\n        label: renderMenuCard('Components', 'Explore our component library.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n      {\n        key: 'templates',\n        label: renderMenuCard('Templates', 'Ready-to-use template designs.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n    ],\n  },\n  {\n    key: 'resources',\n    label: 'Resources',\n    children: [\n      {\n        key: 'blog',\n        label: renderMenuCard('Blog', 'Latest updates and articles.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n      {\n        key: 'community',\n        label: renderMenuCard('Community', 'Join our developer community.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n    ],\n  },\n])\n\nconst popupRender: MenuProps['popupRender'] = (node, info) => {\n  const title = info.item.title || info.item.key\n  return h('div', { class: 'menu-popup', style: popupStyle.value }, [\n    h('div', { class: 'menu-popup-title', style: headerStyle.value }, title),\n    node,\n  ])\n}\n\nconst themeConfig = {\n  components: {\n    Menu: {\n      popupBg: '#fff',\n      horizontalItemSelectedColor: '#1677ff',\n      horizontalItemHoverColor: '#1677ff',\n    },\n  },\n}\n</script>\n\n<template>\n  <a-config-provider :theme=\"themeConfig\">\n    <a-menu mode=\"horizontal\" :items=\"menuItems\" :popup-render=\"popupRender\" />\n  </a-config-provider>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with basic menu container styles and layout",
+          "descriptionZh": "根元素，包含菜单容器的基础样式和布局"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { MailOutlined } from '@antdv-next/icons'\nimport { computed, h, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst mode = ref<'horizontal' | 'vertical' | 'inline'>('horizontal')\nconst current = ref('mail')\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst semantics = computed(() => {\n  const baseLocale = [\n    { name: 'root', desc: t('root') },\n    { name: 'item', desc: t('item') },\n    { name: 'itemIcon', desc: t('itemIcon') },\n    { name: 'itemContent', desc: t('itemContent') },\n  ]\n  const subMenuLocale = [\n    { name: 'subMenu.itemTitle', desc: t('subMenu.itemTitle') },\n    { name: 'subMenu.list', desc: t('subMenu.list') },\n    { name: 'subMenu.item', desc: t('subMenu.item') },\n    { name: 'subMenu.itemIcon', desc: t('subMenu.itemIcon') },\n    { name: 'subMenu.itemContent', desc: t('subMenu.itemContent') },\n  ]\n  const groupLocale = [\n    { name: 'itemTitle', desc: t('itemTitle') },\n    { name: 'list', desc: t('list') },\n  ]\n\n  const additionalPopupLocale = mode.value !== 'inline' ? [{ name: 'popup', desc: t('popup') }] : []\n  const additionalGroupLocale = mode.value !== 'horizontal' ? groupLocale : []\n\n  return [...baseLocale, ...additionalGroupLocale, ...additionalPopupLocale, ...subMenuLocale]\n})\n\nconst items = [\n  { label: 'Navigation One', key: 'mail', icon: h(MailOutlined) },\n  {\n    key: 'SubMenu',\n    label: 'Navigation One',\n    icon: h(MailOutlined),\n    children: [\n      {\n        key: 'g1',\n        label: 'Item 1',\n        type: 'group',\n        children: [\n          { key: '1', label: 'Option 1', icon: h(MailOutlined) },\n          { key: '2', label: 'Option 2' },\n        ],\n      },\n    ],\n  },\n]\n\nconst groupItem = [\n  {\n    key: 'grp',\n    label: 'Group',\n    type: 'group',\n    children: [\n      { key: '13', label: 'Option 13' },\n      { key: '14', label: 'Option 14' },\n    ],\n  },\n]\n\nconst itemList = computed(() => {\n  return mode.value === 'horizontal' ? items : [...items, ...groupItem]\n})\n\nfunction onClick(e: { key: string }) {\n  current.value = e.key\n}\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Menu\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" vertical gap=\"middle\" align=\"center\">\n        <a-segmented\n          :options=\"['horizontal', 'vertical', 'inline']\"\n          :value=\"mode\"\n          @change=\"(val: 'horizontal' | 'vertical' | 'inline') => mode = val\"\n        />\n        <div :style=\"{ height: '360px' }\">\n          <a-menu\n            :selected-keys=\"[current]\"\n            :mode=\"mode\"\n            :items=\"itemList\"\n            :styles=\"{\n              root: { width: mode === 'horizontal' ? '310px' : '230px' },\n              popup: { root: { zIndex: 1 } },\n            }\"\n            :open-keys=\"['SubMenu']\"\n            :get-popup-container=\"() => divRef!\"\n            :classes=\"classes\"\n            @click=\"onClick\"\n          />\n        </div>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with relative positioning, block display, margins, whitespace handling, cursor styles, transitions and other basic interactive styles for menu items",
+          "descriptionZh": "条目元素，包含相对定位、块级显示、外边距、空白符处理、光标样式、过渡动画等菜单项的基础交互样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Item content element with layout and typography styles for menu item content",
+          "descriptionZh": "条目内容元素，包含菜单项内容的布局和排版样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Icon element with min-width, font-size, transitions, icon reset styles, and spacing control with text",
+          "descriptionZh": "图标元素，包含最小宽度、字体大小、过渡动画、图标重置样式，以及与文本的间距控制"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Item title element (no effect in horizontal mode) with title text styles and layout",
+          "descriptionZh": "菜单标题元素(horizontal 模式不生效)，包含标题文字的样式和布局"
+        },
+        {
+          "key": "list",
+          "description": "Menu list element (no effect in horizontal mode) with menu list layout and container styles",
+          "descriptionZh": "菜单列表元素(horizontal 模式不生效)，包含菜单列表的布局和容器样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup menu element (no effect in inline mode) with popup layer positioning, z-index, background and other styles",
+          "descriptionZh": "弹出菜单(inline 模式不生效)，包含弹出层的定位、层级、背景等样式"
+        },
+        {
+          "key": "subMenu.itemTitle",
+          "description": "Submenu title element with submenu title styles and interactive effects",
+          "descriptionZh": "子菜单标题元素，包含子菜单标题的样式和交互效果"
+        },
+        {
+          "key": "subMenu.list",
+          "description": "Submenu list element with submenu list layout and container styles",
+          "descriptionZh": "子菜单列表元素，包含子菜单列表的布局和容器样式"
+        },
+        {
+          "key": "subMenu.item",
+          "description": "Submenu item element with submenu item styles and interactive effects",
+          "descriptionZh": "子菜单单项元素，包含子菜单项的样式和交互效果"
+        },
+        {
+          "key": "subMenu.itemIcon",
+          "description": "Submenu item icon element with submenu icon size and styles",
+          "descriptionZh": "子菜单条目图标元素，包含子菜单图标的尺寸和样式"
+        },
+        {
+          "key": "subMenu.itemContent",
+          "description": "Submenu item content element with submenu content layout and typography",
+          "descriptionZh": "子菜单条目内容元素，包含子菜单内容的布局和排版"
         }
       ]
     },
@@ -13941,14 +14607,38 @@
           "description": "Static methods cannot consume Context provided by `ConfigProvider`. When enable `layer`, they may also cause style errors. Please use hooks version or `App` provided instance first.",
           "descriptionZh": "静态方法无法消费 Context，不能动态响应 ConfigProvider 提供的各项配置，启用 `layer` 时还可能导致样式异常。请优先使用 hooks 版本或者 App 组件提供的 `message` 实例。",
           "code": "<script setup lang=\"ts\">\nimport { message } from 'antdv-next'\n\nfunction info() {\n  message.info('This is an info message')\n}\n</script>\n\n<template>\n  <a-button type=\"primary\" @click=\"info\">\n    Static Method\n  </a-button>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "list",
+          "description": "Message list root element, set positioning, z-index, width, scroll area and placement styles",
+          "descriptionZh": "消息列表根元素，设置定位、层级、宽度、滚动区域和位置样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { message } from 'antdv-next'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { _InternalListDoNotUseOrYouWillBeFired: InternalList } = message\n\nconst { t } = useComponentLocale(locales)\n\nconst previewListStyle = {\n  position: 'relative',\n  inset: 'auto',\n  width: '100%',\n  maxWidth: '100%',\n  height: 'auto',\n  padding: '24px',\n  overflow: 'visible',\n  transform: 'none',\n} as const\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'wrapper', desc: t('wrapper'), version: '1.3.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.3.0' },\n  { name: 'list', desc: t('list'), version: '1.3.0' },\n  { name: 'listContent', desc: t('listContent'), version: '1.3.0' },\n])\n\nconst items = computed(() => [\n  {\n    key: 'semantic-message-1',\n    content: 'Hello, Antdv Next!',\n    type: 'success' as const,\n    duration: false as const,\n  },\n  {\n    key: 'semantic-message-2',\n    content: 'Welcome back!',\n    type: 'info' as const,\n    duration: false as const,\n  },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Message\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <InternalList\n        :style=\"previewListStyle\"\n        :items=\"items\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "listContent",
+          "description": "Message list content element, set notice layout, gap and height transition styles",
+          "descriptionZh": "消息列表内容元素，设置消息项排列、间距和高度动画样式"
+        },
+        {
+          "key": "root",
+          "description": "Message item root element, set background color, border radius, shadow, padding and animation styles",
+          "descriptionZh": "消息项根元素，设置背景色、圆角、阴影、内边距和动画样式"
+        },
+        {
+          "key": "wrapper",
+          "description": "Wrapper element for icon and title, set content layout, gap and alignment styles",
+          "descriptionZh": "图标与标题的包裹元素，设置内容布局、间距和对齐样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element, set font size, line height and status color styles",
+          "descriptionZh": "图标元素，设置字体大小、行高和状态颜色样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element, set text color, font size, line height and content display styles",
+          "descriptionZh": "标题元素，设置文本颜色、字号、行高和内容展示样式"
         }
       ]
     },
@@ -14506,14 +15196,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Modal by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Modal 组件的 [语义化结构](#semantic-dom) 样式。",
           "code": "<script setup lang=\"ts\">\nimport type { ModalProps } from 'antdv-next'\nimport { computed, ref } from 'vue'\n\nconst modalOpen = ref(false)\nconst modalFnOpen = ref(false)\n\nconst lineStyle = {\n  lineHeight: '28px',\n}\n\nconst classNames = computed(() => ({\n  container: 'custom-modal-container',\n}))\n\nconst styles: ModalProps['styles'] = {\n  mask: {\n    backgroundImage: `linear-gradient(to top, #18181b 0, rgba(21, 21, 22, 0.2) 100%)`,\n  },\n}\n\nconst stylesFn: ModalProps['styles'] = {\n  container: {\n    borderRadius: '14px',\n    border: '1px solid #ccc',\n    padding: '0',\n    overflow: 'hidden',\n  },\n  header: {\n    padding: '16px',\n  },\n  body: {\n    padding: '16px',\n  },\n  footer: {\n    padding: '16px 10px',\n    backgroundColor: '#fafafa',\n  },\n}\n\nconst sharedProps = computed<ModalProps>(() => ({\n  centered: true,\n  classes: classNames.value,\n}))\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-button @click=\"modalOpen = true\">\n      Open Style Modal\n    </a-button>\n    <a-button type=\"primary\" @click=\"modalFnOpen = true\">\n      Open Function Modal\n    </a-button>\n\n    <a-modal\n      v-bind=\"sharedProps\"\n      v-model:open=\"modalOpen\"\n      :footer=\"null\"\n      title=\"Custom Style Modal\"\n      :styles=\"styles\"\n    >\n      <div :style=\"lineStyle\">\n        Following the Ant Design specification, we developed a React UI library antd that contains a\n        set of high quality components and demos for building rich, interactive user interfaces.\n      </div>\n      <div :style=\"lineStyle\">\n        🌈 Enterprise-class UI designed for web applications.\n      </div>\n      <div :style=\"lineStyle\">\n        📦 A set of high-quality React components out of the box.\n      </div>\n      <div :style=\"lineStyle\">\n        🛡 Written in TypeScript with predictable static types.\n      </div>\n      <div :style=\"lineStyle\">\n        ⚙️ Whole package of design resources and development tools.\n      </div>\n      <div :style=\"lineStyle\">\n        🌍 Internationalization support for dozens of languages.\n      </div>\n      <div :style=\"lineStyle\">\n        🎨 Powerful theme customization in every detail.\n      </div>\n    </a-modal>\n\n    <a-modal\n      v-bind=\"sharedProps\"\n      v-model:open=\"modalFnOpen\"\n      title=\"Custom Function Modal\"\n      :styles=\"stylesFn\"\n      :mask=\"{ enabled: true, blur: true }\"\n    >\n      <div :style=\"lineStyle\">\n        Following the Ant Design specification, we developed a React UI library antd that contains a\n        set of high quality components and demos for building rich, interactive user interfaces.\n      </div>\n      <div :style=\"lineStyle\">\n        🌈 Enterprise-class UI designed for web applications.\n      </div>\n      <div :style=\"lineStyle\">\n        📦 A set of high-quality React components out of the box.\n      </div>\n      <div :style=\"lineStyle\">\n        🛡 Written in TypeScript with predictable static types.\n      </div>\n      <div :style=\"lineStyle\">\n        ⚙️ Whole package of design resources and development tools.\n      </div>\n      <div :style=\"lineStyle\">\n        🌍 Internationalization support for dozens of languages.\n      </div>\n      <div :style=\"lineStyle\">\n        🎨 Powerful theme customization in every detail.\n      </div>\n      <template #footer>\n        <a-button\n          :style=\"{ borderColor: '#ccc', color: '#171717', backgroundColor: '#fff' }\"\n          @click=\"modalFnOpen = false\"\n        >\n          Cancel\n        </a-button>\n        <a-button\n          type=\"primary\"\n          :style=\"{ backgroundColor: '#171717' }\"\n          @click=\"modalOpen = true\"\n        >\n          Submit\n        </a-button>\n      </template>\n    </a-modal>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, top position, width, max-width, margins, bottom padding and other basic layout styles for modal container",
+          "descriptionZh": "根元素，包含相对定位、顶部位置、宽度、最大宽度、外边距、底部内边距等模态框容器的基础布局样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'mask', desc: t('mask'), version: '1.0.0' },\n  { name: 'container', desc: t('container'), version: '1.0.0' },\n  { name: 'wrapper', desc: t('wrapper'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.3.0' },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Modal\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', inset: 0 }\">\n        <a-modal\n          title=\"Title\"\n          open\n          :get-container=\"() => divRef!\"\n          :width=\"400\"\n          :styles=\"{\n            mask: { position: 'absolute', zIndex: 1 },\n            wrapper: { position: 'absolute', zIndex: 1 },\n          }\"\n          :style=\"{ top: '50%', transform: 'translateY(-50%)', marginBottom: 0, paddingBottom: 0 }\"\n          :classes=\"classes\"\n        >\n          <p>Some contents...</p>\n        </a-modal>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "mask",
+          "description": "Mask element with fixed positioning, z-index, background color, animation transitions and other mask layer styles",
+          "descriptionZh": "遮罩层元素，包含固定定位、层级、背景色、动画过渡等遮罩层的样式"
+        },
+        {
+          "key": "wrapper",
+          "description": "Wrapper element used for motion container with animation and transition effect styles",
+          "descriptionZh": "包裹层元素，一般用于动画容器，包含动画和过渡效果的样式"
+        },
+        {
+          "key": "container",
+          "description": "Modal container element with relative positioning, background, background-clip, border, border-radius, box-shadow, pointer-events, padding and other modal body styles",
+          "descriptionZh": "Modal 容器元素，包含相对定位、背景色、背景裁剪、边框、圆角、阴影、指针事件、内边距等模态框主体样式"
+        },
+        {
+          "key": "header",
+          "description": "Header element with padding, bottom border and other header area styles",
+          "descriptionZh": "头部元素，包含头部内边距、下边框等头部区域样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with margin, color, font-weight, font-size, line-height, word-wrap and other title text styles",
+          "descriptionZh": "标题元素，包含外边距、颜色、字体权重、字体大小、行高、文字换行等标题文字样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with content area background color, padding and other content display styles",
+          "descriptionZh": "内容元素，包含内容区域的背景色、内边距等内容展示样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with footer background color, padding, top border, border-radius and other footer area styles",
+          "descriptionZh": "底部元素，包含底部的背景色、内边距、上边框、圆角等底部区域样式"
+        },
+        {
+          "key": "close",
+          "description": "Close button element with base button styles, positioning and interaction effects",
+          "descriptionZh": "关闭按钮元素，包含按钮基础样式、位置和交互效果"
         }
       ]
     },
@@ -14695,14 +15424,63 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Notification by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义通知的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CSSProperties } from 'vue'\nimport { notification } from 'antdv-next'\n\nconst [api, ContextHolder] = notification.useNotification()\n\nconst defaultStyles: Record<string, CSSProperties> = {\n  root: {\n    backgroundColor: '#f6ffed',\n    border: '2px solid #95de64',\n    borderRadius: '16px',\n    boxShadow: '4px 4px 0 #d9f7be',\n  },\n  icon: {\n    color: '#237804',\n  },\n  title: {\n    color: '#237804',\n    fontWeight: 600,\n  },\n  description: {\n    color: '#3f6600',\n  },\n}\n\nfunction styleFn(info: { props: any }): Record<string, CSSProperties> {\n  if (info.props.type === 'error') {\n    return {\n      ...defaultStyles,\n      root: {\n        ...defaultStyles.root,\n        backgroundColor: '#fff2f0',\n        borderColor: '#ffccc7',\n        boxShadow: '4px 4px 0 #ffccc7',\n      },\n      icon: {\n        color: '#cf1322',\n      },\n      title: {\n        color: '#cf1322',\n      },\n      description: {\n        color: '#5c0011',\n      },\n    }\n  }\n  return defaultStyles\n}\n\nconst sharedProps = {\n  title: 'Notification Title',\n  description: 'This is a notification description.',\n  duration: false as const,\n}\n\nfunction openDefault() {\n  api.info({\n    ...sharedProps,\n    styles: defaultStyles,\n  })\n}\n\nfunction openError() {\n  api.error({\n    ...sharedProps,\n    type: 'error',\n    styles: styleFn as any,\n  })\n}\n</script>\n\n<template>\n  <ContextHolder />\n  <a-space>\n    <a-button type=\"primary\" @click=\"openDefault\">\n      Default Notification\n    </a-button>\n    <a-button @click=\"openError\">\n      Error Notification\n    </a-button>\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "list",
+          "description": "Notification list root element, set positioning, z-index, width, scroll area and placement styles",
+          "descriptionZh": "通知列表根元素，设置定位、层级、宽度、滚动区域和位置样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { Button, notification } from 'antdv-next'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { _InternalListDoNotUseOrYouWillBeFired: InternalList } = notification\n\nconst { t } = useComponentLocale(locales)\n\nconst previewListStyle = {\n  position: 'relative',\n  inset: 'auto',\n  width: '432px',\n  maxWidth: '100%',\n  height: 'auto',\n  padding: '24px',\n  transform: 'none',\n} as const\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'wrapper', desc: t('wrapper'), version: '1.3.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.3.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.3.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n  { name: 'progress', desc: t('progress'), version: '1.3.0' },\n  { name: 'list', desc: t('list'), version: '1.3.0' },\n  { name: 'listContent', desc: t('listContent'), version: '1.3.0' },\n])\n\nconst items = computed(() => [\n  {\n    key: 'semantic-notification-1',\n    title: 'Hello World!',\n    description: 'Hello World?',\n    type: 'success' as const,\n    duration: false as const,\n    actions: h(Button, { type: 'primary', size: 'small' }, () => 'My Button'),\n  },\n  {\n    key: 'semantic-notification-2',\n    title: 'Welcome back!',\n    description: 'This is another notification.',\n    type: 'info' as const,\n    duration: 999999,\n    showProgress: true,\n  },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Notification\"\n    :height=\"320\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <InternalList\n        placement=\"topRight\"\n        :style=\"previewListStyle\"\n        :items=\"items\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "listContent",
+          "description": "Notification list content element, set notice layout, gap and height transition styles",
+          "descriptionZh": "通知列表内容元素，设置通知项排列、间距和高度动画样式"
+        },
+        {
+          "key": "root",
+          "description": "Notice root element, set background color, border radius, shadow, padding and animation styles",
+          "descriptionZh": "通知项根元素，设置背景色、圆角、阴影、内边距和动画样式"
+        },
+        {
+          "key": "wrapper",
+          "description": "Wrapper element for icon and content with content layout styles",
+          "descriptionZh": "图标与内容的包裹元素，设置内容布局样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element, set absolute positioning, font size, line height and status color styles",
+          "descriptionZh": "图标元素，设置绝对定位、字体大小、行高和状态颜色样式"
+        },
+        {
+          "key": "section",
+          "description": "Content section element that contains title and description",
+          "descriptionZh": "内容区域元素，包含标题和描述内容"
+        },
+        {
+          "key": "title",
+          "description": "Title element, set color, font size, line height and margin styles",
+          "descriptionZh": "标题元素，设置颜色、字体大小、行高和外边距样式"
+        },
+        {
+          "key": "description",
+          "description": "Description element, set font size, color and margin styles",
+          "descriptionZh": "描述元素，设置字体大小、颜色和外边距样式"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element, set float right, top margin and action button layout styles",
+          "descriptionZh": "操作组元素，设置右浮动、上边距和操作按钮布局样式"
+        },
+        {
+          "key": "close",
+          "description": "Close button element, set position, size and interaction styles",
+          "descriptionZh": "关闭按钮元素，设置位置、尺寸和交互样式"
+        },
+        {
+          "key": "progress",
+          "description": "Progress element, set progress styles for auto-closing notifications",
+          "descriptionZh": "进度条元素，设置自动关闭通知的进度样式"
         }
       ]
     },
@@ -14721,7 +15499,8 @@
       "props": [],
       "tokens": [],
       "faq": [],
-      "demos": []
+      "demos": [],
+      "semanticStructure": []
     },
     {
       "name": "Pagination",
@@ -15144,14 +15923,18 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Pagination by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Pagination 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { PaginationProps } from 'antdv-next'\nimport { useCssModule } from 'vue'\n\nconst moduleStyles = useCssModule()\n\nconst classes: PaginationProps['classes'] = {\n  root: moduleStyles.root,\n}\n\nconst stylesObject: PaginationProps['styles'] = {\n  item: {\n    borderRadius: '999px',\n  },\n}\n\nconst stylesFn: PaginationProps['styles'] = ({ props }) => {\n  if (props.size === 'small') {\n    return {\n      item: {\n        backgroundColor: 'rgba(200, 200, 200, 0.3)',\n        marginInlineEnd: '4px',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-pagination :total=\"500\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-pagination :total=\"500\" size=\"small\" :classes=\"classes\" :styles=\"stylesFn\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set flex layout, alignment, flex wrap and list styles",
+          "descriptionZh": "根元素，设置flex布局、对齐方式、换行和列表样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Pagination\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-pagination :default-current=\"1\" :total=\"50\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element, set size, padding, border, background color, hover state and active state styles",
+          "descriptionZh": "页码元素，设置尺寸、内边距、边框、背景色、悬停态和激活态样式"
         }
       ]
     },
@@ -15363,14 +16146,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Popconfirm by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Popconfirm 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { PopconfirmProps } from 'antdv-next'\n\nconst classes: PopconfirmProps['classes'] = {\n  container: 'demo-popconfirm-container',\n}\n\nconst stylesObject: PopconfirmProps['styles'] = {\n  container: {\n    backgroundColor: '#eee',\n    boxShadow: 'inset 5px 5px 3px #fff, inset -5px -5px 3px #ddd, 0 0 3px rgba(0,0,0,0.2)',\n  },\n  title: {\n    color: '#262626',\n  },\n  content: {\n    color: '#262626',\n  },\n}\n\nconst stylesFn: PopconfirmProps['styles'] = (info) => {\n  if (info?.props?.arrow === false) {\n    return {\n      container: {\n        backgroundColor: 'rgba(53, 71, 125, 0.8)',\n        padding: '12px',\n        borderRadius: '4px',\n      },\n      title: {\n        color: '#fff',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-popconfirm\n      title=\"Object text\"\n      description=\"Object description\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    >\n      <a-button>Object Style</a-button>\n    </a-popconfirm>\n    <a-popconfirm\n      title=\"Function text\"\n      description=\"Function description\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n      :ok-button-props=\"{ styles: { root: { backgroundColor: 'rgba(53, 71, 125, 0.6)', color: '#fff' } } }\"\n      :cancel-button-props=\"{ styles: { root: { borderColor: 'rgba(53, 71, 125, 0.6)', backgroundColor: '#fff', color: 'rgba(53, 71, 125, 0.8)' } } }\"\n    >\n      <a-button type=\"primary\">\n        Function Style\n      </a-button>\n    </a-popconfirm>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set absolute positioning, z-index, transform origin, arrow direction and popover container styles",
+          "descriptionZh": "根元素，设置绝对定位、层级、变换原点、箭头指向和弹层容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'container', desc: t('container') },\n  { name: 'title', desc: t('title') },\n  { name: 'content', desc: t('content') },\n  { name: 'icon', desc: t('icon'), version: '1.3.0' },\n  { name: 'arrow', desc: t('arrow') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Popconfirm\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', marginTop: '60px' }\">\n        <a-popconfirm\n          open\n          placement=\"top\"\n          title=\"Confirm\"\n          description=\"Are you sure you want to perform this action?\"\n          :auto-adjust-overflow=\"false\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "arrow",
+          "description": "Arrow element with width, height, position, color and border styles",
+          "descriptionZh": "箭头元素，设置宽高、位置、颜色和边框样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element, set title text styles and spacing",
+          "descriptionZh": "标题元素，设置标题文本样式和间距"
+        },
+        {
+          "key": "content",
+          "description": "Description element, set content text styles and layout",
+          "descriptionZh": "描述元素，设置描述文本样式和布局"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element, set icon size, color and margin styles",
+          "descriptionZh": "图标元素，设置图标尺寸、颜色和外边距样式"
         }
       ]
     },
@@ -15574,14 +16381,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Popover by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Popover 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { PopoverProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: PopoverProps['classes'] = {\n  container: 'demo-popover-container',\n}\n\nconst stylesObject: PopoverProps['styles'] = {\n  container: {\n    backgroundColor: '#eee',\n    boxShadow: 'inset 5px 5px 3px #fff, inset -5px -5px 3px #ddd, 0 0 3px rgba(0,0,0,0.2)',\n  },\n  title: {\n    color: '#262626',\n  },\n  content: {\n    color: '#262626',\n  },\n}\n\nconst stylesFn: PopoverProps['styles'] = (info) => {\n  if (info?.props?.arrow === false) {\n    return {\n      container: {\n        backgroundColor: 'rgba(53, 71, 125, 0.8)',\n        padding: '12px',\n        borderRadius: '4px',\n      },\n      title: {\n        color: '#fff',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-popover\n      content=\"Object text\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    >\n      <a-button>Object Style</a-button>\n    </a-popover>\n    <a-popover\n      content=\"Function text\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n    >\n      <a-button type=\"primary\">\n        Function Style\n      </a-button>\n    </a-popover>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set absolute positioning, z-index, transform origin, arrow direction and popover container styles",
+          "descriptionZh": "根元素，设置绝对定位、层级、变换原点、箭头指向和弹层容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'container', desc: t('container') },\n  { name: 'title', desc: t('title') },\n  { name: 'content', desc: t('content') },\n  { name: 'arrow', desc: t('arrow') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Popover\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', marginTop: '60px' }\">\n        <a-popover\n          open\n          placement=\"top\"\n          title=\"Hello\"\n          content=\"Ant Design love you!\"\n          :auto-adjust-overflow=\"false\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "arrow",
+          "description": "Arrow element with width, height, position, color and border styles",
+          "descriptionZh": "箭头元素，设置宽高、位置、颜色和边框样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element, set title text styles and spacing",
+          "descriptionZh": "标题元素，设置标题文本样式和间距"
+        },
+        {
+          "key": "content",
+          "description": "Content element, set content text styles and layout",
+          "descriptionZh": "内容元素，设置内容文本样式和布局"
         }
       ]
     },
@@ -15884,14 +16710,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Progress by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Progress 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { ProgressProps } from 'antdv-next'\n\nconst classes: ProgressProps['classes'] = {\n  root: 'demo-progress-root',\n  rail: 'demo-progress-rail',\n  track: 'demo-progress-track',\n}\n\nconst stylesFn: ProgressProps['styles'] = (info) => {\n  const percent = info?.props?.percent ?? 0\n  const hue = 200 - (200 * percent) / 100\n  return {\n    track: {\n      backgroundImage: `\n        linear-gradient(\n          to right,\n          hsla(${hue}, 85%, 65%, 1),\n          hsla(${hue + 30}, 90%, 55%, 0.95)\n        )`,\n      borderRadius: 8,\n      transition: 'all 0.3s ease',\n    },\n    rail: {\n      backgroundColor: 'rgba(0, 0, 0, 0.1)',\n      borderRadius: 8,\n    },\n  } as ProgressProps['styles']\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"10\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"20\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"40\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"60\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"80\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"99\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set relative positioning and basic container styles",
+          "descriptionZh": "根元素，设置相对定位和基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'body', desc: t('body') },\n  { name: 'rail', desc: t('rail') },\n  { name: 'track', desc: t('track') },\n  { name: 'indicator', desc: t('indicator') },\n])\n\nconst gradient = ref(false)\nconst type = ref('line')\n\nconst colorMap = {\n  '0%': '#108ee9',\n  '100%': '#87d068',\n}\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Progress\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical gap=\"middle\" :style=\"{ width: '100%' }\" align=\"center\">\n        <a-flex align=\"center\" gap=\"middle\">\n          <a-segmented\n            :options=\"['line', 'steps', 'circle', 'dashboard']\"\n            :value=\"type\"\n            @change=\"(val: string) => type = val\"\n          />\n          <a-switch\n            :checked=\"gradient\"\n            checked-children=\"Gradient\"\n            un-checked-children=\"Gradient\"\n            @change=\"(val: boolean) => gradient = val\"\n          />\n        </a-flex>\n        <a-flex vertical align=\"center\" :style=\"{ height: '200px', width: '100%' }\">\n          <a-progress\n            :percent=\"80\"\n            :type=\"type === 'steps' ? 'line' : type\"\n            :steps=\"type === 'steps' ? 5 : undefined\"\n            :stroke-color=\"gradient ? colorMap : undefined\"\n            :classes=\"classes\"\n          />\n        </a-flex>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "body",
+          "description": "Body element, set progress bar layout and size styles",
+          "descriptionZh": "主体元素，设置进度条的布局和尺寸样式"
+        },
+        {
+          "key": "rail",
+          "description": "Rail element, set background track color and border radius styles. Not exist in steps mode",
+          "descriptionZh": "导轨元素，设置背景轨道的颜色和圆角样式，steps 模式下没有该元素"
+        },
+        {
+          "key": "track",
+          "description": "Track element, set progress fill color and transition animation styles",
+          "descriptionZh": "轨迹元素，设置进度填充部分的颜色和过渡动画样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element, set percentage text or icon position and font styles",
+          "descriptionZh": "指示器元素，设置百分比文本或图标的位置和字体样式"
         }
       ]
     },
@@ -16112,14 +16957,18 @@
           "description": "With Popover.",
           "descriptionZh": "带气泡卡片的例子。",
           "code": "<script setup lang=\"ts\">\ndefineOptions({ name: 'Popover' })\n</script>\n\n<template>\n  <a-popover>\n    <template #content>\n      <a-qrcode value=\"https://ant.design\" :bordered=\"false\" />\n    </template>\n    <a-button type=\"primary\">\n      Hover me\n    </a-button>\n  </a-popover>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set flex layout, padding, background color, border, border radius and relative positioning styles",
+          "descriptionZh": "根元素，设置flex布局、内边距、背景色、边框、圆角和相对定位样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'cover', desc: t('cover') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"QRCode\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-qrcode value=\"https://ant.design\" status=\"loading\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "cover",
+          "description": "Cover element, set absolute positioning, z-index, background color and loading state overlay styles",
+          "descriptionZh": "遮罩层元素，设置绝对定位、层级、背景色和加载状态覆盖样式"
         }
       ]
     },
@@ -16521,14 +17370,23 @@
           "description": "Solid radio button style.",
           "descriptionZh": "实色填底的单选按钮样式。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst value = shallowRef('a')\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-radio-group v-model:value=\"value\" button-style=\"solid\">\n      <a-radio-button value=\"a\">\n        Hangzhou\n      </a-radio-button>\n      <a-radio-button value=\"b\">\n        Shanghai\n      </a-radio-button>\n      <a-radio-button value=\"c\">\n        Beijing\n      </a-radio-button>\n      <a-radio-button value=\"d\">\n        Chengdu\n      </a-radio-button>\n    </a-radio-group>\n    <a-radio-group v-model:value=\"value\" button-style=\"solid\">\n      <a-radio-button value=\"a\">\n        Hangzhou\n      </a-radio-button>\n      <a-radio-button value=\"b\" disabled>\n        Shanghai\n      </a-radio-button>\n      <a-radio-button value=\"c\">\n        Beijing\n      </a-radio-button>\n      <a-radio-button value=\"d\">\n        Chengdu\n      </a-radio-button>\n    </a-radio-group>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with layout styles, cursor styles, disabled text color and other basic container styles",
+          "descriptionZh": "根元素，包含布局样式、鼠标样式、禁用状态文字颜色等基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Radio\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-radio :classes=\"classes\">\n        Radio\n      </a-radio>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element with border radius, transition animations, border styles, hover states, focus states and other interactive styles",
+          "descriptionZh": "选中框元素，包含圆角样式、过渡动画、边框样式、悬停状态、焦点状态等交互样式"
+        },
+        {
+          "key": "label",
+          "description": "Label element with padding, text color, disabled states, alignment and other text styles",
+          "descriptionZh": "文本元素，包含内边距、文字颜色、禁用状态、对齐方式等文本样式"
         }
       ]
     },
@@ -16790,7 +17648,8 @@
           "descriptionZh": "调试使用。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst value = ref(2.5)\n</script>\n\n<template>\n  <a-config-provider\n    :theme=\"{\n      components: {\n        Rate: {\n          starColor: 'blue',\n          starSize: 40,\n          starHoverScale: 'scale(2)',\n          starBg: 'red',\n        },\n      },\n    }\"\n  >\n    <a-rate v-model:value=\"value\" allow-half />\n  </a-config-provider>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Result",
@@ -16958,14 +17817,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Result by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Result 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { ResultProps } from 'antdv-next'\n\nconst classesObject: ResultProps['classes'] = {\n  root: 'demo-result-root',\n  title: 'demo-result-title',\n  subTitle: 'demo-result-subtitle',\n  icon: 'demo-result-icon',\n  extra: 'demo-result-extra',\n  body: 'demo-result-body',\n}\n\nconst classesFn: ResultProps['classes'] = (info) => {\n  if (info.props.status === 'success') {\n    return {\n      root: 'demo-result-root--success',\n    } satisfies ResultProps['classes']\n  }\n  return {\n    root: 'demo-result-root--default',\n  } satisfies ResultProps['classes']\n}\n\nconst stylesObject: ResultProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed', padding: '16px' },\n  title: { fontStyle: 'italic', color: '#1890ff' },\n  subTitle: { fontWeight: 'bold' },\n  icon: { opacity: 0.8 },\n  extra: { backgroundColor: '#f0f0f0', padding: 'px' },\n  body: { backgroundColor: '#fafafa', padding: '12px' },\n}\n\nconst stylesFn: ResultProps['styles'] = (info) => {\n  if (info.props.status === 'error') {\n    return {\n      root: { backgroundColor: '#fff2f0', borderColor: '#ff4d4f' },\n      title: { color: '#ff4d4f' },\n    } satisfies ResultProps['styles']\n  }\n  else {\n    return {\n      root: { backgroundColor: '#f6ffed', borderColor: '#52c41a' },\n      title: { color: '#52c41a' },\n    } satisfies ResultProps['styles']\n  }\n}\n</script>\n\n<template>\n  <a-result\n    status=\"info\"\n    title=\"classes Object\"\n    sub-title=\"This is a subtitle\"\n    :styles=\"stylesObject\"\n    :classes=\"classesObject\"\n  >\n    <template #extra>\n      <a-button type=\"primary\">\n        Action\n      </a-button>\n    </template>\n    <div>Content area</div>\n  </a-result>\n  <a-result\n    status=\"success\"\n    title=\"classes Function\"\n    sub-title=\"Dynamic class names\"\n    :styles=\"stylesFn\"\n    :classes=\"classesFn\"\n  >\n    <template #extra>\n      <a-button type=\"primary\">\n        Action\n      </a-button>\n    </template>\n  </a-result>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with text alignment, layout styles and other basic container styles",
+          "descriptionZh": "根元素，包含文本对齐、布局样式等基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'subTitle', desc: t('subTitle'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Result\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-result\n        title=\"title\"\n        sub-title=\"subTitle\"\n        :classes=\"classes\"\n      >\n        <template #extra>\n          <a-button type=\"primary\">\n            extra\n          </a-button>\n        </template>\n        <div :style=\"{ textAlign: 'center' }\">\n          The Content of Result\n        </div>\n      </a-result>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "title",
+          "description": "Title element with font size, text color, line height, text alignment and other text styles",
+          "descriptionZh": "标题元素，包含字体大小、文字颜色、行高、对齐方式等文字样式"
+        },
+        {
+          "key": "subTitle",
+          "description": "Subtitle element with font size, text color, line height and other text styles",
+          "descriptionZh": "副标题元素，包含字体大小、文字颜色、行高等文字样式"
+        },
+        {
+          "key": "body",
+          "description": "Content element with margin, padding, background color and other content area styles",
+          "descriptionZh": "内容元素，包含外边距、内边距、背景色等内容区域样式"
+        },
+        {
+          "key": "extra",
+          "description": "Action area element with margin, text alignment, inner element spacing and other layout styles",
+          "descriptionZh": "操作区域元素，包含外边距、文本对齐、内部元素间距等布局样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with margin, text alignment, font size, status colors and other icon styles",
+          "descriptionZh": "图标元素，包含外边距、文本对齐、字体大小、状态颜色等图标样式"
         }
       ]
     },
@@ -17229,14 +18112,28 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Segmented by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Segmented 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { SegmentedProps } from 'antdv-next'\nimport { CloudOutlined, RocketOutlined, ThunderboltOutlined } from '@antdv-next/icons'\nimport { h } from 'vue'\n\nconst classes: SegmentedProps['classes'] = {\n  root: 'custom-segmented-root',\n}\nconst styleFn: SegmentedProps['styles'] = (info) => {\n  if (info.props.vertical) {\n    return {\n      root: {\n        border: '1px solid #77BEF0',\n        padding: '4px',\n        width: '100px',\n      },\n      icon: {\n        color: '#77BEF0',\n      },\n      item: {\n        textAlign: 'start',\n      },\n    } satisfies SegmentedProps['styles']\n  }\n  return {}\n}\n\nconst styles: SegmentedProps['styles'] = {\n  root: {\n    padding: '4px',\n    width: '260px',\n  },\n}\n\nconst options: SegmentedProps['options'] = [\n  {\n    label: 'Boost',\n    value: 'boost',\n    icon: h(RocketOutlined),\n  },\n  {\n    label: 'Stream',\n    value: 'stream',\n    icon: h(ThunderboltOutlined),\n  },\n  {\n    label: 'Cloud',\n    value: 'cloud',\n    icon: h(CloudOutlined),\n  },\n]\nconst segmentedSharedProps: SegmentedProps = {\n  options,\n  classes,\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-segmented v-bind=\"segmentedSharedProps\" :styles=\"styles\" />\n    <a-segmented v-bind=\"segmentedSharedProps\" :styles=\"styleFn\" vertical />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with inline-block layout, padding, background, border radius, transition and container styles",
+          "descriptionZh": "根元素，设置行内块布局、内边距、背景色、圆角、过渡动画和容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AppstoreOutlined, BarsOutlined } from '@antdv-next/icons'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n])\n\nconst options = [\n  { label: 'List', value: 'List', icon: h(BarsOutlined) },\n  { label: 'Kanban', value: 'Kanban', icon: h(AppstoreOutlined) },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Segmented\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-segmented :options=\"options\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Option element with relative positioning, text alignment, cursor style, transition, selected state background and hover styles",
+          "descriptionZh": "选项元素，设置相对定位、文本对齐、光标样式、过渡动画、选中态背景色和悬停态样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with icon size, color and text spacing styles",
+          "descriptionZh": "图标元素，设置图标的尺寸、颜色和与文本的间距样式"
+        },
+        {
+          "key": "label",
+          "description": "Label content element with min height, line height, padding, text ellipsis and content layout styles",
+          "descriptionZh": "标签内容元素，设置最小高度、行高、内边距、文本省略和内容布局样式"
         }
       ]
     },
@@ -18078,14 +18975,73 @@
           "description": "You can customize the semantic dom style of Select by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "您可以通过 `classes` 和 `styles` 传入对象/函数来自定义 Select 的语义化 DOM 样式。",
           "code": "<script setup lang=\"ts\">\nimport { MehOutlined } from '@antdv-next/icons'\n\nconst options = [\n  { value: 'GuangZhou', label: 'GuangZhou' },\n  { value: 'ShenZhen', label: 'ShenZhen' },\n]\n\nconst stylesObject = {\n  prefix: {\n    color: '#1890ff',\n  },\n  suffix: {\n    color: '#1890ff',\n  },\n}\n\nconst stylesFilled = {\n  prefix: {\n    color: '#722ed1',\n  },\n  suffix: {\n    color: '#722ed1',\n  },\n  popup: {\n    root: {\n      border: '1px solid #722ed1',\n    },\n  },\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-select\n      :options=\"options\"\n      :classes=\"{ root: 'custom-select' }\"\n      :styles=\"stylesObject\"\n      placeholder=\"Object\"\n    >\n      <template #prefix>\n        <MehOutlined />\n      </template>\n    </a-select>\n    <a-select\n      :options=\"options\"\n      :classes=\"{ root: 'custom-select' }\"\n      :styles=\"stylesFilled\"\n      placeholder=\"Function\"\n      variant=\"filled\"\n    >\n      <template #prefix>\n        <MehOutlined />\n      </template>\n    </a-select>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, cursor styles, transitions, border and other basic selector container styles",
+          "descriptionZh": "根元素，包含相对定位、行内 flex 布局、光标样式、过渡动画、边框等选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst mode = ref<'single' | 'multiple'>('single')\n\nconst options = [\n  { value: 'aojunhao123', label: 'aojunhao123' },\n  { value: 'thinkasany', label: 'thinkasany' },\n  { value: 'meet-student', label: 'meet-student' },\n]\n\nconst value = computed(() => {\n  if (mode.value !== 'multiple')\n    return []\n\n  return options.length > 0\n    ? [options[0]!.value]\n    : []\n})\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => {\n  const base = [\n    { name: 'root', desc: t('root') },\n    { name: 'prefix', desc: t('prefix') },\n    { name: 'content', desc: t('content') },\n    { name: 'placeholder', desc: t('placeholder') },\n    { name: 'clear', desc: t('clear') },\n    { name: 'input', desc: t('input') },\n    { name: 'suffix', desc: t('suffix') },\n    { name: 'popup.root', desc: t('popup.root') },\n    { name: 'popup.list', desc: t('popup.list') },\n    { name: 'popup.listItem', desc: t('popup.listItem') },\n  ]\n\n  if (mode.value === 'multiple') {\n    return [\n      ...base,\n      { name: 'item', desc: t('item') },\n      { name: 'itemContent', desc: t('itemContent') },\n      { name: 'itemRemove', desc: t('itemRemove') },\n    ]\n  }\n\n  return base\n})\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Select\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <div :style=\"{ display: 'flex', justifyContent: 'center', marginBottom: '12px' }\">\n          <a-segmented v-model:value=\"mode\" :options=\"['single', 'multiple']\" />\n        </div>\n        <div :style=\"{ display: 'flex', flexDirection: 'column', gap: '12px' }\">\n          <a-select\n            prefix=\"prefix\"\n            :style=\"{ width: '300px' }\"\n            :options=\"options\"\n            :value=\"value\"\n            :mode=\"mode === 'multiple' ? 'multiple' : undefined\"\n            open\n            :get-popup-container=\"() => divRef!\"\n            :classes=\"classes\"\n          />\n        </div>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with layout and styling for prefix content",
+          "descriptionZh": "前缀元素，包含前缀内容的布局和样式"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "clear",
+          "description": "Clear button element with layout, styling and interactive effects for clear button",
+          "descriptionZh": "清除按钮元素，包含清除按钮的布局、样式和交互效果"
+        },
+        {
+          "key": "input",
+          "description": "Input element with search input styling, cursor control, font inheritance and other search-related styles. Remove border styles",
+          "descriptionZh": "输入框元素，包含搜索输入框的样式、光标控制、字体继承等搜索相关样式，去除了边框样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with layout and styling for suffix content like clear button, arrow icon, etc.",
+          "descriptionZh": "后缀元素，包含后缀内容的布局和样式，如清除按钮、箭头图标等"
+        },
+        {
+          "key": "item",
+          "description": "Multiple selection item element with border, background, padding, and margin styles",
+          "descriptionZh": "多选项元素，包含边框、背景、内边距、外边距样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Multiple selection item content area with text ellipsis styles",
+          "descriptionZh": "多选项内容区域，包含文字的省略样式"
+        },
+        {
+          "key": "itemRemove",
+          "description": "Multiple selection item remove button with font-related styless",
+          "descriptionZh": "多选项移除按钮，包含字体相关样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with popup layer positioning, z-index, background, border, box-shadow and other popup container styles",
+          "descriptionZh": "弹出菜单元素，包含弹出层的定位、层级、背景、边框、阴影等弹出容器样式"
+        },
+        {
+          "key": "popup.list",
+          "description": "Popup list element with option list layout, scrolling, max-height and other list container styles",
+          "descriptionZh": "弹出菜单列表元素，包含选项列表的布局、滚动、最大高度等列表容器样式"
+        },
+        {
+          "key": "popup.listItem",
+          "description": "Popup item element with option item padding, hover effects, selected states, disabled states and other option interactive styles",
+          "descriptionZh": "弹出菜单条目元素，包含选项项的内边距、悬浮效果、选中状态、禁用状态等选项交互样式"
         }
       ]
     },
@@ -18540,22 +19496,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Skeleton by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Skeleton 组件的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nconst classes = {\n  root: 'skeleton-root',\n  header: 'skeleton-header',\n}\n\nconst styles = {\n  avatar: {\n    border: '1px solid #aaa',\n  },\n  title: {\n    border: '1px solid #aaa',\n  },\n}\n\nfunction stylesFn(info: { props: { active?: boolean } }) {\n  if (info.props?.active) {\n    return {\n      root: {\n        border: '1px solid rgba(229, 243, 254, 0.3)',\n      },\n      title: {\n        backgroundColor: 'rgba(229, 243, 254, 0.5)',\n        height: '20px',\n        borderRadius: '20px',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-skeleton\n      :classes=\"classes\"\n      :styles=\"styles\"\n      avatar\n      :paragraph=\"false\"\n    />\n    <a-skeleton\n      :classes=\"{ ...classes, paragraph: 'skeleton-paragraph' }\"\n      :styles=\"stylesFn\"\n      active\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with table display, width, animation effects, border radius and other skeleton container basic styles",
+          "descriptionZh": "根元素，包含表格显示、宽度、动画效果、圆角等骨架屏容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'avatar', desc: t('avatar'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'paragraph', desc: t('paragraph'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Skeleton\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-skeleton avatar :paragraph=\"{ rows: 4 }\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with table cell, padding, vertical alignment and other avatar placeholder area layout styles",
+          "descriptionZh": "头部元素，包含表格单元格、内边距、垂直对齐等头像占位区域的布局样式"
         },
         {
-          "name": "_semantic_element",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport type { SegmentedOptions } from 'antdv-next'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\ntype SkeletonElement = 'Avatar' | 'Button' | 'Input' | 'Image' | 'Node'\nconst internalOptions: SegmentedOptions = ['Avatar', 'Button', 'Input', 'Image', 'Node']\n\nconst element = ref<SkeletonElement>('Avatar')\n\nconst componentMap: Record<SkeletonElement, string> = {\n  Avatar: 'a-skeleton-avatar',\n  Button: 'a-skeleton-button',\n  Input: 'a-skeleton-input',\n  Image: 'a-skeleton-image',\n  Node: 'a-skeleton-node',\n}\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('element.root'), version: '1.0.0' },\n  { name: 'content', desc: t('element.content'), version: '1.0.0' },\n])\n\nconst componentName = computed(() => `Skeleton.${element.value}`)\nconst currentComponent = computed(() => componentMap[element.value])\n</script>\n\n<template>\n  <SemanticPreview\n    :component-name=\"componentName\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical :style=\"{ width: 'fit-content', marginInlineEnd: 'auto' }\">\n        <a-segmented v-model:value=\"element\" :options=\"internalOptions\" />\n        <a-divider title-placement=\"start\" plain>\n          {{ t('element.preview') }}\n        </a-divider>\n        <component :is=\"currentComponent\" :classes=\"classes\" />\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Section element with skeleton content area layout styles",
+          "descriptionZh": "区块元素，包含骨架屏内容区域的布局样式"
+        },
+        {
+          "key": "avatar",
+          "description": "Avatar element with inline-block display, vertical alignment, background color, size, border radius and other avatar placeholder styles",
+          "descriptionZh": "头像元素，包含行内块显示、垂直对齐、背景色、尺寸、圆角等头像占位的样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with width, height, background color, border radius and other title placeholder styles",
+          "descriptionZh": "标题元素，包含宽度、高度、背景色、圆角等标题占位的样式"
+        },
+        {
+          "key": "paragraph",
+          "description": "Paragraph element with padding, list item styles, background color, border radius and other paragraph placeholder styles",
+          "descriptionZh": "段落元素，包含内边距、列表项样式、背景色、圆角等段落占位的样式"
+        },
+        {
+          "key": "element.root",
+          "description": "Root element",
+          "descriptionZh": "根元素"
+        },
+        {
+          "key": "element.content",
+          "description": "Content element",
+          "descriptionZh": "内容元素"
+        },
+        {
+          "key": "element.preview",
+          "description": "Preview",
+          "descriptionZh": "预览"
         }
       ]
     },
@@ -18953,14 +19940,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Sliders by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Sliders 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst value = ref(30)\nconst valueVertical = ref(30)\n\nconst stylesObject = {\n  track: { backgroundImage: 'linear-gradient(180deg, #91caff, #1677ff)' },\n  handle: { borderColor: '#1677ff', boxShadow: '0 2px 8px #1677ff' },\n}\n\nfunction stylesFn(info: any) {\n  if (info.props.orientation === 'vertical') {\n    return {\n      root: { height: '300px' },\n      track: { backgroundImage: 'linear-gradient(180deg, #722cc0, #722ed1)' },\n      handle: { borderColor: '#722ed1', boxShadow: '0 2px 8px #722ed1' },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-slider v-model:value=\"value\" class=\"custom-slider\" :styles=\"stylesObject\" />\n    <a-slider\n      v-model:value=\"valueVertical\"\n      class=\"custom-slider-vertical\"\n      orientation=\"vertical\"\n      reverse\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, height, margin, padding, cursor style and touch action control",
+          "descriptionZh": "根元素，设置相对定位、高度、边距、内边距、光标样式和触摸事件控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'track', desc: t('track'), version: '1.0.0' },\n  { name: 'tracks', desc: t('tracks'), version: '1.0.0' },\n  { name: 'rail', desc: t('rail'), version: '1.0.0' },\n  { name: 'handle', desc: t('handle'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Slider\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-slider\n        range\n        :default-value=\"[20, 30, 50]\"\n        :style=\"{ width: '100%' }\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "track",
+          "description": "Track selection bar element with absolute positioning, background color, border radius and transition animation styles",
+          "descriptionZh": "轨道选取条元素，设置绝对定位、背景色、圆角和过渡动画样式"
+        },
+        {
+          "key": "tracks",
+          "description": "Multi-segment track container element with absolute positioning and transition animation styles",
+          "descriptionZh": "多段轨道容器元素，设置绝对定位和过渡动画样式"
+        },
+        {
+          "key": "rail",
+          "description": "Background rail element with absolute positioning, background color, border radius and transition animation styles",
+          "descriptionZh": "背景轨道元素，设置绝对定位、背景色、圆角和过渡动画样式"
+        },
+        {
+          "key": "handle",
+          "description": "Slider handle control element with absolute positioning, size, outline, user selection, background color, border shadow, border radius, cursor style and transition animation",
+          "descriptionZh": "滑块控制点元素，设置绝对定位、尺寸、轮廓线、用户选择、背景色、边框阴影、圆角、光标样式和过渡动画"
         }
       ]
     },
@@ -19183,14 +20189,23 @@
           "description": "Customize semantic structure styles and class names. Supports both object and function forms.",
           "descriptionZh": "自定义语义化结构的样式和类名。支持对象和函数两种形式。",
           "code": "<script setup lang=\"ts\">\nimport type { SpaceProps } from 'antdv-next'\n\nconst classNamesObject: SpaceProps['classes'] = {\n  root: 'demo-space-root',\n  item: 'demo-space-item',\n  separator: 'demo-space-separator',\n}\n\nconst classNamesFn: SpaceProps['classes'] = (info) => {\n  if (info.props.orientation === 'vertical') {\n    return {\n      root: 'demo-space-root--vertical',\n    } satisfies SpaceProps['classes']\n  }\n  else {\n    return {\n      root: 'demo-space-root--horizontal',\n    } satisfies SpaceProps['classes']\n  }\n}\n\nconst stylesObject: SpaceProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed', padding: '8px', marginBottom: '10px' },\n  item: { backgroundColor: '#f0f0f0', padding: '4px' },\n  separator: { color: 'red', fontWeight: 'bold' },\n}\n\nconst stylesFn: SpaceProps['styles'] = (info) => {\n  if (info.props.size === 'large') {\n    return {\n      root: {\n        backgroundColor: '#e6f7ff',\n        borderColor: '#1890ff',\n        padding: '8px',\n      },\n    } satisfies SpaceProps['styles']\n  }\n  else {\n    return {\n      root: {\n        backgroundColor: '#fff7e6',\n        borderColor: '#fa8c16',\n      },\n    } satisfies SpaceProps['styles']\n  }\n}\n</script>\n\n<template>\n  <div>\n    <a-space :styles=\"stylesObject\" :classes=\"classNamesObject\" separator=\"•\">\n      <a-button>Styled Button 1</a-button>\n      <a-button>Styled Button 2</a-button>\n      <a-button>Styled Button 3</a-button>\n    </a-space>\n    <a-space size=\"large\" :styles=\"stylesFn\" :classes=\"classNamesFn\">\n      <a-button>Large Space Button 1</a-button>\n      <a-button>Large Space Button 2</a-button>\n      <a-button>Large Space Button 3</a-button>\n    </a-space>\n  </div>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, gap settings, alignment, wrap and other spacing container basic styles",
+          "descriptionZh": "根元素，包含 flex 布局、间隙设置、对齐方式、换行等间距容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n  { name: 'separator', desc: t('separator') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Space\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-space :classes=\"classes\">\n        <template #separator>\n          <a-divider vertical />\n        </template>\n        <a-button type=\"primary\">\n          Primary\n        </a-button>\n        <a-button>Default</a-button>\n        <a-button type=\"dashed\">\n          Dashed\n        </a-button>\n      </a-space>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Wrapped item element with spacing item layout and styles, providing wrapper for each child element for inline alignment",
+          "descriptionZh": "包裹的子组件，包含间距项的布局和样式，为每个子元素提供包装用于内联对齐"
+        },
+        {
+          "key": "separator",
+          "description": "Separator element with divider styling",
+          "descriptionZh": "分隔符，包含分隔元素的样式"
         }
       ]
     },
@@ -19395,14 +20410,18 @@
           "description": "The `fullscreen` mode is perfect for creating page loaders. It adds a dimmed overlay with a centered spinner.",
           "descriptionZh": "`fullscreen` 属性非常适合创建流畅的页面加载器。它添加了半透明覆盖层，并在其中心放置了一个旋转加载符号。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst spinning = ref(false)\nconst percent = ref(0)\n\nfunction showLoader() {\n  spinning.value = true\n  let ptg = -10\n\n  const interval = setInterval(() => {\n    ptg += 5\n    percent.value = ptg\n\n    if (ptg > 120) {\n      clearInterval(interval)\n      spinning.value = false\n      percent.value = 0\n    }\n  }, 100)\n}\n</script>\n\n<template>\n  <div>\n    <a-button @click=\"showLoader\">\n      Show fullscreen\n    </a-button>\n    <a-spin :spinning=\"spinning\" :percent=\"percent\" fullscreen />\n  </div>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with absolute positioning, display control, color, font size, text alignment, vertical alignment, opacity and transition animation (effective when fullscreen is false)",
+          "descriptionZh": "根元素，设置绝对定位、显示控制、颜色、字体大小、文本对齐、垂直对齐、透明度和过渡动画(fullscreen 为 false 时才有效)"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Spin\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div\n        :style=\"{\n          position: 'relative',\n          width: '500px',\n          height: '100px',\n          display: 'flex',\n          alignItems: 'center',\n          justifyContent: 'center',\n        }\"\n      >\n        <a-spin :percent=\"0\" :classes=\"classes\" />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "indicator",
+          "description": "Indicator element with width, height, font size, inline-block display, transition animation, transform origin, line height and color",
+          "descriptionZh": "指示器元素，设置宽度、高度、字体大小、行内块显示、过渡动画、变换原点、行高和颜色"
         }
       ]
     },
@@ -19685,14 +20704,23 @@
           "description": "Customize semantic structure styles and class names. Supports both object and function forms.",
           "descriptionZh": "自定义语义化结构的样式和类名。支持对象和函数两种形式。",
           "code": "<script setup lang=\"ts\">\nimport type { SplitterProps } from 'antdv-next'\n\nconst stylesObject: SplitterProps['styles'] = {\n  root: { backgroundColor: '#fffbe6' },\n  dragger: { backgroundColor: 'rgba(194,223,252,0.4)' },\n}\n\nconst stylesFn: SplitterProps['styles'] = ({ props }) => {\n  if (props.orientation === 'horizontal') {\n    return {\n      root: {\n        borderWidth: '2px',\n        borderStyle: 'dashed',\n        marginBottom: '10px',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-splitter\n      style=\"height: 200px\"\n      root-class=\"shadow-secondary\"\n      :styles=\"stylesObject\"\n    >\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\" style=\"color: #000\">\n            First\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\" style=\"color: #000\">\n            Second\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n    </a-splitter>\n    <a-splitter\n      style=\"height: 200px\"\n      root-class=\"shadow-secondary\"\n      :styles=\"stylesFn\"\n    >\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\">\n            First\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\">\n            Second\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n    </a-splitter>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, width and height, alignment and stretch styles",
+          "descriptionZh": "根元素，设置flex布局、宽度高度、对齐方式和拉伸样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'panel', desc: t('panel'), version: '1.0.0' },\n  { name: 'dragger', desc: t('dragger'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Splitter\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-splitter\n        :style=\"{ height: '200px', boxShadow: '0 0 10px rgba(0, 0, 0, 0.1)' }\"\n        :classes=\"classes\"\n      >\n        <a-splitter-panel>\n          <div :style=\"{ display: 'flex', height: '100%', alignItems: 'center', justifyContent: 'center' }\">\n            First\n          </div>\n        </a-splitter-panel>\n        <a-splitter-panel>\n          <div :style=\"{ display: 'flex', height: '100%', alignItems: 'center', justifyContent: 'center' }\">\n            Second\n          </div>\n        </a-splitter-panel>\n      </a-splitter>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "panel",
+          "description": "Panel element with flex basis, grow ratio and panel container styles",
+          "descriptionZh": "面板元素，设置flex基础值、增长比例和面板容器样式"
+        },
+        {
+          "key": "dragger",
+          "description": "Drag control element with absolute positioning, user selection, z-index, center alignment, background color, hover and active states styles",
+          "descriptionZh": "拖拽控制元素，设置绝对定位、用户选择、层级、居中对齐、背景色、悬停态和激活态样式"
         }
       ]
     },
@@ -19893,14 +20921,43 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of the Statistic by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Statistic 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { StatisticProps } from 'antdv-next'\nimport { ArrowDownOutlined, ArrowUpOutlined } from '@antdv-next/icons'\n\nconst classes = {\n  root: 'custom-statistic-root',\n}\nconst styleFn: StatisticProps['styles'] = ({ props }) => {\n  const numValue = Number(props.value ?? 0)\n  const isNegative = Number.isFinite(numValue) && numValue < 0\n  if (isNegative) {\n    return {\n      title: {\n        color: '#ff4d4f',\n      },\n      content: {\n        color: '#ff7875',\n      },\n    } satisfies StatisticProps['styles']\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-statistic\n      :value=\"93241\"\n      title=\"Monthly Active Users\"\n      :classes=\"classes\"\n      :styles=\"{ title: { color: '#1890ff', fontWeight: '600px' }, content: { fontSize: '24px' } }\"\n      suffix=\"users\"\n    >\n      <template #prefix>\n        <ArrowUpOutlined />\n      </template>\n    </a-statistic>\n\n    <a-statistic\n      :value=\"-18.7\"\n      title=\"Yearly Loss\"\n      :precision=\"1\"\n      :classes=\"classes\"\n      :styles=\"styleFn\"\n      suffix=\"%\"\n    >\n      <template #prefix>\n        <ArrowDownOutlined />\n      </template>\n    </a-statistic>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with reset styles and overall container styles for statistic component",
+          "descriptionZh": "根元素，包含统计数值组件的重置样式和整体容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { ArrowUpOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'prefix', desc: t('prefix'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'value', desc: t('value'), version: '1.3.0' },\n  { name: 'suffix', desc: t('suffix'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Statistic\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ position: 'absolute' }\">\n        <a-statistic\n          title=\"Active\"\n          :value=\"11.28\"\n          :precision=\"2\"\n          :styles=\"{ content: { color: '#3f8600' } }\"\n          suffix=\"%\"\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <ArrowUpOutlined />\n          </template>\n        </a-statistic>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with bottom padding and title area layout styles",
+          "descriptionZh": "头部元素，包含下内边距和标题区域的布局样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text color, font size and other title text display styles",
+          "descriptionZh": "标题元素，包含文字颜色、字体大小等标题文字的显示样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with text color, font size, font family and other numeric content display styles",
+          "descriptionZh": "内容元素，包含文字颜色、字体大小、字体族等数值内容的展示样式"
+        },
+        {
+          "key": "value",
+          "description": "Value element with text color, font size, font family and other statistic number display styles",
+          "descriptionZh": "数值元素，包含文字颜色、字体大小、字体族等统计数值的展示样式"
+        },
+        {
+          "key": "prefix",
+          "description": "Prefix element with inline-block display, right margin and other prefix content layout styles",
+          "descriptionZh": "前缀元素，包含行内块显示、右外边距等前缀内容的布局样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with inline-block display, left margin and other suffix content layout styles",
+          "descriptionZh": "后缀元素，包含行内块显示、左外边距等后缀内容的布局样式"
         }
       ]
     },
@@ -20206,14 +21263,58 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Steps by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Steps 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { StepsProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: StepsProps['classes'] = {\n  root: 'steps-demo-root',\n}\n\nconst stylesObject: StepsProps['styles'] = {\n  itemIcon: {\n    borderRadius: '30%',\n  },\n  itemContent: {\n    fontStyle: 'italic',\n  },\n}\n\nconst stylesFn: StepsProps['styles'] = (info) => {\n  if (info?.props?.type === 'navigation') {\n    return {\n      root: {\n        borderColor: '#1890ff',\n      },\n    }\n  }\n  return {}\n}\n\nconst items: StepsProps['items'] = [\n  { title: 'Finished', content: 'This is a content.' },\n  { title: 'In Progress', content: 'This is a content.' },\n  { title: 'Waiting', content: 'This is a content.' },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-steps :items=\"items\" :current=\"1\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-steps\n      :items=\"items\"\n      :current=\"1\"\n      type=\"navigation\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, nowrap, alignment, CSS variables and other basic step container styles",
+          "descriptionZh": "根元素，包含 flex 布局、禁止换行、对齐方式、CSS 变量等步骤条容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemWrapper', desc: t('itemWrapper') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n  { name: 'itemHeader', desc: t('itemHeader') },\n  { name: 'itemTitle', desc: t('itemTitle') },\n  { name: 'itemSubtitle', desc: t('itemSubtitle') },\n  { name: 'itemSection', desc: t('itemSection') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'itemRail', desc: t('itemRail') },\n])\n\nconst items = [\n  { title: 'Step 1', subTitle: '00:01', content: 'This is a content.' },\n  { title: 'Step 2', subTitle: '00:02', content: 'This is a content.' },\n  { title: 'Step 3', subTitle: '00:03', content: 'This is a content.' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Steps\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical gap=\"large\" :style=\"{ width: '100%' }\">\n        <a-steps\n          :current=\"1\"\n          :style=\"{ width: '100%' }\"\n          title-placement=\"vertical\"\n          :items=\"items\"\n          :classes=\"classes\"\n        />\n        <a-steps\n          :current=\"1\"\n          :style=\"{ width: '100%' }\"\n          type=\"panel\"\n          size=\"small\"\n          title-placement=\"horizontal\"\n          :items=\"items\"\n          :classes=\"classes\"\n        />\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Step item element with flex layout, relative positioning and other basic step item container styles",
+          "descriptionZh": "步骤项元素，包含 flex 布局、相对定位等单个步骤项的基础容器样式"
+        },
+        {
+          "key": "itemWrapper",
+          "description": "Step item wrapper element with flex layout, nowrap, top padding and other step content wrapping styles",
+          "descriptionZh": "步骤项内裹元素，包含 flex 布局、禁止换行、顶部内边距等步骤项内容的包装样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Step item icon element with icon size, positioning, font-size and other icon display related styles",
+          "descriptionZh": "步骤项图标元素，包含图标的尺寸、定位、字体大小等图标显示相关样式"
+        },
+        {
+          "key": "itemHeader",
+          "description": "Step item header element with flex layout, nowrap, alignment and other header area layout styles",
+          "descriptionZh": "步骤项头部元素，包含 flex 布局、禁止换行、对齐方式等头部区域的布局样式"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Step item title element with color, font-size, line-height, word-break, transitions and other title text styles",
+          "descriptionZh": "步骤项标题元素，包含颜色、字体大小、行高、文字换行、过渡动画等标题文字样式"
+        },
+        {
+          "key": "itemSubtitle",
+          "description": "Step item subtitle element with color, font-weight, font-size, line-height, margin, word-break and other subtitle styles",
+          "descriptionZh": "步骤项副标题元素，包含颜色、字体权重、字体大小、行高、外边距、文字换行等副标题样式"
+        },
+        {
+          "key": "itemSection",
+          "description": "Step item section element with step content area layout and styling",
+          "descriptionZh": "步骤项区域元素，包含步骤项内容区域的布局和样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Step item content element with color, font-size, line-height, word-break, transitions and other content text styles",
+          "descriptionZh": "步骤项内容元素，包含颜色、字体大小、行高、文字换行、过渡动画等内容文字样式"
+        },
+        {
+          "key": "itemRail",
+          "description": "Step item rail element with border-style, border-width, transitions and other connecting line styles",
+          "descriptionZh": "步骤项连接线元素，包含边框样式、边框宽度、过渡动画等连接线的样式"
         }
       ]
     },
@@ -20512,14 +21613,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Switch by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Switch 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes = {\n  root: 'custom-switch-root',\n}\n\nconst stylesObject = {\n  root: {\n    backgroundColor: '#F5D2D2',\n  },\n}\n\nfunction stylesFn(info: any) {\n  if (info.props.size === 'medium') {\n    return {\n      root: {\n        backgroundColor: '#BDE3C3',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-switch\n      size=\"small\"\n      checked-children=\"on\"\n      un-checked-children=\"off\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n    />\n    <a-switch :classes=\"classes\" size=\"medium\" :styles=\"stylesFn\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with min-width, height, line-height, vertical alignment, background color, border, border radius, cursor style, transition animations, user selection and other basic switch container styles",
+          "descriptionZh": "根元素，包含最小宽度、高度、行高、垂直对齐、背景色、边框、圆角、光标样式、过渡动画、用户选择等开关容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.3' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Switch\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-switch\n        checked-children=\"on\"\n        un-checked-children=\"off\"\n        default-checked\n        disabled\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "content",
+          "description": "Content element with block display, overflow hidden, border radius, height, padding, transition animations and other switch content area layout and styles",
+          "descriptionZh": "内容元素，包含块级显示、溢出隐藏、圆角、高度、内边距、过渡动画等开关内容区域的布局和样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element with absolute positioning, width, height, background color, border radius, shadow, transition animations and other switch handle styles and interactive effects",
+          "descriptionZh": "指示器元素,包含绝对定位、宽度、高度、背景色、圆角、阴影、过渡动画等开关把手的样式和交互效果"
         }
       ]
     },
@@ -21317,14 +22427,73 @@
           "description": "Customize header and body cells via the headerCell and bodyCell slots.",
           "descriptionZh": "通过 headerCell 与 bodyCell 插槽自定义表头和单元格内容。",
           "code": "<script setup lang=\"ts\">\nimport type { TableProps } from 'antdv-next'\n\ninterface DataItem {\n  key: string\n  name: string\n  age: number\n  address: string\n}\n\nconst columns: TableProps['columns'] = [\n  {\n    title: 'Name',\n    dataIndex: 'name',\n    key: 'name',\n  },\n  {\n    title: 'Age',\n    dataIndex: 'age',\n    key: 'age',\n  },\n  {\n    title: 'Address',\n    dataIndex: 'address',\n    key: 'address',\n  },\n  {\n    title: 'Action',\n    key: 'action',\n  },\n]\n\nconst dataSource: DataItem[] = [\n  {\n    key: '1',\n    name: 'John Brown',\n    age: 32,\n    address: 'New York No. 1 Lake Park',\n  },\n  {\n    key: '2',\n    name: 'Jim Green',\n    age: 42,\n    address: 'London No. 1 Lake Park',\n  },\n  {\n    key: '3',\n    name: 'Joe Black',\n    age: 32,\n    address: 'Sydney No. 1 Lake Park',\n  },\n]\n\nfunction handleAction(record: Record<string, any>) {\n  console.log('Action:', record.name)\n}\n</script>\n\n<template>\n  <a-table :columns=\"columns\" :data-source=\"dataSource\">\n    <template #headerCell=\"{ column }\">\n      <template v-if=\"column.key === 'name'\">\n        <span class=\"table-header-strong\">{{ column.title }}</span>\n      </template>\n    </template>\n    <template #bodyCell=\"{ column, text, record }\">\n      <template v-if=\"column.key === 'name'\">\n        <a class=\"table-name\" @click.prevent=\"handleAction(record)\">{{ text }}</a>\n      </template>\n      <template v-else-if=\"column.key === 'action'\">\n        <a @click.prevent=\"handleAction(record)\">Action</a>\n      </template>\n    </template>\n  </a-table>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with font-size, background, border-radius, scrollbar-color and other basic table container styles",
+          "descriptionZh": "根元素，包含字体大小、背景色、圆角、滚动条颜色等表格容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'title', desc: t('title') },\n  { name: 'content', desc: t('content') },\n  { name: 'header.wrapper', desc: t('header.wrapper') },\n  { name: 'header.row', desc: t('header.row') },\n  { name: 'header.cell', desc: t('header.cell') },\n  { name: 'section', desc: t('section') },\n  { name: 'body.wrapper', desc: t('body.wrapper') },\n  { name: 'body.row', desc: t('body.row') },\n  { name: 'body.cell', desc: t('body.cell') },\n  { name: 'footer', desc: t('footer') },\n  { name: 'pagination.root', desc: t('pagination.root') },\n  { name: 'pagination.item', desc: t('pagination.item') },\n])\n\nconst columns = [\n  {\n    title: 'Personal Info',\n    children: [\n      { title: 'Name', dataIndex: 'name', key: 'name' },\n      { title: 'Age', dataIndex: 'age', key: 'age' },\n    ],\n  },\n  { title: 'Address', dataIndex: 'address' },\n]\n\nconst data = [\n  { key: '1', name: 'thinkasany', age: 24, address: 'New York No. 1 Lake Park' },\n  { key: '2', name: 'Jim Green', age: 42, address: 'London No. 1 Lake Park' },\n  { key: '3', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n  { key: '4', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n  { key: '5', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n  { key: '6', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Table\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-table\n        bordered\n        :style=\"{ width: '100%' }\"\n        :columns=\"columns\"\n        :data-source=\"data\"\n        size=\"middle\"\n        :pagination=\"{ pageSize: 3 }\"\n        :classes=\"classes\"\n      >\n        <template #title>\n          table title\n        </template>\n        <template #footer>\n          table footer\n        </template>\n      </a-table>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Container element with clear-fix, max-width, scrollbar background and other table wrapper styles",
+          "descriptionZh": "容器元素，包含清除浮动、最大宽度、滚动条背景等表格包装容器样式"
+        },
+        {
+          "key": "header.wrapper",
+          "description": "Header wrapper element with table header layout and container styles",
+          "descriptionZh": "头部容器元素，包含表头的布局和容器样式"
+        },
+        {
+          "key": "header.row",
+          "description": "Header row element with table header row layout and styling",
+          "descriptionZh": "头部行元素，包含表头行的布局和样式"
+        },
+        {
+          "key": "header.cell",
+          "description": "Header cell element with relative positioning, padding, word-wrap, background, text color, font-weight and other header cell styles",
+          "descriptionZh": "头部单元格元素，包含相对定位、内边距、文字换行、背景色、文字颜色、字体权重等表头单元格样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with table title styling and layout",
+          "descriptionZh": "标题元素，包含表格标题的样式和布局"
+        },
+        {
+          "key": "body.wrapper",
+          "description": "Body wrapper element with table body layout and container styles",
+          "descriptionZh": "主体容器元素，包含表格主体的布局和容器样式"
+        },
+        {
+          "key": "body.row",
+          "description": "Body row element with hover effects, selected states, expanded states and other interactive row styles",
+          "descriptionZh": "主体行元素，包含数据行的悬浮效果、选中状态、展开状态等交互样式"
+        },
+        {
+          "key": "body.cell",
+          "description": "Body cell element with relative positioning, padding, word-wrap and other basic data cell styles",
+          "descriptionZh": "主体单元格元素，包含相对定位、内边距、文字换行等数据单元格的基础样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with table footer background color, text color and other footer styles",
+          "descriptionZh": "底部元素，包含表格底部的背景色、文字颜色等样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with table content area styling and layout",
+          "descriptionZh": "内容元素，包含表格内容区域的样式和布局"
+        },
+        {
+          "key": "pagination.root",
+          "description": "Pagination root element with pagination component basic styles and layout",
+          "descriptionZh": "分页根元素，包含分页组件的基础样式和布局"
+        },
+        {
+          "key": "pagination.item",
+          "description": "Pagination item element with pagination item styling and interactive effects",
+          "descriptionZh": "分页单项元素，包含分页项的样式和交互效果"
         }
       ]
     },
@@ -21829,14 +22998,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tabs by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tabs 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TabsProps } from 'antdv-next'\n\nconst items: TabsProps['items'] = [\n  { key: '1', label: 'Tab 1', content: 'Content of Tab Pane 1' },\n  { key: '2', label: 'Tab 2', content: 'Content of Tab Pane 2' },\n  { key: '3', label: 'Tab 3', content: 'Content of Tab Pane 3' },\n]\n\nconst classes: TabsProps['classes'] = {\n  root: 'custom-tabs-root',\n}\n\nconst stylesObject: TabsProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed', padding: '16px', marginBottom: '10px' },\n  header: { backgroundColor: 'rgba(245,245,245,0.5)' },\n  item: { fontWeight: 'bold', color: '#1890ff', padding: `6px 10px` },\n  indicator: { backgroundColor: 'rgba(255,77,79, 0.3)', height: '4px' },\n  content: { backgroundColor: 'rgba(230,247,255,0.8)', padding: '16px' },\n}\n\nconst stylesFn: TabsProps['styles'] = (info) => {\n  if (info.props.type === 'card') {\n    return {\n      root: { backgroundColor: 'rgba(250,250,250, 0.8)', borderColor: '#d9d9d9' },\n      header: { textAlign: 'start' },\n    } satisfies TabsProps['styles']\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-tabs :items=\"items\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-tabs type=\"card\" :items=\"items\" :classes=\"classes\" :styles=\"stylesFn\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with basic tab container styles, layout and direction control",
+          "descriptionZh": "根元素，包含标签页容器的基础样式、布局和方向控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'header', desc: t('header') },\n  { name: 'item', desc: t('item') },\n  { name: 'indicator', desc: t('indicator') },\n  { name: 'content', desc: t('content') },\n  { name: 'popup.root', desc: t('popup.root') },\n])\n\nconst items = computed(() =>\n  Array.from({ length: 30 }, (_, i) => {\n    const id = String(i)\n    return {\n      label: `Tab-${id}`,\n      key: id,\n      disabled: i === 28,\n      content: `Content of tab ${id}`,\n    }\n  }),\n)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tabs\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-tabs\n        default-active-key=\"1\"\n        :style=\"{ height: '220px', width: '100%' }\"\n        :styles=\"{\n          popup: {\n            root: { background: '#fff' },\n          },\n        }\"\n        :items=\"items\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with relative positioning, padding, colors, text ellipsis, border-radius, transitions and other tab item styles and interactive effects",
+          "descriptionZh": "Item 元素，包含相对定位、内边距、颜色、文本省略、圆角、过渡动画等标签项的样式和交互效果"
+        },
+        {
+          "key": "header",
+          "description": "Header element with tab navigation header layout, background, borders and other styles",
+          "descriptionZh": "头部元素，包含标签页头部导航的布局、背景、边框等样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element with indicator bar color, position, dimensions, transitions and other active state indication styles",
+          "descriptionZh": "指示器元素，包含指示条的颜色、位置、尺寸、过渡动画等活跃状态指示样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with tab content panel layout, padding and other content display styles",
+          "descriptionZh": "内容元素，包含标签页内容面板的布局、内边距等内容展示样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup menu element with dropdown absolute positioning, z-index, display control, max-height, scrolling and other styles",
+          "descriptionZh": "弹出菜单元素，包含下拉菜单的绝对定位、层级、显示控制、最大高度、滚动等样式"
         }
       ]
     },
@@ -22148,14 +23341,28 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tag by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tag 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { CheckCircleOutlined, CloseCircleOutlined } from '@antdv-next/icons'\n\nconst tagStyles = {\n  root: {\n    backgroundColor: '#e6f7ff',\n  },\n  icon: {\n    color: '#52c41a',\n  },\n  content: {\n    color: '#262626',\n  },\n}\n\nconst filledTagStyles = {\n  root: {\n    backgroundColor: '#F5EFFF',\n  },\n  icon: {\n    color: '#8F87F1',\n  },\n  content: {\n    color: '#8F87F1',\n  },\n}\n\nconst groupStyles = {\n  root: {\n    gap: '12px',\n    padding: '8px 12px',\n    backgroundColor: 'rgba(82, 196, 26, 0.08)',\n    borderRadius: '8px',\n  },\n  item: {\n    backgroundColor: 'rgba(82, 196, 26, 0.1)',\n    borderColor: 'rgba(82, 196, 26, 0.3)',\n    color: '#52c41a',\n  },\n}\n\nconst multipleGroupStyles = {\n  root: {\n    gap: '16px',\n    padding: '8px 12px',\n    backgroundColor: 'rgba(143, 135, 241, 0.08)',\n    borderRadius: '8px',\n  },\n  item: {\n    backgroundColor: 'rgba(143, 135, 241, 0.1)',\n    borderColor: 'rgba(143, 135, 241, 0.3)',\n    color: '#8F87F1',\n    fontWeight: 500,\n  },\n}\n\nconst options1 = ['React', 'Vue', 'Angular']\nconst options2 = ['meet-student', 'thinkasany']\n</script>\n\n<template>\n  <a-space size=\"large\" vertical>\n    <a-flex gap=\"middle\">\n      <a-tag :classes=\"{ root: 'custom-tag-root' }\" :styles=\"tagStyles\">\n        <template #icon>\n          <CheckCircleOutlined />\n        </template>\n        Object\n      </a-tag>\n      <a-tag\n        variant=\"filled\"\n        :classes=\"{ root: 'custom-tag-root' }\"\n        :styles=\"filledTagStyles\"\n      >\n        <template #icon>\n          <CloseCircleOutlined />\n        </template>\n        Function\n      </a-tag>\n    </a-flex>\n    <a-flex vertical gap=\"middle\">\n      <a-checkable-tag-group\n        :classes=\"{ root: 'custom-tag-root' }\"\n        :styles=\"groupStyles\"\n        :options=\"options1\"\n      />\n      <a-checkable-tag-group\n        :classes=\"{ root: 'custom-tag-root' }\"\n        :styles=\"multipleGroupStyles\"\n        :options=\"options2\"\n        multiple\n      />\n    </a-flex>\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with inline-block display, auto height, padding, font size, line height, nowrap, background color, border, border radius, opacity, transition animations, text alignment, relative positioning and other basic tag styles",
+          "descriptionZh": "根元素，包含行内块布局、自动高度、内边距、字体大小、行高、禁止换行、背景色、边框、圆角、透明度、过渡动画、文本对齐、相对定位等标签的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AntDesignOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.3.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tag\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-tag closable :classes=\"classes\">\n        <template #icon>\n          <AntDesignOutlined />\n        </template>\n        Ant Design\n      </a-tag>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element with font size, color, cursor style, transition animations and other icon display styles",
+          "descriptionZh": "图标元素，包含字体大小、颜色、光标样式、过渡动画等图标的显示样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with text content color, font styles and other content area styles",
+          "descriptionZh": "内容元素，包含文本内容的颜色、字体样式等内容区域的样式"
+        },
+        {
+          "key": "close",
+          "description": "Close element with close button layout, cursor styles, transition animations and other interaction styles",
+          "descriptionZh": "关闭元素，包含关闭按钮的布局、光标样式、过渡动画等交互样式"
         }
       ]
     },
@@ -22302,14 +23509,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of TimePicker by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 TimePicker 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TimePickerProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { useToken } = theme\nconst { token } = useToken()\n\nconst customClasses = {\n  root: 'custom-timepicker-root',\n}\n\nconst stylesObject: TimePickerProps['styles'] = {\n  root: {\n    borderColor: '#d9d9d9',\n  },\n}\n\nconst stylesFn: TimePickerProps['styles'] = (info) => {\n  if (info.props.size === 'large') {\n    return {\n      root: {\n        borderColor: '#722ed1',\n      },\n      suffix: {\n        color: '#722ed1',\n      },\n      popup: {\n        container: { border: '1px solid #722ed1', borderRadius: '8px' },\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-time-picker :classes=\"customClasses\" :styles=\"stylesObject\" placeholder=\"Object\" />\n    <a-time-picker :classes=\"customClasses\" :styles=\"stylesFn\" placeholder=\"Function\" size=\"large\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, padding, border-radius, transition animations and other basic styles for time picker container",
+          "descriptionZh": "根元素，包含相对定位、行内flex布局、内边距、边框圆角、过渡动画等时间选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { SmileOutlined } from '@antdv-next/icons'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'popup.root', desc: t('popup') },\n  { name: 'popup.container', desc: t('popup.container') },\n  { name: 'popup.content', desc: t('popup.content') },\n  { name: 'popup.item', desc: t('popup.item') },\n  { name: 'popup.footer', desc: t('popup.footer') },\n])\n\nconst type = ref<'Single' | 'Multiple'>('Single')\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    :component-name=\"type === 'Single' ? 'TimePicker' : 'TimePicker.RangePicker'\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" vertical :style=\"{ alignSelf: 'flex-start' }\" gap=\"middle\" align=\"center\">\n        <a-segmented\n          :options=\"['Single', 'Multiple']\"\n          :value=\"type\"\n          @change=\"(val: 'Single' | 'Multiple') => type = val\"\n        />\n        <a-time-picker\n          v-if=\"type === 'Single'\"\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-time-picker>\n        <a-time-range-picker\n          v-else\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-time-range-picker>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with flex layout and margin styles for prefix content layout",
+          "descriptionZh": "前缀元素，包含flex布局、右外边距等前缀内容的布局样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with relative positioning, width, color, font, line-height, transition animations and other core interactive styles for input field",
+          "descriptionZh": "输入框元素，包含相对定位、宽度、颜色、字体、行高、过渡动画等输入框的核心交互样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with flex layout, color, line-height, pointer events, transition animations and other styles for suffix content",
+          "descriptionZh": "后缀元素，包含flex布局、颜色、行高、指针事件、过渡动画等后缀内容的样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup element",
+          "descriptionZh": "弹出框元素"
+        },
+        {
+          "key": "popup.container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "popup.content",
+          "description": "Popup content element with width, border, cell and other content display styles for time list",
+          "descriptionZh": "弹出框内容元素，包含时间列表的宽度、边框、单元格等内容展示样式"
+        },
+        {
+          "key": "popup.item",
+          "description": "Popup item element with size, background, border-radius, hover state, selected state and other interactive styles for time cells",
+          "descriptionZh": "弹出框单项元素，包含时间单元格的尺寸、背景色、边框圆角、悬停态、选中态等交互样式"
+        },
+        {
+          "key": "popup.footer",
+          "description": "Popup footer element with layout styles for bottom operation area including confirm/cancel buttons",
+          "descriptionZh": "弹出框底部元素，包含确认取消按钮等底部操作区域的布局样式"
         }
       ]
     },
@@ -22538,14 +23784,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Timeline by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Timeline 的[语义化结构](#semantic-dom)样式。",
           "code": "<script lang=\"ts\" setup>\nconst classes = {\n  root: 'custom-timeline-root',\n}\n\nconst styles = {\n  itemIcon: {\n    borderColor: '#1890ff',\n  },\n}\n\nfunction stylesFn(info: any) {\n  if (info.props.orientation === 'vertical') {\n    return {\n      root: {\n        padding: '10px 6px',\n        border: '1px solid #A294F9',\n      },\n      itemIcon: {\n        borderColor: '#A294F9',\n      },\n    }\n  }\n  return {}\n}\n\nconst items = [\n  {\n    title: '2015-09-01',\n    content: 'Create a services site',\n  },\n  {\n    title: '2015-09-01 09:12:11',\n    content: 'Solve initial network problems',\n  },\n  {\n    content: 'Technical testing',\n  },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-timeline :items=\"items\" orientation=\"horizontal\" :styles=\"styles\" :classes=\"classes\" />\n    <a-timeline :items=\"items\" orientation=\"vertical\" :styles=\"stylesFn\" :classes=\"classes\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with timeline container list style reset, vertical layout, dot icon, outlined style, alternate layout and other basic container styles",
+          "descriptionZh": "根元素，设置时间轴容器的列表样式重置、垂直布局、点状图标、轮廓样式、交替布局等基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemWrapper', desc: t('itemWrapper') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n  { name: 'itemSection', desc: t('itemSection') },\n  { name: 'itemHeader', desc: t('itemHeader') },\n  { name: 'itemTitle', desc: t('itemTitle') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'itemRail', desc: t('itemRail') },\n])\n\nconst items = [\n  { title: '2015-09-01', content: 'Create a services' },\n  { title: '2015-09-01 09:12:11', content: 'Solve initial network problems' },\n  { content: 'Technical testing' },\n  { title: '2015-09-01 09:12:11', content: 'Network problems being solved' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Timeline\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-timeline :items=\"items\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with single timeline node relative positioning, margin, padding, font size, finish state, color theme, layout direction and other node basic styles",
+          "descriptionZh": "节点元素，设置单个时间节点的相对定位、外边距、内边距、字体大小、完成状态、颜色主题、布局方向等节点基础样式"
+        },
+        {
+          "key": "itemWrapper",
+          "description": "Item wrapper element with timeline node content wrapping container styles",
+          "descriptionZh": "节点包装元素，设置时间节点内容的包装容器样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Item icon element with node head icon absolute positioning, width/height size, background color, border, border radius, wave animation and other icon styles",
+          "descriptionZh": "节点图标元素，设置节点头部图标的绝对定位、宽高尺寸、背景色、边框、圆角、波纹动画等图标样式"
+        },
+        {
+          "key": "itemHeader",
+          "description": "Item header element with header area layout containing title and rail, alignment, text direction and other styles",
+          "descriptionZh": "节点头部元素，设置包含标题和连接线的头部区域布局、对齐方式、文本方向等样式"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Item title element with node title text font size, line height, color and other text styles",
+          "descriptionZh": "节点标题元素，设置节点标题文字的字体大小、行高、颜色等文本样式"
+        },
+        {
+          "key": "itemSection",
+          "description": "Item section element with section container containing header and content flex layout, wrap, gap and other layout styles",
+          "descriptionZh": "节点区域元素，设置包含头部和内容的区域容器的Flex布局、换行、间距等布局样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Item content element with node detail content relative positioning, top offset, left margin, text color, word break and other content styles",
+          "descriptionZh": "节点内容元素，设置节点详细内容的相对定位、顶部偏移、左侧外边距、文字颜色、词汇换行等内容样式"
+        },
+        {
+          "key": "itemRail",
+          "description": "Item rail element with timeline node connection track line absolute positioning, top offset, left offset, height, border color, width, style and other connection line styles",
+          "descriptionZh": "节点连接线元素，设置连接时间节点的轨道线条的绝对定位、顶部偏移、左侧偏移、高度、边框颜色、宽度、样式等连接线样式"
         }
       ]
     },
@@ -22914,14 +24199,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tooltip by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tooltip 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TooltipProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: TooltipProps['classes'] = {\n  container: 'demo-tooltip-container',\n}\n\nconst stylesObject: TooltipProps['styles'] = {\n  container: {\n    borderRadius: '12px',\n    boxShadow: 'inset 0 0 8px #ccc',\n  },\n}\n\nconst stylesFn: TooltipProps['styles'] = (info) => {\n  if (info?.props?.arrow === false) {\n    return {\n      container: {\n        backgroundColor: 'rgba(53, 71, 125, 0.8)',\n        padding: '12px',\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-tooltip title=\"Object text\" :classes=\"classes\" :styles=\"stylesObject\" :arrow=\"false\">\n      <a-button>Object Style</a-button>\n    </a-tooltip>\n    <a-tooltip title=\"Function text\" :classes=\"classes\" :styles=\"stylesFn\" :arrow=\"false\">\n      <a-button type=\"primary\">\n        Function Style\n      </a-button>\n    </a-tooltip>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element (including arrows, content elements) with absolute positioning, z-index, block display, max width, visibility, transform origin and arrow background color",
+          "descriptionZh": "根元素 (包含箭头、内容元素)，设置绝对定位、层级、块级显示、最大宽度、可见性、变换原点和箭头背景色"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'container', desc: t('container') },\n  { name: 'arrow', desc: t('arrow') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tooltip\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', marginTop: '60px' }\">\n        <a-tooltip\n          open\n          placement=\"top\"\n          title=\"tooltip prompt text\"\n          :auto-adjust-overflow=\"false\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "container",
+          "description": "Content element with min width and height, padding, color, text alignment, background color, border radius, shadow and border styles",
+          "descriptionZh": "内容元素，设置最小宽度高度、内边距、颜色、文本对齐、背景色、圆角、阴影和边框样式"
+        },
+        {
+          "key": "arrow",
+          "description": "Arrow element with width, height, position, color and border styles",
+          "descriptionZh": "箭头元素，设置宽高、位置、颜色和边框样式"
         }
       ]
     },
@@ -23223,14 +24517,68 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tour by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tour 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TourProps, TourStepItem } from 'antdv-next'\nimport { computed, h, shallowRef } from 'vue'\n\nconst ref1 = shallowRef()\nconst ref2 = shallowRef()\nconst ref3 = shallowRef()\nconst open = shallowRef(false)\nconst openFn = shallowRef(false)\n\nconst btnProps = {\n  nextButtonProps: {\n    style: {\n      border: '1px solid #CDC1FF',\n      color: '#CDC1FF',\n    },\n  },\n  prevButtonProps: {\n    style: {\n      backgroundColor: '#CDC1FF',\n      color: '#fff',\n    },\n  },\n}\n\nconst coverNode = h('img', {\n  alt: 'tour.png',\n  src: 'https://user-images.githubusercontent.com/5378891/197385811-55df8480-7ff4-44bd-9d43-a7dade598d70.png',\n})\n\nconst steps: TourStepItem[] = [\n  {\n    title: 'Upload File',\n    description: 'Put your files here.',\n    cover: coverNode,\n    target: ref1,\n    prevButtonProps: {},\n  },\n  {\n    title: 'Save',\n    description: 'Save your changes.',\n    target: ref2,\n  },\n  {\n    title: 'Other Actions',\n    description: 'Click to see other actions.',\n    target: ref3,\n  },\n]\n\nconst stepsWithButtonProps = computed(() => steps.map(step => ({ ...step, ...btnProps })))\n\nconst classes: TourProps['classes'] = {\n  root: 'custom-tour-root',\n  section: 'custom-tour-section',\n}\n\nconst stylesObject: TourProps['styles'] = {\n  mask: {\n    backgroundColor: 'rgba(0, 0, 0, 0.3)',\n  },\n  section: {\n    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',\n    border: '2px solid #4096ff',\n  },\n  cover: {\n    borderRadius: '12px 12px 0 0',\n  },\n}\n\nconst stylesFn: TourProps['styles'] = (info) => {\n  if (info.props.type === 'primary') {\n    return {\n      mask: {\n        backgroundColor: 'rgba(0, 0, 0, 0.3)',\n      },\n      section: {\n        backgroundColor: 'rgba(205, 193, 255, 0.8)',\n        boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',\n      },\n      cover: {\n        borderRadius: '12px 12px 0 0',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-flex gap=\"middle\">\n      <a-button type=\"primary\" @click=\"open = true\">\n        Begin Tour Object\n      </a-button>\n      <a-button type=\"primary\" @click=\"openFn = true\">\n        Begin Tour Function\n      </a-button>\n    </a-flex>\n    <a-divider />\n    <a-tour\n      v-model:open=\"open\"\n      :steps=\"steps\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    />\n    <a-tour\n      v-model:open=\"openFn\"\n      :steps=\"stepsWithButtonProps\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n      type=\"primary\"\n    />\n    <a-space>\n      <a-button ref=\"ref1\" type=\"primary\">\n        Upload\n      </a-button>\n      <a-button ref=\"ref2\">\n        Save\n      </a-button>\n      <a-button ref=\"ref3\" type=\"dashed\">\n        Other Actions\n      </a-button>\n    </a-space>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Tour root container with absolute positioning, z-index control, max width, visibility, arrow background color variable, theme styles and other container styles",
+          "descriptionZh": "引导根容器，设置绝对定位、层级控制、最大宽度、可见性、箭头背景色变量、主题样式等容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'mask', desc: t('mask'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'cover', desc: t('cover'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n  { name: 'indicators', desc: t('indicators'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.3.0' },\n])\n\nconst open = ref(true)\nconst createBtnRef = ref<HTMLButtonElement | null>(null)\n\nconst steps = [\n  {\n    title: 'Hello World!',\n    description: 'Hello World?!',\n    target: () => createBtnRef.value!,\n    mask: true,\n  },\n  {\n    title: 'Save',\n    description: 'Save your changes.',\n    target: () => createBtnRef.value!,\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tour\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div\n        :style=\"{\n          width: '100%',\n          height: '825px',\n          display: 'flex',\n          alignItems: 'center',\n          justifyContent: 'center',\n          position: 'relative',\n          overflow: 'hidden',\n        }\"\n      >\n        <a-button ref=\"createBtnRef\" @click=\"open = true\">\n          Show\n        </a-button>\n        <a-tour\n          v-model:open=\"open\"\n          :z-index=\"1\"\n          :default-current=\"0\"\n          :get-popup-container=\"false\"\n          :steps=\"steps\"\n          :classes=\"classes\"\n        >\n          <template #coverRender=\"{ index }\">\n            <template v-if=\"index === 0\">\n              <img src=\"https://user-images.githubusercontent.com/5378891/197385811-55df8480-7ff4-44bd-9d43-a7dade598d70.png\" alt=\"img\">\n            </template>\n          </template>\n        </a-tour>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "cover",
+          "description": "Card cover area with text center alignment, padding, image width and other image display styles",
+          "descriptionZh": "卡片封面区域，设置文本居中对齐、内边距、图片宽度等图片展示样式"
+        },
+        {
+          "key": "section",
+          "description": "Card main content area with text alignment, border radius, box shadow, relative positioning, background color, border, background clip and other card styles",
+          "descriptionZh": "卡片主要内容区域，设置文本对齐、边框圆角、盒阴影、相对定位、背景色、边框、背景裁剪等卡片样式"
+        },
+        {
+          "key": "footer",
+          "description": "Card bottom action area with padding, text right alignment, border radius, flex layout and other bottom container styles",
+          "descriptionZh": "卡片底部操作区域，设置内边距、文本右对齐、边框圆角、Flex布局等底部容器样式"
+        },
+        {
+          "key": "actions",
+          "description": "Action button group container with left auto margin, button spacing and other button group layout styles",
+          "descriptionZh": "操作按钮组容器，设置左侧自动外边距、按钮间距等按钮组布局样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Single indicator element with width/height size, inline-block display, border radius, background color, right margin, active state and other dot styles",
+          "descriptionZh": "单个指示器元素，设置宽高尺寸、行内块显示、圆角、背景色、右外边距、激活状态等圆点样式"
+        },
+        {
+          "key": "indicators",
+          "description": "Indicator group container with inline-block display and other indicator container styles",
+          "descriptionZh": "指示器组容器，设置行内块显示等指示器容器样式"
+        },
+        {
+          "key": "header",
+          "description": "Card header area with padding, width calculation, word break and other header container styles",
+          "descriptionZh": "卡片头部区域，设置内边距、宽度计算、词汇换行等头部容器样式"
+        },
+        {
+          "key": "title",
+          "description": "Guide title text with font weight and other title text styles",
+          "descriptionZh": "引导标题文字，设置字体粗细等标题文本样式"
+        },
+        {
+          "key": "description",
+          "description": "Guide description text with padding, word wrap and other description text styles",
+          "descriptionZh": "引导描述文字，设置内边距、词汇换行等描述文本样式"
+        },
+        {
+          "key": "mask",
+          "description": "Mask layer element with fixed positioning, full screen coverage, z-index, pointer events, transition animation and other mask styles",
+          "descriptionZh": "遮罩层元素，设置固定定位、全屏覆盖、层级、指针事件、过渡动画等遮罩样式"
+        },
+        {
+          "key": "close",
+          "description": "Close button element with absolute positioning, size, color, hover state and interaction feedback styles",
+          "descriptionZh": "关闭按钮元素，设置绝对定位、尺寸、颜色、悬浮态和交互反馈等关闭按钮样式"
         }
       ]
     },
@@ -23562,14 +24910,73 @@
           "description": "Custom the labels for select all checkboxes.",
           "descriptionZh": "自定义穿梭框全选按钮的文字。",
           "code": "<script setup lang=\"ts\">\nimport type { TransferEmits, TransferProps } from 'antdv-next'\nimport { ref } from 'vue'\n\ninterface RecordType {\n  key: string\n  title: string\n  description: string\n}\n\nconst mockData = Array.from({ length: 10 }).map<RecordType>((_, i) => ({\n  key: i.toString(),\n  title: `content${i + 1}`,\n  description: `description of content${i + 1}`,\n}))\n\nconst oriTargetKeys = mockData.filter(item => Number(item.key) % 3 > 1).map(item => item.key)\n\nconst selectAllLabels: TransferProps['selectAllLabels'] = [\n  'Select All',\n  ({ selectedCount, totalCount }) => `${selectedCount}/${totalCount}`,\n]\n\nconst targetKeys = ref(oriTargetKeys)\n\nconst handleChange: TransferEmits['change'] = (newTargetKeys) => {\n  targetKeys.value = newTargetKeys\n}\n</script>\n\n<template>\n  <a-transfer\n    v-model:target-keys=\"targetKeys\"\n    :data-source=\"mockData\"\n    :render=\"(item: RecordType) => item.title\"\n    :select-all-labels=\"selectAllLabels\"\n    @change=\"handleChange\"\n  />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, transfer container base styles and layout control",
+          "descriptionZh": "根元素，设置flex布局、穿梭框容器的基础样式和布局控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'section', desc: t('section') },\n  { name: 'header', desc: t('header') },\n  { name: 'title', desc: t('title') },\n  { name: 'body', desc: t('body') },\n  { name: 'list', desc: t('list') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'footer', desc: t('footer') },\n  { name: 'actions', desc: t('actions') },\n  { name: 'source', desc: t('source'), version: '1.3.0' },\n  { name: 'target', desc: t('target'), version: '1.3.0' },\n])\n\nconst mockData = Array.from({ length: 20 }).map((_, i) => ({\n  key: i,\n  title: `content ${i + 1}`,\n}))\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Transfer\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-transfer\n        show-search\n        :titles=\"['Source', 'Target']\"\n        :data-source=\"mockData\"\n        :selected-keys=\"[]\"\n        :target-keys=\"[3, 9]\"\n        :render=\"(item: any) => item.title\"\n        :styles=\"{\n          section: { height: '250px', width: '200px' },\n        }\"\n        :classes=\"classes\"\n      >\n        <template #footer>\n          <div :style=\"{ padding: '8px' }\">\n            Custom Footer\n          </div>\n        </template>\n      </a-transfer>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Section element with flex layout, width, height, min height, border, border radius and other single-side transfer container styles",
+          "descriptionZh": "区域元素，设置flex布局、宽度、高度、最小高度、边框、圆角等单侧穿梭框的容器样式"
+        },
+        {
+          "key": "header",
+          "description": "Header element with flex layout, alignment, height, padding, color, background color, bottom border, border radius and other header area styles",
+          "descriptionZh": "头部元素，设置flex布局、对齐方式、高度、内边距、颜色、背景色、下边框、圆角等头部区域的样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text ellipsis, flex ratio, text alignment, auto left margin and other title text layout and styles",
+          "descriptionZh": "标题元素，设置文本省略、flex占比、文本对齐、自动左边距等标题文字的布局和样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with list main area container styles and layout control",
+          "descriptionZh": "内容元素，设置列表主体区域的容器样式和布局控制"
+        },
+        {
+          "key": "list",
+          "description": "List element with list content styles, layout and scroll control",
+          "descriptionZh": "列表元素，设置列表内容的样式、布局和滚动控制"
+        },
+        {
+          "key": "item",
+          "description": "List item element with relative positioning, padding, border, hover state, selected state, disabled state and other list item interaction styles",
+          "descriptionZh": "列表项元素，设置相对定位、内边距、边框、悬停态、选中态、禁用态等列表项的交互样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "List item icon element with checkbox and other icon styles and interaction states",
+          "descriptionZh": "列表项图标元素，设置复选框等图标的样式和交互状态"
+        },
+        {
+          "key": "itemContent",
+          "description": "List item content element with text ellipsis, padding and other list item text content display styles",
+          "descriptionZh": "列表项内容元素，设置文本省略、内边距等列表项文本内容的展示样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with bottom operation area styles and layout",
+          "descriptionZh": "页脚元素，设置底部操作区域的样式和布局"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element with transfer button group styles, layout and interaction states",
+          "descriptionZh": "操作元素，设置穿梭按钮组的样式、布局和交互状态"
+        },
+        {
+          "key": "source",
+          "description": "Source-side (left) overrides nested under the same shared semantic keys (section/header/title/body/list/item/itemIcon/itemContent/footer); only the source list picks them up",
+          "descriptionZh": "源（左侧）区域专属语义，与共享 section/header/title/body/list/item/itemIcon/itemContent/footer 同级，仅覆盖源侧"
+        },
+        {
+          "key": "target",
+          "description": "Target-side (right) overrides nested under the same shared semantic keys (section/header/title/body/list/item/itemIcon/itemContent/footer); only the target list picks them up",
+          "descriptionZh": "目标（右侧）区域专属语义，与共享 section/header/title/body/list/item/itemIcon/itemContent/footer 同级，仅覆盖目标侧"
         }
       ]
     },
@@ -24264,14 +25671,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tree by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tree 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TreeDataNode, TreeProps } from 'antdv-next'\nimport { ref } from 'vue'\n\nconst treeData: TreeDataNode[] = [\n  {\n    title: 'parent 1',\n    key: '0-0',\n    children: [\n      {\n        title: 'parent 1-0',\n        key: '0-0-0',\n        children: [\n          {\n            title: 'leaf',\n            key: '0-0-0-0',\n          },\n          {\n            title: 'leaf',\n            key: '0-0-0-1',\n          },\n        ],\n      },\n      {\n        title: 'parent 1-1',\n        key: '0-0-1',\n        children: [\n          {\n            title: 'leaf',\n            key: '0-0-1-0',\n          },\n        ],\n      },\n    ],\n  },\n]\n\nconst styles: TreeProps['styles'] = {\n  root: { border: '2px solid #d9d9d9' },\n  item: { margin: '2px 0' },\n}\n\nconst stylesFn: TreeProps['styles'] = (info) => {\n  if (!info.props.checkable) {\n    return {\n      root: {\n        border: `2px solid #E5D9F2`,\n        borderRadius: '4px',\n      },\n    }\n  }\n  return {}\n}\n\nconst expandedKeys = ref(['0-0-0', '0-0-1'])\nconst selectedKeys = ref(['0-0-1'])\nconst checkedKeys = ref(['0-0-0', '0-0-1'])\nconst classes = {\n  root: 'root',\n  item: 'item',\n  itemTitle: 'itemTitle',\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-tree\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      auto-expand-parent\n      checkable\n      :styles=\"styles\"\n    />\n    <a-tree\n      v-model:expanded-keys=\"expandedKeys\"\n      v-model:selected-keys=\"selectedKeys\"\n      v-model:checked-keys=\"checkedKeys\"\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      auto-expand-parent\n      :checkable=\"false\"\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with tree control base styles, layout and container control",
+          "descriptionZh": "根元素，设置树形控件的基础样式、布局和容器控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { DownOutlined, FrownFilled, FrownOutlined, MehOutlined, SmileOutlined } from '@antdv-next/icons'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'itemIcon', desc: t('itemIcon'), version: '1.0.0' },\n  { name: 'itemTitle', desc: t('itemTitle'), version: '1.0.0' },\n  { name: 'itemSwitcher', desc: t('itemSwitcher'), version: '1.3.0' },\n])\n\nconst treeData = [\n  {\n    title: 'parent 1',\n    key: '0-0',\n    icon: h(SmileOutlined),\n    children: [\n      { title: 'leaf', key: '0-0-0', icon: h(MehOutlined) },\n      { title: 'leaf', key: '0-0-1', icon: ({ selected }: { selected: boolean }) => selected ? h(FrownFilled) : h(FrownOutlined) },\n    ],\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tree\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-tree\n        show-icon\n        default-expand-all\n        :default-selected-keys=\"['0-0-0']\"\n        :tree-data=\"treeData\"\n        :classes=\"classes\"\n      >\n        <template #switcherIcon>\n          <DownOutlined />\n        </template>\n      </a-tree>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with tree node base styles, drag state, role attributes, indentation, switcher, content wrapper and other node structure",
+          "descriptionZh": "条目元素，设置树节点的基础样式、拖拽状态、角色属性、缩进、切换器、内容包装器等节点结构"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Title element with tree node title text display styles and text content",
+          "descriptionZh": "标题元素，设置树节点标题文字的显示样式和文本内容"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Icon element with tree node icon styles, size and state display",
+          "descriptionZh": "图标元素，设置树节点图标的样式、尺寸和状态显示"
+        },
+        {
+          "key": "itemSwitcher",
+          "description": "Switcher element with tree node expand/collapse button styles and background",
+          "descriptionZh": "切换器元素，设置树节点展开/收起按钮的样式和背景"
         }
       ]
     },
@@ -24854,14 +26280,73 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of TreeSelect by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 TreeSelect 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TreeSelectProps } from 'antdv-next'\n\nconst classes: TreeSelectProps['classes'] = {\n  root: 'custom-tree-select',\n}\n\nconst stylesObject: TreeSelectProps['styles'] = {\n  input: {\n    fontSize: 16,\n  },\n  suffix: {\n    color: '#1890ff',\n  },\n  popup: {\n    root: {\n      border: '1px solid #1890ff',\n    },\n  },\n}\n\nconst stylesFn: TreeSelectProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      suffix: {\n        color: '#722ed1',\n      },\n      popup: {\n        item: {\n          color: '#722ed1',\n        },\n      },\n    }\n  }\n  return {}\n}\n\nconst treeData: TreeSelectProps['treeData'] = [\n  {\n    value: 'parent 1',\n    title: 'parent 1',\n    children: [\n      {\n        value: 'parent 1-0',\n        title: 'parent 1-0',\n        children: [\n          {\n            value: 'leaf1',\n            title: 'leaf1',\n          },\n          {\n            value: 'leaf2',\n            title: 'leaf2',\n          },\n        ],\n      },\n      {\n        value: 'parent 1-1',\n        title: 'parent 1-1',\n        children: [\n          {\n            value: 'leaf3',\n            title: 'leaf3',\n          },\n        ],\n      },\n    ],\n  },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-tree-select\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      placeholder=\"Object\"\n    />\n    <a-tree-select\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      placeholder=\"Function\"\n      size=\"middle\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with tree selector base styles, border, border radius container styles",
+          "descriptionZh": "根元素，设置树选择器的基础样式、边框、圆角容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst mode = ref<'single' | 'multiple'>('single')\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => {\n  const base = [\n    { name: 'root', desc: t('root') },\n    { name: 'prefix', desc: t('prefix') },\n    { name: 'placeholder', desc: t('placeholder') },\n  ]\n\n  if (mode.value === 'multiple') {\n    base.push(\n      ...[\n        { name: 'content', desc: t('content') },\n        { name: 'item', desc: t('item') },\n        { name: 'itemContent', desc: t('itemContent') },\n        { name: 'itemRemove', desc: t('itemRemove') },\n      ],\n    )\n  }\n\n  base.push(\n    ...[\n      { name: 'input', desc: t('input') },\n      { name: 'suffix', desc: t('suffix') },\n      { name: 'popup.root', desc: t('popup.root') },\n      { name: 'popup.item', desc: t('popup.item') },\n      { name: 'popup.itemTitle', desc: t('popup.itemTitle') },\n      { name: 'popup.itemSwitcher', desc: t('popup.itemSwitcher'), version: '1.3.0' },\n    ],\n  )\n\n  return base\n})\n\nconst treeValue = ref<string | string[] | undefined>(undefined)\nfunction handleResetValue(newMode: string | number) {\n  if (newMode === 'multiple') {\n    treeValue.value = ['aojunhao123']\n  }\n  else {\n    treeValue.value = undefined\n  }\n}\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst treeData = [\n  {\n    value: 'contributors',\n    title: 'contributors',\n    children: [\n      { value: 'aojunhao123', title: 'aojunhao123' },\n      { value: 'thinkasany', title: 'thinkasany' },\n      { value: 'meet-student', title: 'meet-student' },\n    ],\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"TreeSelect\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <div :style=\"{ display: 'flex', justifyContent: 'center', marginBottom: '12px' }\">\n          <a-segmented v-model:value=\"mode\" :options=\"['single', 'multiple']\" @change=\"handleResetValue\" />\n        </div>\n\n        <a-tree-select\n          v-model:value=\"treeValue\"\n          prefix=\"prefix\"\n          :style=\"{ width: '300px' }\"\n          :tree-data=\"treeData\"\n          tree-default-expand-all\n          :multiple=\"mode === 'multiple'\"\n          show-search\n          max-tag-count=\"responsive\"\n          placeholder=\"Please select\"\n          allow-clear\n          open\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with prefix content layout and styles",
+          "descriptionZh": "前缀元素，设置前缀内容的布局和样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "input",
+          "description": "Input element with text input, search, selected value display and other input core interaction styles",
+          "descriptionZh": "输入框元素，设置文本输入、搜索、选择值显示等输入框的核心交互样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with suffix content, clear button, dropdown arrow and other suffix area styles",
+          "descriptionZh": "后缀元素，设置后缀内容、清除按钮、下拉箭头等后缀区域的样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with dropdown tree selection panel positioning, z-index, background, border, shadow and other popup layer styles",
+          "descriptionZh": "弹出菜单元素，设置下拉树形选择面板的定位、层级、背景、边框、阴影等弹层样式"
+        },
+        {
+          "key": "popup.item",
+          "description": "Popup item element with tree node option styles, hover state, selected state and other interaction states",
+          "descriptionZh": "弹出菜单条目元素，设置树节点选项的样式、悬停态、选中态等交互状态"
+        },
+        {
+          "key": "popup.itemTitle",
+          "description": "Popup title element with tree node title text display styles",
+          "descriptionZh": "弹出菜单标题元素，设置树节点标题文字的显示样式"
+        },
+        {
+          "key": "popup.itemSwitcher",
+          "description": "Popup switcher element with tree node expand/collapse button styles and background",
+          "descriptionZh": "弹出菜单切换器元素，设置树节点展开/收起按钮的样式和背景"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "item",
+          "description": "Multiple selection item element with border, background, padding, and margin styles",
+          "descriptionZh": "多选项元素，包含边框、背景、内边距、外边距样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Multiple selection item content area with text ellipsis styles",
+          "descriptionZh": "多选项内容区域，包含文字的省略样式"
+        },
+        {
+          "key": "itemRemove",
+          "description": "Multiple selection item remove button with font-related styles",
+          "descriptionZh": "多选项移除按钮，包含字体相关样式"
         }
       ]
     },
@@ -25373,14 +26858,28 @@
           "description": "Add suffix ellipsis support.",
           "descriptionZh": "添加后缀的省略。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst rows = ref(1)\n\nconst article = `To be, or not to be, that is the question: Whether it is nobler in the mind to suffer. The slings and arrows of outrageous fortune Or to take arms against a sea of troubles, And by opposing end them? To die: to sleep; No more; and by a sleep to say we end The heart-ache and the thousand natural shocks That flesh is heir to, 'tis a consummation Devoutly to be wish'd. To die, to sleep To sleep- perchance to dream: ay, there's the rub! For in that sleep of death what dreams may come When we have shuffled off this mortal coil, Must give us pause. There 's the respect That makes calamity of so long life`\n\nfunction onEllipsis(ellipsis: boolean) {\n  console.log('Ellipsis changed:', ellipsis)\n}\n</script>\n\n<template>\n  <div>\n    <a-slider v-model:value=\"rows\" :min=\"1\" :max=\"10\" />\n    <a-typography-paragraph\n      :ellipsis=\"{\n        rows,\n        expandable: true,\n        suffix: '--William Shakespeare',\n        onEllipsis,\n      }\"\n      :title=\"`${article}--William Shakespeare`\"\n    >\n      {{ article }}\n    </a-typography-paragraph>\n  </div>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with base typography styles, layout, and positioning",
+          "descriptionZh": "根元素，包含排版基础样式、布局和定位"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst editing = ref(false)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.3.0' },\n  { name: 'actions', desc: t('actions'), version: '1.3.0' },\n  { name: 'action', desc: t('action'), version: '1.3.0' },\n  { name: 'textarea', desc: t('textarea'), version: '1.3.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Typography\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex\n        vertical\n        gap=\"middle\"\n        align=\"start\"\n        :style=\"{ width: '100%', alignSelf: 'flex-start' }\"\n      >\n        <a-switch\n          v-model:checked=\"editing\"\n          checked-children=\"Editing\"\n          un-checked-children=\"Editing\"\n        />\n        <a-typography-paragraph\n          copyable\n          :editable=\"{ editing }\"\n          :ellipsis=\"{ rows: 2, expandable: true }\"\n          :style=\"{ width: '100%' }\"\n          :classes=\"classes\"\n        >\n          Ant Design is a design language for background applications, refined by Ant UED Team.\n          It aims to uniform the user interface specs for internal background projects, lower the\n          unnecessary cost of design differences and implementation and liberate the resources of\n          design and front-end development.\n        </a-typography-paragraph>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "actions",
+          "description": "Actions element with layout and spacing styles for copy, edit, expand/collapse buttons",
+          "descriptionZh": "操作区域元素，包含复制、编辑、展开/收起等操作按钮的布局和间距样式"
+        },
+        {
+          "key": "action",
+          "description": "Individual action button element including copy, edit, expand, collapse button styles like padding, border radius, colors, etc.",
+          "descriptionZh": "单个操作按钮元素，包括复制、编辑、展开、收起按钮的样式，如内边距、圆角、颜色等"
+        },
+        {
+          "key": "textarea",
+          "description": "TextArea element in editable mode, used to customize className and inline styles for the edit input",
+          "descriptionZh": "可编辑模式下的 TextArea 元素样式，用于自定义编辑输入框的类名和内联样式"
         }
       ]
     },
@@ -25838,14 +27337,23 @@
           "description": "Component Token Debug.",
           "descriptionZh": "Component Token Debug.",
           "code": "<script setup lang=\"ts\">\nimport type { UploadEmits, UploadFile } from 'antdv-next'\nimport { UploadOutlined } from '@antdv-next/icons'\n\nconst defaultFileList: UploadFile[] = [\n  {\n    uid: '1',\n    name: 'xxx.png',\n    status: 'uploading',\n    url: 'http://www.baidu.com/xxx.png',\n    percent: 33,\n  },\n  {\n    uid: '2',\n    name: 'yyy.png',\n    status: 'done',\n    url: 'http://www.baidu.com/yyy.png',\n  },\n  {\n    uid: '3',\n    name: 'zzz.png',\n    status: 'error',\n    response: 'Server Error 500',\n    url: 'http://www.baidu.com/zzz.png',\n  },\n]\n\nconst handleChange: UploadEmits['change'] = ({ file, fileList }) => {\n  if (file.status !== 'uploading') {\n    console.log(file, fileList)\n  }\n}\n</script>\n\n<template>\n  <a-config-provider\n    :theme=\"{\n      components: {\n        Upload: {\n          actionsColor: 'yellow',\n        },\n      },\n    }\"\n  >\n    <a-upload\n      action=\"https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload\"\n      :default-file-list=\"defaultFileList\"\n      @change=\"handleChange\"\n    >\n      <a-button>\n        <template #icon>\n          <UploadOutlined />\n        </template>\n        Upload\n      </a-button>\n    </a-upload>\n  </a-config-provider>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root container element with layout styles, disabled text color, user-select control, cursor styles and other basic styles",
+          "descriptionZh": "根元素容器，包含布局样式、禁用状态文字颜色、用户选择控制、鼠标样式等基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { UploadOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'list', desc: t('list'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n])\n\nconst defaultFileList = [\n  { uid: '1', name: 'xxx.png', status: 'uploading', url: 'http://www.baidu.com/xxx.png', percent: 33 },\n  { uid: '2', name: 'yyy.png', status: 'done', url: 'http://www.baidu.com/yyy.png' },\n  { uid: '3', name: 'zzz.png', status: 'error', response: 'Server Error 500', url: 'http://www.baidu.com/zzz.png' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Upload\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-upload\n        action=\"https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload\"\n        :default-file-list=\"defaultFileList\"\n        :classes=\"classes\"\n      >\n        <a-button>\n          <template #icon>\n            <UploadOutlined />\n          </template>\n          Upload\n        </a-button>\n      </a-upload>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "list",
+          "description": "File list container with layout arrangement, transition animations, spacing control and other styles",
+          "descriptionZh": "文件列表容器，包含布局排列、过渡动画、间距控制等样式"
+        },
+        {
+          "key": "item",
+          "description": "File item element with padding, background color, border styles, hover effects, status colors, transition animations and other styles",
+          "descriptionZh": "文件项元素，包含内边距、背景色、边框样式、悬停效果、状态颜色、过渡动画等样式"
         }
       ]
     },
@@ -25992,7 +27500,8 @@
           "descriptionZh": "在 Modal 与 Drawer 中使用。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst showModal = shallowRef(false)\nconst showDrawer = shallowRef(false)\nconst showDrawer2 = shallowRef(false)\n\nconst placeholderStyle = {\n  height: '300px',\n  display: 'flex',\n  justifyContent: 'center',\n  alignItems: 'center',\n  backgroundColor: 'rgba(150, 150, 150, 0.2)',\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-button type=\"primary\" @click=\"showModal = true\">\n      Show in Modal\n    </a-button>\n    <a-button type=\"primary\" @click=\"showDrawer = true\">\n      Show in Drawer\n    </a-button>\n    <a-button type=\"primary\" @click=\"showDrawer2 = true\">\n      Not Show in Drawer\n    </a-button>\n  </a-flex>\n  <a-watermark content=\"Antdv Next\">\n    <a-modal\n      v-model:open=\"showModal\"\n      destroy-on-hidden\n      title=\"Modal\"\n      @ok=\"showModal = false\"\n      @cancel=\"showModal = false\"\n    >\n      <div :style=\"placeholderStyle\">\n        A mock height\n      </div>\n    </a-modal>\n    <a-drawer\n      v-model:open=\"showDrawer\"\n      destroy-on-hidden\n      title=\"Drawer\"\n      @close=\"showDrawer = false\"\n    >\n      <div :style=\"placeholderStyle\">\n        A mock height\n      </div>\n    </a-drawer>\n  </a-watermark>\n  <a-watermark content=\"Antdv Next\" :inherit=\"false\">\n    <a-drawer\n      v-model:open=\"showDrawer2\"\n      destroy-on-hidden\n      title=\"Drawer\"\n      @close=\"showDrawer2 = false\"\n    >\n      <div :style=\"placeholderStyle\">\n        A mock height\n      </div>\n    </a-drawer>\n  </a-watermark>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     }
   ],
   "changelog": [

--- a/data/v1.4.6.json
+++ b/data/v1.4.6.json
@@ -1833,7 +1833,8 @@
           "descriptionZh": "用 `target` 设置 `Affix` 需要监听其滚动事件的元素，默认为 `window`。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst container = shallowRef()\n</script>\n\n<template>\n  <div ref=\"container\" style=\"width: 100%;height: 100px;overflow: auto;box-shadow: 0 0 0 1px #1677ff;scrollbar-width: thin;scrollbar-gutter: stable\">\n    <div style=\"width: 100%;height: 1000px\">\n      <a-affix :target=\"() => container\">\n        <a-button type=\"primary\">\n          Fixed at the top of container\n        </a-button>\n      </a-affix>\n    </div>\n  </div>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Alert",
@@ -2130,14 +2131,43 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Alert by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Alert 的 [语义化结构](#semantic-dom) 样式。",
           "code": "<script setup lang=\"ts\">\nimport type { AlertProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: AlertProps['classes'] = {\n  root: 'demo-alert-root',\n}\n\nconst stylesObject: AlertProps['styles'] = {\n  icon: {\n    fontSize: '18px',\n  },\n  section: {\n    fontWeight: 500,\n  },\n}\n\nconst stylesFn: AlertProps['styles'] = (info) => {\n  if (info?.props?.type === 'success') {\n    return {\n      root: {\n        backgroundColor: 'rgba(82, 196, 26, 0.1)',\n        borderColor: '#b7eb8f',\n      },\n      icon: {\n        color: '#52c41a',\n      },\n    }\n  }\n  if (info?.props?.type === 'warning') {\n    return {\n      root: {\n        backgroundColor: 'rgba(250, 173, 20, 0.1)',\n        borderColor: '#ffe58f',\n      },\n      icon: {\n        color: '#faad14',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"small\">\n    <a-alert\n      title=\"Object styles\"\n      type=\"info\"\n      show-icon\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n    >\n      <template #action>\n        <a-button size=\"small\">\n          Action\n        </a-button>\n      </template>\n    </a-alert>\n    <a-alert\n      title=\"Function styles\"\n      type=\"success\"\n      show-icon\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with border, background, padding, border-radius, and positioning styles for the alert container",
+          "descriptionZh": "根元素，包含边框、背景色、内边距、圆角、位置布局等警告提示框的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Alert\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-alert\n        closable\n        title=\"Info Text\"\n        show-icon\n        description=\"Info Description Info Description Info Description Info Description\"\n        type=\"info\"\n        :classes=\"classes\"\n      >\n        <template #action>\n          <a-flex vertical gap=\"small\" :style=\"{ minWidth: '80px' }\">\n            <a-button size=\"small\" type=\"primary\" block>\n              Accept\n            </a-button>\n            <a-button size=\"small\" danger ghost block>\n              Decline\n            </a-button>\n          </a-flex>\n        </template>\n      </a-alert>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Content element with flex layout controlling content area typography and minimum width",
+          "descriptionZh": "内容元素，采用 flex 布局控制内容区域的排版和最小宽度"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with color, line-height, and margin styles, supporting different status icon types",
+          "descriptionZh": "图标元素，包含图标的颜色、行高、外边距等样式，支持不同类型的状态图标"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text color and font styling for the alert title",
+          "descriptionZh": "标题元素，包含标题文字的颜色、字体等样式"
+        },
+        {
+          "key": "description",
+          "description": "Description element with font-size and line-height styles for additional content",
+          "descriptionZh": "描述元素，包含描述文字的字体大小、行高等排版样式"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element with layout and spacing styles for action buttons",
+          "descriptionZh": "操作组元素，包含操作按钮的布局和间距样式"
+        },
+        {
+          "key": "close",
+          "description": "Close button element with basic button styling",
+          "descriptionZh": "关闭按钮元素，包含按钮的基础样式"
         }
       ]
     },
@@ -2375,14 +2405,28 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Anchor by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "您可以通过 `classes` 和 `styles` 传入对象/函数可以自定义 Anchor 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { AnchorProps } from 'antdv-next'\n\nconst classesObject: AnchorProps['classes'] = {\n  root: 'demo-anchor-root',\n  item: 'demo-anchor-item',\n  itemTitle: 'demo-anchor-title',\n  indicator: 'demo-anchor-indicator',\n}\n\nconst stylesFn: AnchorProps['styles'] = (info) => {\n  if (info.props.direction === 'vertical') {\n    return {\n      root: {\n        backgroundColor: 'rgba(255,251,230,0.5)',\n        height: '100vh',\n      },\n    }\n  }\n  return {}\n}\n\nconst items: NonNullable<AnchorProps['items']> = [\n  {\n    key: 'part-1',\n    href: '#part-1',\n    title: 'Part 1',\n  },\n  {\n    key: 'part-2',\n    href: '#part-2',\n    title: 'Part 2',\n  },\n  {\n    key: 'part-3',\n    href: '#part-3',\n    title: 'Part 3',\n  },\n]\n</script>\n\n<template>\n  <a-row>\n    <a-col :span=\"16\">\n      <div id=\"part-1\" style=\"height: 100vh; background: rgba(255, 0, 0, 0.08)\" />\n      <div id=\"part-2\" style=\"height: 100vh; background: rgba(0, 255, 0, 0.08)\" />\n      <div id=\"part-3\" style=\"height: 100vh; background: rgba(0, 0, 255, 0.08)\" />\n    </a-col>\n    <a-col :span=\"8\">\n      <a-anchor replace :items=\"items\" :styles=\"stylesFn\" :classes=\"classesObject\" />\n    </a-col>\n  </a-row>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with layout positioning, padding, margin, background color and other basic styles",
+          "descriptionZh": "根元素，包含布局定位、内边距、边距、背景色等基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'itemTitle', desc: t('itemTitle'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n])\n\nconst items = [\n  {\n    key: 'api',\n    href: '#api',\n    title: 'API',\n    children: [\n      { key: '4', href: '#anchor-props', title: 'Anchor Props' },\n      { key: '5', href: '#link-props', title: 'Link Props' },\n    ],\n  },\n  { key: '1', href: '#anchor-demo-basic', title: 'Basic demo' },\n  { key: '2', href: '#anchor-demo-static', title: 'Static demo' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Anchor\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-anchor :affix=\"false\" :items=\"items\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Link item element with padding, text color, hover states, transition animations and other styles",
+          "descriptionZh": "链接项元素，包含内边距、文字颜色、悬停状态、过渡动画等样式"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Title text element with font styles, color changes, text decoration, transition effects and other styles",
+          "descriptionZh": "标题文字元素，包含字体样式、颜色变化、文本装饰、过渡效果等样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element with width, height, background color, position changes, transition animations and other styles",
+          "descriptionZh": "指示器元素，包含宽度、高度、背景色、位置变化、过渡动画等样式"
         }
       ]
     },
@@ -2445,7 +2489,8 @@
           "descriptionZh": "对 `message`、`notification` 进行配置。。",
           "code": "<script setup lang=\"ts\">\nimport MyPage2 from './myPage2.vue'\n</script>\n\n<template>\n  <a-app :message=\"{ maxCount: 1 }\" :notification=\"{ placement: 'bottomLeft' }\">\n    <MyPage2 />\n  </a-app>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "AutoComplete",
@@ -2786,14 +2831,53 @@
           "description": "Disabled text colour inside a Form, debug. Checks that the input text uses the disabled\ncolour both when the Form is disabled and when the component itself is.",
           "descriptionZh": "禁用文字颜色在 Form 中 Debug。校验 `Form disabled` 与组件自身 `disabled` 两种来源下，\n输入框文字都使用禁用色。",
           "code": "<script setup lang=\"ts\">\nconst options = [{ value: 'Disabled Value' }]\n</script>\n\n<template>\n  <a-flex vertical :gap=\"12\" :style=\"{ width: '240px' }\">\n    <a-form disabled>\n      <a-form-item label=\"Form disabled\" :style=\"{ marginBottom: 0 }\">\n        <a-auto-complete value=\"Disabled Value\" :options=\"options\" />\n      </a-form-item>\n    </a-form>\n    <a-auto-complete disabled value=\"Disabled Value\" :options=\"options\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, cursor styles, transitions, border and other basic selector container styles",
+          "descriptionZh": "根元素，包含相对定位、行内 flex 布局、光标样式、过渡动画、边框等选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'placeholder', desc: t('placeholder') },\n  { name: 'content', desc: t('content') },\n  { name: 'clear', desc: t('clear') },\n  { name: 'popup.root', desc: t('popup.root') },\n  { name: 'popup.list', desc: t('popup.list') },\n  { name: 'popup.listItem', desc: t('popup.listItem') },\n])\n\nconst options = ref([\n  { value: 'aojunhao123', label: 'aojunhao123' },\n  { value: 'thinkasany', label: 'thinkasany' },\n  { value: 'meet-student', label: 'meet-student' },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"AutoComplete\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <a-auto-complete\n          prefix=\"prefix\"\n          :style=\"{ width: '200px' }\"\n          :options=\"options\"\n          placeholder=\"input here\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with layout and styling for prefix content",
+          "descriptionZh": "前缀元素，包含前缀内容的布局和样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with search input styling, cursor control, font inheritance and other search-related styles. Remove border styles",
+          "descriptionZh": "输入框元素，包含搜索输入框的样式、光标控制、字体继承等搜索相关样式，去除了边框样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "clear",
+          "description": "Clear button element with layout, styling and interactive effects for clear button",
+          "descriptionZh": "清除按钮元素，包含清除按钮的布局、样式和交互效果"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with popup layer positioning, z-index, background, border, box-shadow and other popup container styles",
+          "descriptionZh": "弹出菜单元素，包含弹出层的定位、层级、背景、边框、阴影等弹出容器样式"
+        },
+        {
+          "key": "popup.list",
+          "description": "Popup list element with option list layout, scrolling, max-height and other list container styles",
+          "descriptionZh": "弹出菜单列表元素，包含选项列表的布局、滚动、最大高度等列表容器样式"
+        },
+        {
+          "key": "popup.listItem",
+          "description": "Popup item element with option item padding, hover effects, selected states, disabled states and other option interactive styles",
+          "descriptionZh": "弹出菜单条目元素，包含选项项的内边距、悬浮效果、选中状态、禁用状态等选项交互样式"
         }
       ]
     },
@@ -3082,7 +3166,8 @@
           "descriptionZh": "头像大小可以根据屏幕大小自动调整。",
           "code": "<script setup lang=\"ts\">\nimport { AntDesignOutlined } from '@antdv-next/icons'\n</script>\n\n<template>\n  <a-avatar\n    :size=\"{ xs: 24, sm: 32, md: 40, lg: 64, xl: 80, xxl: 100 }\"\n  >\n    <template #icon>\n      <AntDesignOutlined />\n    </template>\n  </a-avatar>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Badge",
@@ -3359,22 +3444,33 @@
           "description": "The badge will display `title` when hovered over, instead of `count`.",
           "descriptionZh": "设置鼠标放在状态点上时显示的文字。",
           "code": "<script setup lang=\"ts\">\n</script>\n\n<template>\n  <a-space size=\"large\">\n    <a-badge :count=\"5\" title=\"Custom hover text\">\n      <a-avatar shape=\"square\" size=\"large\" />\n    </a-badge>\n    <a-badge :count=\"-5\" title=\"Negative\">\n      <a-avatar shape=\"square\" size=\"large\" />\n    </a-badge>\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-block display, and fit-content width for basic layout",
+          "descriptionZh": "根元素，包含相对定位、行内块布局、适应内容宽度等基础布局样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Badge\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-badge :count=\"5\" :classes=\"classes\">\n        <a-avatar shape=\"square\" size=\"large\" />\n      </a-badge>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "indicator",
+          "description": "Indicator element with positioning, z-index, dimensions, colors, fonts, text alignment, background, border-radius, box-shadow, and transition animations for complete badge styling",
+          "descriptionZh": "指示器元素，包含定位、层级、尺寸、颜色、字体、文本对齐、背景、圆角、阴影、过渡动画等完整的徽标样式"
         },
         {
-          "name": "_semantic_ribbon",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('ribbonRoot'), version: '1.0.0' },\n  { name: 'indicator', desc: t('ribbonIndicator'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <div style=\"display: flex; flex-direction: column; gap: 24px;\">\n    <SemanticPreview\n      component-name=\"Badge\"\n      :semantics=\"semantics\"\n    >\n      <template #default=\"{ classes }\">\n        <div style=\"width: 100%;\">\n          <a-badge-ribbon text=\"Hippies\" color=\"magenta\" :classes=\"classes\">\n            <a-card title=\"Pushes open the window\" size=\"small\">\n              and raises the spyglass.\n            </a-card>\n          </a-badge-ribbon>\n        </div>\n      </template>\n    </SemanticPreview>\n  </div>\n</template>"
+          "key": "ribbonRoot",
+          "description": "Root element, set relative positioning and wrapper container styles",
+          "descriptionZh": "根元素，设置相对定位和包装容器样式"
+        },
+        {
+          "key": "ribbonIndicator",
+          "description": "Indicator element, set absolute positioning, padding, background color, border radius and ribbon styles",
+          "descriptionZh": "指示器元素，设置绝对定位、内边距、背景色、圆角和缎带样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element, set text color and ribbon content display styles",
+          "descriptionZh": "文本元素，设置文本颜色和缎带内容显示样式"
         }
       ]
     },
@@ -3466,7 +3562,8 @@
           "descriptionZh": "通过 `ConfigProvider` 的 theme.components 可以覆盖 BorderBeam 的 `lineWidth` token，从而调整流光的线宽。",
           "code": "<script setup lang=\"ts\">\nconst customTheme = {\n  components: {\n    BorderBeam: { lineWidth: 3 },\n  },\n}\n</script>\n\n<template>\n  <a-flex :gap=\"24\" wrap>\n    <div :style=\"{ width: '320px' }\">\n      <a-border-beam>\n        <a-card title=\"Default line width\">\n          <a-typography-text type=\"secondary\">\n            Uses the default global lineWidth token from the current theme.\n          </a-typography-text>\n        </a-card>\n      </a-border-beam>\n    </div>\n    <a-config-provider :theme=\"customTheme\">\n      <div :style=\"{ width: '320px' }\">\n        <a-border-beam>\n          <a-card title=\"Custom line width\">\n            <a-typography-text type=\"secondary\">\n              Override lineWidth from theme.token.\n            </a-typography-text>\n          </a-card>\n        </a-border-beam>\n      </div>\n    </a-config-provider>\n  </a-flex>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Breadcrumb",
@@ -3654,14 +3751,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Breadcrumb by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Breadcrumb 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { BreadcrumbProps } from 'antdv-next'\n\nconst classesObject = {\n  root: 'demo-breadcrumb-root',\n  item: 'demo-breadcrumb-item',\n  separator: 'demo-breadcrumb-separator',\n}\n\nconst stylesObject: BreadcrumbProps['styles'] = {\n  root: { border: '1px solid #f0f0f0', padding: '8px', borderRadius: '4px' },\n  item: { color: '#1890ff' },\n  separator: { color: 'rgba(0, 0, 0, 0.45)' },\n}\n\nconst stylesFn: BreadcrumbProps['styles'] = (info) => {\n  const items = info.props.items || []\n  if (items.length > 2) {\n    return {\n      root: { border: '1px solid #F5EFFF', padding: '8px', borderRadius: '4px' },\n      item: { color: '#8F87F1' },\n    }\n  }\n  return {}\n}\n\nconst items = [\n  { title: 'Antdv Next' },\n  { title: 'Component' },\n  { title: 'Breadcrumb' },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-breadcrumb\n      :classes=\"classesObject\"\n      :items=\"items.slice(0, 2)\"\n      :styles=\"stylesObject\"\n      aria-label=\"Breadcrumb with Object\"\n    />\n    <a-breadcrumb\n      :classes=\"classesObject\"\n      :items=\"items\"\n      :styles=\"stylesFn\"\n      aria-label=\"Breadcrumb with Function\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with text color, font size, icon size and other basic styles, using flex layout with ordered list",
+          "descriptionZh": "根元素，包含文字颜色、字体大小、图标尺寸等基础样式，内部使用 flex 布局的有序列表"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { HomeOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'separator', desc: t('separator'), version: '1.0.0' },\n])\n\nconst items = [\n  { href: '', title: h(HomeOutlined) },\n  { href: '', title: [h(UserOutlined), h('span', 'Application List')] },\n  { title: 'Application' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Breadcrumb\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-breadcrumb :items=\"items\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with text color, link color transitions, hover effects, padding, border-radius, height, and margin styles",
+          "descriptionZh": "Item 元素，包含文字颜色、链接的颜色变化、悬浮效果、内边距、圆角、高度、外边距等样式"
+        },
+        {
+          "key": "separator",
+          "description": "Separator element with margin and color styles for the divider",
+          "descriptionZh": "分隔符元素，包含分隔符的外边距和颜色样式"
         }
       ]
     },
@@ -4182,20 +4288,29 @@
           "code": "<script setup lang=\"ts\">\nimport type { ButtonProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: ButtonProps['classes'] = {\n  root: 'demo-button-root',\n  content: 'demo-button-content',\n}\n\nconst stylesObject: ButtonProps['styles'] = {\n  root: {\n    boxShadow: '0 1px 2px 0 rgba(0,0,0,0.05)',\n  },\n}\n\nconst stylesFn: ButtonProps['styles'] = (info) => {\n  if (info?.props?.type === 'primary') {\n    return {\n      root: {\n        backgroundColor: '#171717',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"small\">\n    <a-button type=\"default\" :classes=\"classes\" :styles=\"stylesObject\">\n      Object\n    </a-button>\n    <a-button type=\"primary\" :classes=\"classes\" :styles=\"stylesFn\">\n      Function\n    </a-button>\n  </a-flex>\n</template>"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AntDesignOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Button\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-button type=\"primary\" :classes=\"classes\">\n        <template #icon>\n          <AntDesignOutlined />\n        </template>\n        Antdv Next\n      </a-button>\n    </template>\n  </SemanticPreview>\n</template>"
-        },
-        {
           "name": "chinese-space",
           "title": "",
           "titleZh": "移除两个汉字之间的空格",
           "description": "We add a space between two Chinese characters by default, which can be removed by setting `autoInsertSpace` to `false`.",
           "descriptionZh": "我们默认在两个汉字之间添加空格，可以通过设置 `autoInsertSpace` 为 `false` 关闭。",
           "code": "<template>\n  <a-flex gap=\"small\" wrap>\n    <a-button type=\"primary\" :auto-insert-space=\"false\">\n      确定\n    </a-button>\n    <a-button type=\"primary\" auto-insert-space>\n      确定\n    </a-button>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with comprehensive button styling including border, background, padding, border-radius, box-shadow, transitions, cursor, font-weight, alignment, and layout properties",
+          "descriptionZh": "根元素，包含边框样式、背景色、内边距、圆角、阴影效果、过渡动画、光标样式、文字权重、对齐方式等完整的按钮外观样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element that wraps button text with typography styles including nowrap, text-align center, and Chinese character spacing optimization",
+          "descriptionZh": "内容元素，包装按钮文本内容，控制文本的不换行显示、居中对齐、中文字符间距优化等文本排版样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with font-size, color inheritance, and SVG style reset for proper icon display",
+          "descriptionZh": "图标元素，包含图标的字体大小、颜色继承、SVG 样式重置等图标显示相关样式"
         }
       ]
     },
@@ -4483,14 +4598,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Calendar by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Calendar 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CalendarProps } from 'antdv-next'\nimport type { Dayjs } from 'dayjs'\n\nconst classes = {\n  root: 'custom-calendar-root',\n}\n\nconst stylesObject: CalendarProps<Dayjs>['styles'] = {\n  root: {\n    borderRadius: '8px',\n    width: '600px',\n  },\n}\n\nconst stylesFunction: CalendarProps<Dayjs>['styles'] = (info) => {\n  if (info.props.fullscreen) {\n    return {\n      root: {\n        border: '2px solid #BDE3C3',\n        borderRadius: '10px',\n        backgroundColor: 'rgba(189,227,195, 0.3)',\n      },\n    } satisfies CalendarProps<Dayjs>['styles']\n  }\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-calendar :fullscreen=\"false\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-calendar :classes=\"classes\" :styles=\"stylesFunction\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element containing background, border, border-radius and overall layout structure of the calendar component",
+          "descriptionZh": "根元素，包含日历组件的背景色、边框、圆角等基础样式和整体布局结构"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'itemContent', desc: t('itemContent'), version: '1.3.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Calendar\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-calendar :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with layout and style control for year selector, month selector and mode switcher",
+          "descriptionZh": "头部元素，包含年份选择器、月份选择器、模式切换器的布局和样式控制"
+        },
+        {
+          "key": "body",
+          "description": "Body element with padding and layout control for the calendar table that contains the calendar grid",
+          "descriptionZh": "主体元素，包含日历表格的内边距、布局控制等样式，用于容纳日历网格"
+        },
+        {
+          "key": "content",
+          "description": "Content element with width, height and table styling control for the calendar table",
+          "descriptionZh": "内容元素，包含日历表格的宽度、高度等尺寸控制和表格样式"
+        },
+        {
+          "key": "item",
+          "description": "Item element with background, border, hover state, selected state and other interactive styles for calendar cells",
+          "descriptionZh": "条目元素，包含日历单元格的背景色、边框、悬停态、选中态等交互样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Item content element with layout and styles for the calendar cell content area",
+          "descriptionZh": "条目内容元素，包含日历单元格内容区域的布局和样式"
         }
       ]
     },
@@ -4976,14 +5115,43 @@
           "description": "Debug vertical alignment of button icons inside Card extra (#57727, #57896, #58428).",
           "descriptionZh": "调试 Card extra 中按钮图标的垂直对齐（#57727、#57896、#58428）。",
           "code": "<script setup lang=\"ts\">\nimport { SmileOutlined } from '@antdv-next/icons'\nimport { Popconfirm } from 'antdv-next'\nimport { h } from 'vue'\n\nconst InternalPopconfirm = Popconfirm._InternalPanelDoNotUseOrYouWillBeFired\n\nconst btnCls = {\n  icon: 'card-btn-debug-icon',\n  content: 'card-btn-debug-content',\n}\n</script>\n\n<template>\n  <a-config-provider :button=\"{ classes: btnCls }\">\n    <a-flex vertical gap=\"middle\">\n      <a-card class=\"line-card\" title=\"#57727 Card extra\">\n        <template #extra>\n          <a-button>\n            <template #icon>\n              <SmileOutlined />\n            </template>\n            Test\n          </a-button>\n        </template>\n        Button in Card extra should be vertically centered with the title.\n      </a-card>\n\n      <a-card title=\"#57896 regression minimum case\">\n        <div class=\"simulate-57896\">\n          <div class=\"inline-buttons\">\n            <a-button>Cancel</a-button>\n            <a-button type=\"primary\" :icon=\"() => h(SmileOutlined)\">\n              Confirm\n            </a-button>\n          </div>\n        </div>\n      </a-card>\n\n      <InternalPopconfirm\n        title=\"Are you OK?\"\n        :ok-button-props=\"{ icon: () => h(SmileOutlined) }\"\n      />\n    </a-flex>\n  </a-config-provider>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Card root element with positioning, background, border, border-radius, box-shadow, padding and other container styles",
+          "descriptionZh": "卡片根元素，包含位置定位、背景色、边框、圆角、阴影、内边距等卡片容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, EllipsisOutlined, SettingOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'cover', desc: t('cover'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Card\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ position: 'absolute' }\">\n        <a-card\n          title=\"Card title\"\n          extra=\"More\"\n          :style=\"{ width: '300px' }\"\n          :classes=\"classes\"\n        >\n          <template #cover>\n            <img\n              draggable=\"false\"\n              alt=\"example\"\n              src=\"https://gw.alipayobjects.com/zos/rmsportal/JiqGstEfoWAOHiTxclqi.png\"\n            >\n          </template>\n          <template #actions>\n            <SettingOutlined key=\"setting\" />\n            <EditOutlined key=\"edit\" />\n            <EllipsisOutlined key=\"ellipsis\" />\n          </template>\n          <a-card-meta\n            title=\"Card Meta title\"\n            description=\"This is the description\"\n          >\n            <template #avatar>\n              <a-avatar src=\"https://api.dicebear.com/7.x/miniavs/svg?seed=8\" />\n            </template>\n          </a-card-meta>\n        </a-card>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Card header area with flex layout, min-height, padding, text color, font-weight, font-size, background, bottom border and top border-radius",
+          "descriptionZh": "卡片头部区域，包含 flex 布局、最小高度、内边距、文字颜色、字体权重、字体大小、背景色、下边框、顶部圆角等样式"
+        },
+        {
+          "key": "body",
+          "description": "Card content area with padding, font-size and other content display styles",
+          "descriptionZh": "卡片内容区域，包含内边距、字体大小等内容展示的基础样式"
+        },
+        {
+          "key": "extra",
+          "description": "Card extra operation area in top-right corner with text color and layout styles for additional content",
+          "descriptionZh": "卡片右上角的操作区域，包含额外内容的文字颜色和布局样式"
+        },
+        {
+          "key": "title",
+          "description": "Card title with inline-block display, flex-grow, text ellipsis and other title display styles",
+          "descriptionZh": "卡片标题，包含行内块布局、flex 占比、文本省略等标题显示样式"
+        },
+        {
+          "key": "actions",
+          "description": "Card bottom action group with flex layout, list-style reset, background, top border and bottom border-radius for action buttons container",
+          "descriptionZh": "卡片底部操作组，包含 flex 布局、列表样式重置、背景色、上边框、底部圆角等操作按钮容器样式"
+        },
+        {
+          "key": "cover",
+          "description": "Title cover with styles for cover image display and layout",
+          "descriptionZh": "标题封面，包含封面图片的显示和布局样式"
         }
       ]
     },
@@ -5249,7 +5417,8 @@
           "descriptionZh": "展示指示点的进度。",
           "code": "<template>\n  <a-carousel :autoplay=\"{ dotDuration: true }\" :autoplay-speed=\"5000\">\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        1\n      </h3>\n    </div>\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        2\n      </h3>\n    </div>\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        3\n      </h3>\n    </div>\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        4\n      </h3>\n    </div>\n  </a-carousel>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Cascader",
@@ -5641,14 +5810,6 @@
           "code": "<script setup lang=\"ts\">\nimport type { CascaderEmits } from 'antdv-next'\nimport { ref } from 'vue'\n\ninterface Option {\n  value: string | number\n  label: string\n  children?: Option[]\n}\n\nconst options: Option[] = [\n  {\n    value: 'zhejiang',\n    label: 'Zhejiang',\n    children: [\n      {\n        value: 'hangzhou',\n        label: 'Hangzhou',\n        children: [\n          {\n            value: 'xihu',\n            label: 'West Lake',\n          },\n        ],\n      },\n    ],\n  },\n  {\n    value: 'jiangsu',\n    label: 'Jiangsu',\n    children: [\n      {\n        value: 'nanjing',\n        label: 'Nanjing',\n        children: [\n          {\n            value: 'zhonghuamen',\n            label: 'Zhong Hua Men',\n          },\n        ],\n      },\n    ],\n  },\n]\n\nconst disabled = ref(false)\n\nconst onChange: CascaderEmits['change'] = (value) => {\n  console.log(value)\n}\n\nconst onMultipleChange: CascaderEmits['change'] = (value) => {\n  console.log(value)\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"small\" align=\"flex-start\">\n    <a-switch\n      v-model:checked=\"disabled\"\n      checked-children=\"Enabled\"\n      un-checked-children=\"Disabled\"\n      aria-label=\"disabled switch\"\n    />\n    <a-cascader-panel :options=\"options\" :disabled=\"disabled\" @change=\"onChange\" />\n    <a-cascader-panel multiple :options=\"options\" :disabled=\"disabled\" @change=\"onMultipleChange\" />\n    <a-cascader-panel />\n  </a-flex>\n</template>"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst mode = ref<'single' | 'multiple'>('single')\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => {\n  const base = [\n    { name: 'root', desc: t('root') },\n    { name: 'prefix', desc: t('prefix') },\n    { name: 'content', desc: t('content') },\n    { name: 'placeholder', desc: t('placeholder') },\n    { name: 'clear', desc: t('clear') },\n    { name: 'input', desc: t('input') },\n    { name: 'suffix', desc: t('suffix') },\n    { name: 'popup.root', desc: t('popup.root') },\n    { name: 'popup.list', desc: t('popup.list') },\n    { name: 'popup.listItem', desc: t('popup.listItem') },\n  ]\n\n  if (mode.value === 'multiple') {\n    return [\n      ...base,\n      { name: 'item', desc: t('item') },\n      { name: 'itemContent', desc: t('itemContent') },\n      { name: 'itemRemove', desc: t('itemRemove') },\n    ]\n  }\n\n  return base\n})\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst options = [\n  {\n    value: 'contributors',\n    label: 'contributors',\n    children: [\n      { value: 'aojunhao123', label: 'aojunhao123' },\n      { value: 'thinkasany', label: 'thinkasany' },\n      { value: 'meet-student', label: 'meet-student' },\n    ],\n  },\n]\n\nconst value = computed(() => {\n  if (mode.value !== 'multiple')\n    return ['contributors', 'thinkasany']\n\n  return [['contributors', 'aojunhao123']]\n})\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Cascader\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <div :style=\"{ display: 'flex', justifyContent: 'center', marginBottom: '12px' }\">\n          <a-segmented v-model:value=\"mode\" :options=\"['single', 'multiple']\" />\n        </div>\n        <div :style=\"{ display: 'flex', flexDirection: 'column', gap: '12px' }\">\n          <a-cascader\n            prefix=\"prefix\"\n            :style=\"{ width: '300px' }\"\n            :options=\"options\"\n            :value=\"value\"\n            :multiple=\"mode === 'multiple'\"\n            open\n            :get-popup-container=\"() => divRef!\"\n            :classes=\"classes\"\n          />\n        </div>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
-        },
-        {
           "name": "basic",
           "title": "",
           "titleZh": "基本",
@@ -5695,6 +5856,73 @@
           "description": "Allows the selection of only parent options.",
           "descriptionZh": "这种交互允许只选中父级选项。",
           "code": "<script setup lang=\"ts\">\nimport type { CascaderEmits } from 'antdv-next'\nimport { shallowRef } from 'vue'\n\ninterface Option {\n  value: string\n  label: string\n  children?: Option[]\n}\n\nconst options: Option[] = [\n  {\n    value: 'zhejiang',\n    label: 'Zhejiang',\n    children: [\n      {\n        value: 'hangzhou',\n        label: 'Hanzhou',\n        children: [\n          {\n            value: 'xihu',\n            label: 'West Lake',\n          },\n        ],\n      },\n    ],\n  },\n  {\n    value: 'jiangsu',\n    label: 'Jiangsu',\n    children: [\n      {\n        value: 'nanjing',\n        label: 'Nanjing',\n        children: [\n          {\n            value: 'zhonghuamen',\n            label: 'Zhong Hua Men',\n          },\n        ],\n      },\n    ],\n  },\n]\n\nconst onChange: CascaderEmits['change'] = (value) => {\n  console.log(value)\n}\nconst value = shallowRef()\n</script>\n\n<template>\n  <a-cascader v-model:value=\"value\" :options=\"options\" change-on-select @change=\"onChange\" />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, cursor styles, transitions, border and other basic selector container styles",
+          "descriptionZh": "根元素，包含相对定位、行内 flex 布局、光标样式、过渡动画、边框等选择器容器的基础样式"
+        },
+        {
+          "key": "prefix",
+          "description": "Prefix element with layout and styling for prefix content",
+          "descriptionZh": "前缀元素，包含前缀内容的布局和样式"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "clear",
+          "description": "Clear button element with layout, styling and interactive effects for clear button式",
+          "descriptionZh": "清除按钮元素，包含清除按钮的布局、样式和交互效果"
+        },
+        {
+          "key": "item",
+          "description": "Multiple selection item element with border, background, padding, and margin styles",
+          "descriptionZh": "多选项元素，包含边框、背景、内边距、外边距样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Multiple selection item content area with text ellipsis styles",
+          "descriptionZh": "多选项内容区域，包含文字的省略样式"
+        },
+        {
+          "key": "itemRemove",
+          "description": "Multiple selection item remove button with font-related styles式",
+          "descriptionZh": "多选项移除按钮，包含字体相关样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with search input styling, cursor control, font inheritance and other search-related styles. Remove border styles",
+          "descriptionZh": "输入框元素，包含搜索输入框的样式、光标控制、字体继承等搜索相关样式，去除了边框样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with layout and styling for suffix content like clear button, arrow icon, etc.",
+          "descriptionZh": "后缀元素，包含后缀内容的布局和样式，如清除按钮、箭头图标等"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with popup layer positioning, z-index, background, border, box-shadow and other popup container styles",
+          "descriptionZh": "弹出菜单元素，包含弹出层的定位、层级、背景、边框、阴影等弹出容器样式"
+        },
+        {
+          "key": "popup.list",
+          "description": "Popup list element with option list layout, scrolling, max-height and other list container styles",
+          "descriptionZh": "弹出菜单列表元素，包含选项列表的布局、滚动、最大高度等列表容器样式"
+        },
+        {
+          "key": "popup.listItem",
+          "description": "Popup item element with option item padding, hover effects, selected states, disabled states and other option interactive styles",
+          "descriptionZh": "弹出菜单条目元素，包含选项项的内边距、悬浮效果、选中状态、禁用状态等选项交互样式式"
         }
       ]
     },
@@ -5923,14 +6151,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Checkbox by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Checkbox 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CheckboxProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\nimport { ref } from 'vue'\n\nconst checked = ref(true)\nconst { token } = theme.useToken()\n\n// Object styles — 静态样式对象\nconst stylesObject: CheckboxProps['styles'] = {\n  icon: {\n    borderRadius: '6px',\n  },\n  label: {\n    color: 'blue',\n  },\n}\n\n// Function classes — 根据 checked 状态动态返回类名\nconst classesFn: CheckboxProps['classes'] = (info) => {\n  const base: Record<string, string> = {\n    root: 'checkbox-demo-root',\n    icon: 'checkbox-demo-icon',\n    label: 'checkbox-demo-label',\n  }\n  if (info.props.checked) {\n    return {\n      root: base.root,\n      icon: `${base.icon} checkbox-demo-icon-checked`,\n      label: `${base.label} checkbox-demo-label-checked`,\n    }\n  }\n  return base\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-checkbox :styles=\"stylesObject\">\n      Object styles\n    </a-checkbox>\n    <a-checkbox\n      v-model:checked=\"checked\"\n      :classes=\"classesFn\"\n    >\n      Function classes\n    </a-checkbox>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with inline-flex layout, baseline alignment, cursor style, reset styles and other basic checkbox container styles",
+          "descriptionZh": "根元素，包含行内 flex 布局、基线对齐、光标样式、重置样式等复选框容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Checkbox\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-checkbox :classes=\"classes\">\n        Checkbox\n      </a-checkbox>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Checkbox icon element with size, direction, background, border, border-radius, transitions, and checked state checkmark styles",
+          "descriptionZh": "选中框元素，包含尺寸、方向、背景色、边框、圆角、过渡动画，以及选中状态的勾选标记样式"
+        },
+        {
+          "key": "label",
+          "description": "Label text element with padding and spacing styles relative to the checkbox",
+          "descriptionZh": "文本元素，包含文本的内边距和与复选框的间距样式"
         }
       ]
     },
@@ -6314,14 +6551,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Collapse by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Collapse 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CollapseProps } from 'antdv-next'\nimport { h } from 'vue'\n\nconst text\n  = 'A dog is a type of domesticated animal. Known for its loyalty and faithfulness, it can be found as a welcome guest in many households across the world.'\n\nconst element = h('p', text)\n\nconst items = [\n  {\n    key: '1',\n    label: 'This is panel header 1',\n    content: element,\n  },\n  {\n    key: '2',\n    label: 'This is panel header 2',\n    content: element,\n  },\n  {\n    key: '3',\n    label: 'This is panel header 3',\n    content: element,\n  },\n]\n\nconst classes: CollapseProps['classes'] = {\n  root: 'demo-collapse-root',\n}\n\nconst stylesObject: CollapseProps['styles'] = {\n  root: {\n    backgroundColor: '#fafafa',\n    border: '1px solid #e0e0e0',\n    borderRadius: '8px',\n  },\n  header: {\n    backgroundColor: '#f0f0f0',\n    padding: '12px 16px',\n    color: '#141414',\n  },\n}\n\nconst stylesFn: CollapseProps['styles'] = (info) => {\n  if (info?.props?.size === 'large') {\n    return {\n      root: {\n        backgroundColor: '#fff',\n        border: '1px solid #696FC7',\n        borderRadius: '8px',\n      },\n      header: {\n        backgroundColor: '#F5EFFF',\n        padding: '12px 16px',\n        color: '#141414',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-collapse :items=\"items\" :classes=\"classes\" :styles=\"stylesObject\" :default-active-key=\"['1']\" />\n    <a-collapse :items=\"items\" :classes=\"classes\" :styles=\"stylesFn\" size=\"large\" :default-active-key=\"['2']\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with border, border-radius, background color and container styles that control the overall layout and appearance of collapse panels",
+          "descriptionZh": "根元素，包含折叠面板的边框、圆角、背景色等容器样式，控制面板的整体布局和外观"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { theme } from 'antdv-next'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n])\n\nconst { token } = theme.useToken()\n\nconst items = computed(() => [\n  {\n    key: '1',\n    label: 'This is panel header',\n    children: 'This is panel body',\n  },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Collapse\"\n    items-a-p-i=\"items\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ position: 'absolute', inset: 0, margin: `${token.marginXL}px` }\">\n        <a-collapse\n          :items=\"items\"\n          :default-active-key=\"['1']\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with flex layout, padding, color, line-height, cursor style, transition animations and other interactive styles for panel headers",
+          "descriptionZh": "头部元素，包含flex布局、内边距、颜色、行高、光标样式、过渡动画等面板头部的交互和样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with flex auto layout and margin styles for title text layout and typography",
+          "descriptionZh": "标题元素，包含flex自适应布局、右边距等标题文字的布局和排版样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with padding, color, background color and other styles for panel content area display",
+          "descriptionZh": "内容元素，包含内边距、颜色、背景色等面板内容区域的展示样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with font size, transition animations, rotation transforms and other styles and animations for expand/collapse arrows",
+          "descriptionZh": "图标元素，包含字体大小、过渡动画、旋转变换等展开收起箭头的样式和动效"
         }
       ]
     },
@@ -6669,14 +6925,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of ColorPicker by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或函数可以自定义 ColorPicker 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst classes = { root: 'custom-color-picker' }\n\nconst color = shallowRef('#1677ff')\nconst colorLarge = shallowRef('#722ed1')\n\nconst stylesObject = {\n  popup: {\n    root: {\n      border: '1px solid #fff',\n    },\n  },\n}\n\nfunction stylesFn(info: any) {\n  if (info?.props?.size === 'large') {\n    return {\n      popup: {\n        root: {\n          border: '1px solid #722ed1',\n        },\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-space size=\"middle\" wrap>\n    <a-color-picker\n      v-model:value=\"color\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    />\n    <a-color-picker\n      v-model:value=\"colorLarge\"\n      size=\"large\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n    />\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Trigger container with border styles, transition animations, size controls, displaying color block and text content",
+          "descriptionZh": "触发器容器，包含边框样式、过渡动画、尺寸控制等样式，显示颜色块和文本内容"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'body', desc: t('body') },\n  { name: 'content', desc: t('content') },\n  { name: 'description', desc: t('description') },\n  { name: 'popup.root', desc: t('popup.root') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\nconst body = document?.body\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"ColorPicker\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" :style=\"{ height: '300px' }\" align=\"flex-start\" gap=\"small\">\n        <a-color-picker\n          default-value=\"#1677ff\"\n          open\n          show-text\n          :get-popup-container=\"() => divRef || body\"\n          :styles=\"{ popup: { root: { zIndex: 1 } } }\"\n          :classes=\"classes\"\n        />\n        <a-color-picker :open=\"false\" allow-clear :classes=\"classes\" />\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "popup.root",
+          "description": "Popup panel root container with background color, shadow effects, color selection panel, slider controls and preset colors",
+          "descriptionZh": "弹出面板根容器，包含背景色、阴影效果、色彩选择面板、滑块控制和预设颜色等样式"
+        },
+        {
+          "key": "body",
+          "description": "Color block container with background color, border styles",
+          "descriptionZh": "色块容器，包含底色、边框等样式"
+        },
+        {
+          "key": "content",
+          "description": "Color block element with actual selected color styles",
+          "descriptionZh": "色块颜色元素，包含实际选择的颜色样式"
+        },
+        {
+          "key": "description",
+          "description": "Description text content with font styles and color",
+          "descriptionZh": "描述文本内容，包含字体样式、颜色等样式"
         }
       ]
     },
@@ -6890,7 +7165,8 @@
           "descriptionZh": "获取父级 `Provider` 的值。如 `DisabledContextProvider`、`SizeContextProvider`。",
           "code": "<script setup lang=\"ts\">\nimport type { ConfigProviderProps } from 'antdv-next'\nimport { ref } from 'vue'\nimport ConfigDisplay from './use-config-display.vue'\n\ntype SizeType = ConfigProviderProps['componentSize']\n\nconst componentSize = ref<SizeType>('small')\nconst disabled = ref(true)\n</script>\n\n<template>\n  <div>\n    <a-space>\n      <a-radio-group v-model:value=\"componentSize\">\n        <a-radio-button value=\"small\">\n          Small\n        </a-radio-button>\n        <a-radio-button value=\"middle\">\n          Middle\n        </a-radio-button>\n        <a-radio-button value=\"large\">\n          Large\n        </a-radio-button>\n      </a-radio-group>\n      <a-checkbox v-model:checked=\"disabled\">\n        Form disabled\n      </a-checkbox>\n    </a-space>\n    <a-divider />\n    <a-config-provider :component-size=\"componentSize\">\n      <div class=\"example\">\n        <a-form :disabled=\"disabled\">\n          <ConfigDisplay />\n        </a-form>\n      </div>\n    </a-config-provider>\n  </div>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "DatePicker",
@@ -7524,14 +7800,63 @@
           "description": "Custom `prefix` and `suffixIcon`.",
           "descriptionZh": "自定义前缀 `prefix` 和后缀图标 `suffixIcon`。",
           "code": "<script setup lang=\"ts\">\nimport type { Dayjs } from 'dayjs'\nimport { SmileOutlined } from '@antdv-next/icons'\nimport { h } from 'vue'\n\nconst smileIcon = h(SmileOutlined)\n\nfunction handleChange(date: Dayjs | (Dayjs | null)[] | null, dateString: string | string[] | null) {\n  console.log(date, dateString)\n}\n</script>\n\n<template>\n  <a-space vertical :size=\"12\">\n    <a-date-picker :suffix-icon=\"smileIcon\" @change=\"handleChange\" />\n    <a-date-picker :suffix-icon=\"smileIcon\" picker=\"month\" @change=\"handleChange\" />\n    <a-range-picker :suffix-icon=\"smileIcon\" @change=\"handleChange\" />\n    <a-date-picker :suffix-icon=\"smileIcon\" picker=\"week\" @change=\"handleChange\" />\n    <a-date-picker suffix-icon=\"ab\" @change=\"handleChange\" />\n    <a-date-picker suffix-icon=\"ab\" picker=\"month\" @change=\"handleChange\" />\n    <a-range-picker suffix-icon=\"ab\" @change=\"handleChange\" />\n    <a-date-picker suffix-icon=\"ab\" picker=\"week\" @change=\"handleChange\" />\n    <a-date-picker :prefix=\"smileIcon\" picker=\"week\" @change=\"handleChange\" />\n    <a-date-picker prefix=\"Event Period\" picker=\"week\" @change=\"handleChange\" />\n    <a-range-picker :prefix=\"smileIcon\" picker=\"week\" @change=\"handleChange\" />\n    <a-range-picker prefix=\"Event Period\" picker=\"week\" @change=\"handleChange\" />\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, padding, border-radius, transition animations and other basic styles for date picker container",
+          "descriptionZh": "根元素，包含相对定位、行内flex布局、内边距、边框圆角、过渡动画等日期选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { SmileOutlined } from '@antdv-next/icons'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'popup.root', desc: t('popup') },\n  { name: 'popup.container', desc: t('popup.container') },\n  { name: 'popup.header', desc: t('popup.header') },\n  { name: 'popup.body', desc: t('popup.body') },\n  { name: 'popup.content', desc: t('popup.content') },\n  { name: 'popup.item', desc: t('popup.item') },\n  { name: 'popup.footer', desc: t('popup.footer') },\n])\n\nconst type = ref<'Single' | 'Multiple'>('Single')\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    :component-name=\"type === 'Single' ? 'DatePicker' : 'DatePicker.RangePicker'\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" vertical :style=\"{ alignSelf: 'flex-start' }\" gap=\"middle\" align=\"center\">\n        <a-segmented\n          :options=\"['Single', 'Multiple']\"\n          :value=\"type\"\n          @change=\"(val: 'Single' | 'Multiple') => type = val\"\n        />\n        <a-date-picker\n          v-if=\"type === 'Single'\"\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-date-picker>\n        <a-range-picker\n          v-else\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-range-picker>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with flex layout and margin styles for prefix content layout",
+          "descriptionZh": "前缀元素，包含flex布局、右外边距等前缀内容的布局样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with relative positioning, width, color, font, line-height, transition animations and other core interactive styles for input field",
+          "descriptionZh": "输入框元素，包含相对定位、宽度、颜色、字体、行高、过渡动画等输入框的核心交互样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with flex layout, color, line-height, pointer events, transition animations and other styles for suffix content",
+          "descriptionZh": "后缀元素，包含flex布局、颜色、行高、指针事件、过渡动画等后缀内容的样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup element",
+          "descriptionZh": "弹出框元素"
+        },
+        {
+          "key": "popup.container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "popup.header",
+          "description": "Popup header element with navigation buttons, month/year selectors and other header control area layout and styles",
+          "descriptionZh": "弹出框头部元素，包含导航按钮、月份年份选择器等头部控制区域的布局和样式"
+        },
+        {
+          "key": "popup.body",
+          "description": "Popup body element with container layout and styles for date panel table",
+          "descriptionZh": "弹出框主体元素，包含日期面板表格的容器布局和样式"
+        },
+        {
+          "key": "popup.content",
+          "description": "Popup content element with width, border, cell and other content display styles for date table",
+          "descriptionZh": "弹出框内容元素，包含日期表格的宽度、边框、单元格等内容展示样式"
+        },
+        {
+          "key": "popup.item",
+          "description": "Popup item element with size, background, border-radius, hover state, selected state and other interactive styles for date cells",
+          "descriptionZh": "弹出框单项元素，包含日期单元格的尺寸、背景色、边框圆角、悬停态、选中态等交互样式"
+        },
+        {
+          "key": "popup.footer",
+          "description": "Popup footer element with layout styles for bottom operation area including confirm/cancel buttons and shortcuts",
+          "descriptionZh": "弹出框底部元素，包含确认取消按钮、快捷选择等底部操作区域的布局样式"
         }
       ]
     },
@@ -7785,14 +8110,38 @@
           "description": "Display of the entire line.",
           "descriptionZh": "整行的展示。",
           "code": "<script setup lang=\"ts\">\nimport type { DescriptionsItemType } from 'antdv-next'\n\nconst items: DescriptionsItemType[] = [\n  {\n    label: 'UserName',\n    content: 'Zhou Maomao',\n  },\n  {\n    label: 'Live',\n    span: 'filled', // span = 2\n    content: 'Hangzhou, Zhejiang',\n  },\n  {\n    label: 'Remark',\n    span: 'filled', // span = 3\n    content: 'empty',\n  },\n  {\n    label: 'Address',\n    span: 1, // span will be 3 and warning for span is not align to the end\n    content: 'No. 18, Wantang Road, Xihu District, Hangzhou, Zhejiang, China',\n  },\n]\n</script>\n\n<template>\n  <a-descriptions title=\"User Info\" :items=\"items\" bordered />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with basic styles, reset styles, border styles, layout direction and other overall styles for description list container",
+          "descriptionZh": "根元素，包含描述列表容器的基础样式、重置样式、边框样式、布局方向等整体样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n\nconst bordered = ref(false)\n\nconst items = [\n  { key: '1', label: 'Telephone', content: '1810000000' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Descriptions\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ width: '100%', height: '100%' }\">\n        <a-switch v-model:checked=\"bordered\" />\n        Toggle Border\n        <a-divider />\n        <a-descriptions\n          title=\"User Info\"\n          :items=\"items\"\n          :bordered=\"bordered\"\n          :classes=\"classes\"\n        >\n          <template #extra>\n            <a-button type=\"primary\">\n              Edit\n            </a-button>\n          </template>\n        </a-descriptions>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with flex layout, alignment, bottom margin and other layout and style controls for header area",
+          "descriptionZh": "头部元素，包含flex布局、对齐方式、下边距等头部区域的布局和样式控制"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text ellipsis, flex ratio, color, font weight, font size, line height and other title text styles",
+          "descriptionZh": "标题元素，包含文本省略、flex占比、颜色、字体权重、字体大小、行高等标题文字样式"
+        },
+        {
+          "key": "extra",
+          "description": "Extra content element with left margin, color, font size and other styles for additional operation area",
+          "descriptionZh": "额外内容元素，包含左边距、颜色、字体大小等额外操作区域的样式"
+        },
+        {
+          "key": "label",
+          "description": "Label element with color, font weight, font size, line height, text align, colon styles and other label text styles",
+          "descriptionZh": "标签元素，包含颜色、字体权重、字体大小、行高、文本对齐、冒号样式等标签文字的样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with table cell layout, color, font size, line height, word break and other content display styles",
+          "descriptionZh": "内容元素，包含表格单元格布局、颜色、字体大小、行高、文字换行等内容展示样式"
         }
       ]
     },
@@ -7961,14 +8310,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of divider by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义分割线的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { DividerProps } from 'antdv-next'\n\nconst classesObject: DividerProps['classes'] = {\n  root: 'demo-divider-root',\n  content: 'demo-divider-content',\n  rail: 'demo-divider-rail',\n}\n\nconst classesFn: DividerProps['classes'] = (info) => {\n  if (info?.props?.titlePlacement === 'start') {\n    return {\n      root: 'demo-divider-root--start',\n    }\n  }\n  return {\n    root: 'demo-divider-root--default',\n  }\n}\n\nconst stylesObject: DividerProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed' },\n  content: { fontStyle: 'italic' },\n  rail: { opacity: 0.85 },\n}\n\nconst stylesFn: DividerProps['styles'] = (info) => {\n  if (info?.props?.size === 'small') {\n    return {\n      root: { opacity: 0.6, cursor: 'default' },\n    }\n  }\n  return {\n    root: { backgroundColor: '#fafafa', borderColor: '#d9d9d9' },\n  }\n}\n</script>\n\n<template>\n  <div>\n    <a-divider :classes=\"classesObject\">\n      classes Object\n    </a-divider>\n    <a-divider title-placement=\"start\" :classes=\"classesFn\">\n      classes Function\n    </a-divider>\n    <a-divider :styles=\"stylesObject\">\n      styles Object\n    </a-divider>\n    <a-divider size=\"small\" :styles=\"stylesFn\">\n      styles Function\n    </a-divider>\n  </div>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with border-top style, divider styling and other basic divider container styles",
+          "descriptionZh": "根元素，包含边框顶部样式、分隔线样式等分割线容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'rail', desc: t('rail') },\n  { name: 'content', desc: t('content') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Divider\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div>\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider :classes=\"classes\" />\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider :classes=\"classes\">\n          Solid\n        </a-divider>\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider title-placement=\"left\" variant=\"dotted\" :classes=\"classes\">\n          Dotted\n        </a-divider>\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider title-placement=\"right\" variant=\"dashed\" :classes=\"classes\">\n          Dashed\n        </a-divider>\n        These\n        <a-divider orientation=\"vertical\" :classes=\"classes\" />\n        are\n        <a-divider orientation=\"vertical\" :classes=\"classes\" />\n        vertical\n        <a-divider orientation=\"vertical\" :classes=\"classes\" />\n        Dividers\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "content",
+          "description": "Content element with inline-block display, padding and other divider text content styles",
+          "descriptionZh": "内容元素，包含行内块显示、内边距等分割线文本内容的样式"
+        },
+        {
+          "key": "rail",
+          "description": "Background rail element with border-top style and other divider connection line styles",
+          "descriptionZh": "背景条元素，包含边框顶部样式等分割线连接条的样式"
         }
       ]
     },
@@ -8345,14 +8703,58 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Drawer by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Drawer 组件的 [语义化结构](#semantic-dom) 样式。",
           "code": "<script setup lang=\"ts\">\nimport type { DrawerProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\nimport { ref } from 'vue'\n\nconst { token } = theme.useToken()\nconst open = ref(false)\nconst openFn = ref(false)\n\nconst classes: DrawerProps['classes'] = {\n  header: 'demo-drawer-header',\n  body: 'demo-drawer-body',\n}\n\nconst stylesObject: DrawerProps['styles'] = {\n  body: {\n    backgroundColor: '#f5f5f5',\n  },\n  footer: {\n    backgroundColor: '#fafafa',\n  },\n}\n\nconst stylesFn: DrawerProps['styles'] = (info) => {\n  if (info?.props?.placement === 'right') {\n    return {\n      mask: {\n        backgroundColor: 'rgba(0, 0, 0, 0.2)',\n      },\n      wrapper: {\n        boxShadow: '0 8px 24px rgba(0, 0, 0, 0.15)',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-button @click=\"open = true\">\n      Object Style\n    </a-button>\n    <a-button type=\"primary\" @click=\"openFn = true\">\n      Function Style\n    </a-button>\n  </a-flex>\n\n  <a-drawer\n    v-model:open=\"open\"\n    title=\"Custom Style Drawer\"\n    :classes=\"classes\"\n    :styles=\"stylesObject\"\n    @close=\"open = false\"\n  >\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n  </a-drawer>\n\n  <a-drawer\n    v-model:open=\"openFn\"\n    title=\"Custom Function Drawer\"\n    :classes=\"classes\"\n    :styles=\"stylesFn\"\n    @close=\"openFn = false\"\n  >\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n  </a-drawer>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with fixed positioning, z-index control, pointer events, color and other basic styles and layout control for drawer container",
+          "descriptionZh": "根元素，包含固定定位、层级控制、指针事件、颜色等抽屉容器的基础样式和布局控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'mask', desc: t('mask'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n  { name: 'dragger', desc: t('dragger'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Drawer\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-drawer\n        title=\"Title\"\n        placement=\"right\"\n        open\n        :get-container=\"false\"\n        :size=\"300\"\n        :resizable=\"{}\"\n        :classes=\"classes\"\n      >\n        <template #footer>\n          <a-typography-link>Footer</a-typography-link>\n        </template>\n        <template #extra>\n          <a-button>Cancel</a-button>\n        </template>\n        <p>Some contents...</p>\n      </a-drawer>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "mask",
+          "description": "Mask element with absolute positioning, z-index, background color, pointer events and other mask layer styles and interaction controls",
+          "descriptionZh": "遮罩层元素，包含绝对定位、层级、背景色、指针事件等遮罩层的样式和交互控制"
+        },
+        {
+          "key": "section",
+          "description": "Drawer container element with flex layout, width/height, overflow control, background color, pointer events and other drawer body styles",
+          "descriptionZh": "Drawer 容器元素，包含flex布局、宽高、溢出控制、背景色、指针事件等抽屉主体的样式"
+        },
+        {
+          "key": "header",
+          "description": "Header element with flex layout, alignment, padding, font size, line height, bottom border and other header area styles",
+          "descriptionZh": "头部元素，包含flex布局、对齐方式、内边距、字体大小、行高、下边框等头部区域的样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with flex ratio, minimum size, padding, overflow scroll and other content area display and layout styles",
+          "descriptionZh": "内容元素，包含flex占比、最小尺寸、内边距、溢出滚动等内容区域的展示和布局样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with flex shrink, padding, top border and other bottom operation area styles",
+          "descriptionZh": "底部元素，包含flex收缩、内边距、上边框等底部操作区域的样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with flex ratio, margin, font weight, font size, line height and other title text styles",
+          "descriptionZh": "标题元素，包含flex占比、外边距、字体权重、字体大小、行高等标题文字的样式"
+        },
+        {
+          "key": "extra",
+          "description": "Extra element with flex fixed layout and other additional operation content style controls",
+          "descriptionZh": "额外元素，包含flex固定布局等额外操作内容的样式控制"
+        },
+        {
+          "key": "dragger",
+          "description": "Dragger element used to resize the drawer, with absolute positioning, transparent background, pointer events control, hover state styles, and dragging state styles",
+          "descriptionZh": "拖拽元素，用于调整抽屉大小的拖拽手柄，包含绝对定位、背景透明、指针事件控制、hover状态样式、拖拽状态样式等"
+        },
+        {
+          "key": "close",
+          "description": "Close button element with basic button styling",
+          "descriptionZh": "关闭按钮元素，包含按钮的基础样式"
         }
       ]
     },
@@ -8709,14 +9111,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of the Dropdown by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Dropdown 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { DropdownProps, MenuItemType } from 'antdv-next'\nimport { DownOutlined, LogoutOutlined, SettingOutlined } from '@antdv-next/icons'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst items: MenuItemType[] = [\n  {\n    key: '1',\n    label: 'Profile',\n  },\n  {\n    key: '2',\n    label: 'Settings',\n    icon: SettingOutlined,\n  },\n  {\n    type: 'divider',\n  },\n  {\n    key: '3',\n    label: 'Logout',\n    icon: LogoutOutlined,\n    danger: true,\n  },\n]\n\nconst classes: DropdownProps['classes'] = {\n  root: 'demo-dropdown-root',\n}\n\nconst objectStyles: DropdownProps['styles'] = {\n  root: {\n    backgroundColor: '#ffffff',\n    border: '1px solid #d9d9d9',\n    borderRadius: '4px',\n  },\n  item: {\n    padding: '8px 12px',\n    fontSize: '14px',\n  },\n  itemTitle: {\n    fontWeight: '500',\n  },\n  itemIcon: {\n    color: '#1890ff',\n    marginRight: '8px',\n  },\n  itemContent: {\n    backgroundColor: 'transparent',\n  },\n}\n\nconst functionStyles: DropdownProps['styles'] = (info) => {\n  const isClick = info.props.trigger?.includes('click')\n  if (isClick) {\n    return {\n      root: {\n        borderColor: '#1890ff',\n        borderRadius: '8px',\n      },\n    }\n  }\n  return {}\n}\n\nconst sharedProps: DropdownProps = {\n  menu: { items },\n  placement: 'bottomLeft',\n  classes,\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\" wrap=\"wrap\">\n    <a-space direction=\"vertical\" size=\"large\">\n      <a-dropdown v-bind=\"sharedProps\" :styles=\"objectStyles\">\n        <a-button>\n          <a-space>\n            Object Style\n            <DownOutlined />\n          </a-space>\n        </a-button>\n      </a-dropdown>\n\n      <a-dropdown v-bind=\"sharedProps\" :styles=\"functionStyles\" :trigger=\"['click']\">\n        <a-button type=\"primary\">\n          <a-space>\n            Function Style\n            <DownOutlined />\n          </a-space>\n        </a-button>\n      </a-dropdown>\n    </a-space>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element of dropdown, sets positioning, z-index and container styles",
+          "descriptionZh": "dropdown 的根元素，设置定位、层级和容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { DeleteOutlined, DownOutlined, EditOutlined, SaveOutlined } from '@antdv-next/icons'\nimport { computed, h, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'itemTitle', desc: t('itemTitle') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst items: any[] = [\n  {\n    key: '1',\n    type: 'group',\n    label: 'Group title',\n    children: [\n      { key: '1-1', label: '1st menu item', icon: h(SaveOutlined) },\n      { key: '1-2', label: '2nd menu item', icon: h(EditOutlined) },\n    ],\n  },\n  {\n    key: 'SubMenu',\n    label: 'SubMenu',\n    children: [\n      {\n        key: 'g1',\n        label: 'Item 1',\n        type: 'group',\n        children: [\n          { key: '1', label: 'Option 1' },\n          { key: '2', label: 'Option 2' },\n        ],\n      },\n    ],\n  },\n  { key: '3', type: 'divider' },\n  { key: '4', label: 'Delete', icon: h(DeleteOutlined), danger: true },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Dropdown\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ height: '120px', position: 'absolute', top: '50px' }\">\n        <a-dropdown\n          open\n          :menu=\"{ items }\"\n          :styles=\"{ root: { width: '200px', zIndex: 1 } }\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        >\n          <a @click.prevent>\n            <a-space>\n              Hover me\n              <DownOutlined />\n            </a-space>\n          </a>\n        </a-dropdown>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "itemTitle",
+          "description": "Title content area of dropdown option, sets layout and text styles",
+          "descriptionZh": "dropdown 选项的标题内容区域，设置布局和文字样式"
+        },
+        {
+          "key": "item",
+          "description": "Individual dropdown option element, sets interaction states and background styles",
+          "descriptionZh": "dropdown 的单个选项元素，设置选项的交互状态和背景样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Main content area of dropdown option, sets content layout and link styles",
+          "descriptionZh": "dropdown 选项的主要内容区域，设置内容布局和链接样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Icon area of dropdown option, sets icon size and spacing styles",
+          "descriptionZh": "dropdown 选项的图标区域，设置图标的尺寸和间距样式"
         }
       ]
     },
@@ -8826,14 +9247,28 @@
           "description": "Hide default description.",
           "descriptionZh": "隐藏默认描述。",
           "code": "<template>\n  <a-empty :description=\"false\" />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets text alignment, font and line height styles",
+          "descriptionZh": "根元素，设置文本对齐、字体和行高样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'image', desc: t('image'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Empty\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-empty\n        :image=\"1\"\n        :styles=\"{ image: { height: '60px' } }\"\n        :classes=\"classes\"\n      >\n        <template #description>\n          <a-typography-text>\n            Customize <a href=\"#API\">Description</a>\n          </a-typography-text>\n        </template>\n        <a-button type=\"primary\">\n          Create Now\n        </a-button>\n      </a-empty>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "image",
+          "description": "Image element, sets height, opacity, margin and image styles",
+          "descriptionZh": "图标元素，设置高度、透明度、边距和图片样式"
+        },
+        {
+          "key": "description",
+          "description": "Description element, sets text color styles",
+          "descriptionZh": "描述元素，设置文本颜色样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element, sets top margin and action button styles",
+          "descriptionZh": "底部元素，设置顶部边距和操作按钮样式"
         }
       ]
     },
@@ -8943,7 +9378,8 @@
           "descriptionZh": "嵌套使用，可以实现更复杂的布局。",
           "code": "<script setup lang=\"ts\">\nimport type { CSSProperties } from 'vue'\n\nconst cardStyle: CSSProperties = {\n  width: '620px',\n}\nconst imgStyle: CSSProperties = {\n  display: 'block',\n  width: '273px',\n}\n</script>\n\n<template>\n  <a-card :style=\"cardStyle\" :styles=\"{ body: { padding: 0, overflow: 'hidden' } }\">\n    <a-flex justify=\"space-between\">\n      <img\n        alt=\"avatar\"\n        src=\"https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png\"\n        :style=\"imgStyle\"\n      >\n      <a-flex vertical align=\"flex-end\" justify=\"space-between\" :style=\"{ padding: '32px' }\">\n        <a-typography>\n          <a-typography-title :level=\"3\">\n            “antd is an enterprise-class UI design language and Vue UI library.”\n          </a-typography-title>\n        </a-typography>\n        <a-button type=\"primary\" href=\"https://antdv.com\" target=\"_blank\">\n          Get Start\n        </a-button>\n      </a-flex>\n    </a-flex>\n  </a-card>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "FloatButton",
@@ -9352,22 +9788,63 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of FloatButton by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 FloatButton 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { FloatButtonProps } from 'antdv-next'\nimport { QuestionCircleOutlined } from '@antdv-next/icons'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: FloatButtonProps['classes'] = {\n  root: 'demo-float-button-root',\n  content: 'demo-float-button-content',\n}\n\nconst stylesObject: FloatButtonProps['styles'] = {\n  root: {\n    boxShadow: '0 1px 2px 0 rgba(0,0,0,0.05)',\n  },\n}\n\nconst stylesFn: FloatButtonProps['styles'] = (info) => {\n  if (info?.props?.type === 'primary') {\n    return {\n      root: {\n        backgroundColor: '#171717',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-float-button-group shape=\"circle\" style=\"inset-inline-end: 94px;\">\n    <a-float-button\n      type=\"primary\"\n      :classes=\"classes\"\n      href=\"https://ant.design/index-cn\"\n      :styles=\"stylesFn\"\n    >\n      <template #tooltip>\n        <div>custom style class</div>\n      </template>\n    </a-float-button>\n    <a-float-button\n      type=\"default\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n    >\n      <template #icon>\n        <QuestionCircleOutlined />\n      </template>\n    </a-float-button>\n  </a-float-button-group>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with float button base styles, shape size, type theme, fixed positioning, z-index, shadow, spacing and other container styles",
+          "descriptionZh": "根元素，设置悬浮按钮的基础样式、形状尺寸、类型主题、固定定位、层级、阴影、间距等容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { QuestionCircleOutlined } from '@antdv-next/icons'\nimport { FloatButton } from 'antdv-next'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst PurePanel = (FloatButton as any)._InternalPanelDoNotUseOrYouWillBeFired\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'icon', desc: t('icon') },\n  { name: 'content', desc: t('content') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"FloatButton\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <PurePanel\n        type=\"primary\"\n        shape=\"square\"\n        content=\"HELP\"\n        :classes=\"classes\"\n      >\n        <template #icon>\n          <QuestionCircleOutlined />\n        </template>\n      </PurePanel>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "content",
+          "description": "Content element with button text content font size, color, alignment, line wrap and other text display styles",
+          "descriptionZh": "内容元素，设置按钮内文字内容的字体大小、颜色、对齐、换行等文本显示样式"
         },
         {
-          "name": "_semantic_group",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AlertOutlined, BugOutlined, BulbOutlined } from '@antdv-next/icons'\nimport { FloatButton } from 'antdv-next'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst PurePanel = (FloatButton as any)._InternalPanelDoNotUseOrYouWillBeFired\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('group.root') },\n  { name: 'list', desc: t('group.list') },\n  { name: 'item', desc: t('group.item') },\n  { name: 'itemIcon', desc: t('group.itemIcon') },\n  { name: 'itemContent', desc: t('group.itemContent') },\n  { name: 'trigger', desc: t('group.trigger') },\n  { name: 'triggerIcon', desc: t('group.triggerIcon') },\n  { name: 'triggerContent', desc: t('group.triggerContent') },\n])\n\nconst items = [\n  {\n    icon: h(AlertOutlined),\n    content: 'warn',\n  },\n  {\n    icon: h(BugOutlined),\n    content: 'bug',\n  },\n  {\n    icon: h(BulbOutlined),\n    content: 'idea',\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"FloatButton\"\n    :semantics=\"semantics\"\n    :style=\"{ paddingTop: '100px' }\"\n  >\n    <template #default=\"{ classes }\">\n      <PurePanel\n        type=\"primary\"\n        shape=\"square\"\n        :items=\"items\"\n        trigger=\"hover\"\n        :open=\"true\"\n        content=\"back\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element with button icon size, color, line height, alignment and other icon display styles",
+          "descriptionZh": "图标元素，设置按钮内图标的尺寸、颜色、行高、对齐等图标显示样式"
+        },
+        {
+          "key": "group.root",
+          "description": "Root element with float button group container styles, fixed positioning, z-index, padding, gap, direction mode and other combined layout styles",
+          "descriptionZh": "根元素，设置悬浮按钮组的容器样式、固定定位、层级、内边距、间距、方向模式等组合布局样式"
+        },
+        {
+          "key": "group.list",
+          "description": "List element with button group list flex layout, border radius, shadow, animation transition, vertical alignment and other list container styles",
+          "descriptionZh": "列表元素，设置按钮组列表的Flex布局、圆角、阴影、动画过渡、垂直对齐等列表容器样式"
+        },
+        {
+          "key": "group.item",
+          "description": "Item element with individual float button styles, size, shape, type, state, icon content and other button base styles",
+          "descriptionZh": "列表项元素，设置单个悬浮按钮的样式、尺寸、形状、类型、状态、图标内容等按钮基础样式"
+        },
+        {
+          "key": "group.itemIcon",
+          "description": "Item icon element with float button icon size, color, alignment and other icon display styles",
+          "descriptionZh": "列表项图标元素，设置悬浮按钮内图标的尺寸、颜色、对齐等图标显示样式"
+        },
+        {
+          "key": "group.itemContent",
+          "description": "Item content element with float button text content, badge, description and other content area styles",
+          "descriptionZh": "列表项内容元素，设置悬浮按钮内文字内容、徽标、描述等内容区域样式"
+        },
+        {
+          "key": "group.trigger",
+          "description": "Trigger element with menu mode trigger button styles, shape, icon, hover state, expand/collapse state and other interaction styles",
+          "descriptionZh": "触发元素，设置菜单模式下触发按钮的样式、形状、图标、悬停态、展开收起状态等交互样式"
+        },
+        {
+          "key": "group.triggerIcon",
+          "description": "Trigger icon element with trigger button icon styles, rotation animation, toggle state and other icon interaction styles",
+          "descriptionZh": "触发图标元素，设置触发按钮内图标的样式、旋转动画、切换状态等图标交互样式"
+        },
+        {
+          "key": "group.triggerContent",
+          "description": "Trigger content element with trigger button content area text, identifier, state indicator and other content styles",
+          "descriptionZh": "触发内容元素，设置触发按钮内容区域的文字、标识、状态指示等内容样式"
         }
       ]
     },
@@ -10381,14 +10858,38 @@
           "description": "Label ellipsis debug.",
           "descriptionZh": "label 省略展示调试。",
           "code": "<script setup lang=\"ts\">\nimport { reactive } from 'vue'\n\nconst model = reactive({\n  username: '',\n  password: '',\n})\n</script>\n\n<template>\n  <a-form\n    name=\"label-ellipsis\"\n    :model=\"model\"\n    :label-col=\"{ span: 8 }\"\n    :wrapper-col=\"{ span: 16 }\"\n    style=\"max-width: 600px\"\n  >\n    <a-form-item name=\"username\">\n      <template #label>\n        <a-typography-text ellipsis>\n          longtextlongtextlongtextlongtextlongtextlongtextlongtext\n        </a-typography-text>\n      </template>\n      <a-input v-model:value=\"model.username\" />\n    </a-form-item>\n\n    <a-form-item name=\"password\">\n      <template #label>\n        <a-typography-text ellipsis>\n          longtext longtext longtext longtext longtext longtext longtext\n        </a-typography-text>\n      </template>\n      <a-input-password v-model:value=\"model.password\" />\n    </a-form-item>\n  </a-form>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with form item margin-bottom, vertical-align, transitions, hidden states, error/warning states and other basic form item container styles",
+          "descriptionZh": "根元素，包含表单项的底边距、垂直对齐、过渡动画、隐藏状态、错误警告状态等表单项容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport type { FormInstance } from 'antdv-next'\nimport { computed, onMounted, shallowRef } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst formRef = shallowRef<FormInstance>()\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'help', desc: t('help'), version: '1.3.0' },\n  { name: 'helpItem', desc: t('helpItem'), version: '1.3.0' },\n  { name: 'extra', desc: t('extra'), version: '1.3.0' },\n])\n\nonMounted(() => {\n  formRef.value?.setFields?.([\n    {\n      name: 'password',\n      errors: ['Please input your password!', 'Use at least 8 characters.'],\n    },\n  ])\n})\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Form\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-form\n        ref=\"formRef\"\n        name=\"basic\"\n        :label-col=\"{ span: 8 }\"\n        :wrapper-col=\"{ span: 16 }\"\n        :style=\"{ maxWidth: '600px' }\"\n        :initial-values=\"{ remember: true }\"\n        autocomplete=\"off\"\n        :classes=\"classes\"\n      >\n        <a-form-item\n          label=\"Username\"\n          name=\"username\"\n          help=\"Use 4 to 16 characters.\"\n          :rules=\"[{ required: true, message: 'Please input your username!' }]\"\n        >\n          <a-input />\n        </a-form-item>\n        <a-form-item\n          label=\"Password\"\n          name=\"password\"\n          extra=\"Password must contain letters and numbers.\"\n          :rules=\"[\n            { required: true, message: 'Please input your password!' },\n            { min: 8, message: 'Use at least 8 characters.' },\n          ]\"\n        >\n          <a-input-password />\n        </a-form-item>\n      </a-form>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "label",
+          "description": "Label element with flex layout, overflow hidden, whitespace nowrap, text alignment, vertical alignment, plus label color, font size, height, required marks and other label display styles",
+          "descriptionZh": "标签元素，包含 flex 布局、溢出隐藏、文本不换行、文本对齐、垂直对齐，以及标签的颜色、字体大小、高度、必填标记等标签显示样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with form content area layout, styling and control container related styles",
+          "descriptionZh": "内容元素，包含表单内容区域的布局、样式和控件容器的相关样式"
+        },
+        {
+          "key": "help",
+          "description": "Help container element with spacing, motion, and presentation styles for help and validation areas",
+          "descriptionZh": "帮助信息容器元素，包含帮助文案与校验信息区域的间距、过渡与展示样式"
+        },
+        {
+          "key": "helpItem",
+          "description": "Single help message item with typography styles for prompt, error, and warning text",
+          "descriptionZh": "帮助信息单项元素，包含错误、警告与提示文案的排版样式"
+        },
+        {
+          "key": "extra",
+          "description": "Extra prompt container element with spacing, color, and typography styles for supplementary text",
+          "descriptionZh": "额外提示容器元素，包含补充说明文案的间距、颜色与排版样式"
         }
       ]
     },
@@ -10666,7 +11167,8 @@
           "descriptionZh": "使用 `useBreakpoint` Hook 实现个性化布局，其中 `xs` 仅当满足最小宽度时生效。",
           "code": "<script setup lang=\"ts\">\nimport { useBreakpoint } from 'antdv-next'\nimport { computed } from 'vue'\n\nconst screens = useBreakpoint()\nconst screenKeys = computed(() => Object.entries(screens.value ?? {}).filter(screen => !!screen[1]))\n</script>\n\n<template>\n  Current break point:\n  <div class=\"gap-2 inline-flex\">\n    <template v-for=\"item in screenKeys\" :key=\"item[0]\">\n      <a-tag color=\"blue\">\n        {{ item[0] }}\n      </a-tag>\n    </template>\n  </div>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Icon",
@@ -10729,7 +11231,8 @@
           "descriptionZh": "`scriptUrl` 可引用多个资源，用户可灵活的管理 [iconfont.cn](http://iconfont.cn/) 图标。如果资源的图标出现重名，会按照数组顺序进行覆盖。",
           "code": "<script setup lang=\"ts\">\nimport { createFromIconfontCN } from '@antdv-next/icons'\n\nconst IconFont = createFromIconfontCN({\n  scriptUrl: [\n    '//at.alicdn.com/t/font_1788044_0dwu4guekcwr.js', // icon-javascript, icon-java, icon-shoppingcart (overridden)\n    '//at.alicdn.com/t/font_1788592_a5xf2bdic3u.js', // icon-shoppingcart, icon-python\n  ],\n})\n</script>\n\n<template>\n  <a-space>\n    <IconFont type=\"icon-javascript\" />\n    <IconFont type=\"icon-java\" />\n    <IconFont type=\"icon-shoppingcart\" />\n    <IconFont type=\"icon-python\" />\n  </a-space>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Image",
@@ -10956,14 +11459,53 @@
           "description": "Nested in the modal.",
           "descriptionZh": "嵌套在弹框当中使用。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst show1 = ref(false)\nconst show2 = ref(false)\nconst show3 = ref(false)\n\nfunction handlePreviewGroupChange(current: number, prev: number) {\n  console.log(`current index: ${current}, prev index: ${prev}`)\n}\n</script>\n\n<template>\n  <a-button @click=\"show1 = true\">\n    showModal\n  </a-button>\n  <a-modal\n    v-model:open=\"show1\"\n    @cancel=\"show1 = false\"\n    @ok=\"show1 = false\"\n  >\n    <a-button @click=\"show2 = true\">\n      test2\n    </a-button>\n    <a-modal\n      v-model:open=\"show2\"\n      @cancel=\"show2 = false\"\n      @ok=\"show2 = false\"\n    >\n      <a-button @click=\"show3 = true\">\n        test3\n      </a-button>\n      <a-modal\n        v-model:open=\"show3\"\n        @cancel=\"show3 = false\"\n        @ok=\"show3 = false\"\n      >\n        <a-image\n          :width=\"200\"\n          alt=\"svg image\"\n          src=\"https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg\"\n        />\n        <a-divider />\n        <a-image-preview-group\n          :preview=\"{\n            onChange: handlePreviewGroupChange,\n          }\"\n        >\n          <a-image\n            :width=\"200\"\n            alt=\"svg image\"\n            src=\"https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg\"\n          />\n          <a-image\n            :width=\"200\"\n            src=\"https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg\"\n          />\n        </a-image-preview-group>\n      </a-modal>\n    </a-modal>\n  </a-modal>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets relative positioning and inline-block layout styles",
+          "descriptionZh": "根元素，设置相对定位和行内块布局样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { theme } from 'antdv-next'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'image', desc: t('image') },\n  { name: 'cover', desc: t('cover') },\n  { name: 'popup.root', desc: t('popup.root') },\n  { name: 'popup.mask', desc: t('popup.mask') },\n  { name: 'popup.body', desc: t('popup.body') },\n  { name: 'popup.footer', desc: t('popup.footer') },\n  { name: 'popup.actions', desc: t('popup.actions') },\n  { name: 'popup.close', desc: t('popup.close'), version: '1.3.0' },\n])\n\nconst { token } = theme.useToken()\nconst holderRef = ref<HTMLDivElement | null>(null)\n\nconst previewItems = [\n  'https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg',\n  'https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg',\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Image\"\n    :padding=\"false\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical align=\"center\" :style=\"{ minHeight: '100%', width: '100%' }\">\n        <a-flex :style=\"{ padding: `${token.padding}px`, flex: 'none' }\" justify=\"center\">\n          <a-image\n            :width=\"200\"\n            src=\"https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png\"\n            :classes=\"classes\"\n          />\n        </a-flex>\n        <div ref=\"holderRef\" :style=\"{ flex: 1, position: 'relative', minHeight: '500px', width: '100%' }\">\n          <a-image-preview-group\n            :items=\"previewItems\"\n            :classes=\"classes\"\n            :styles=\"{ popup: { root: { position: 'absolute' } } }\"\n            :preview=\"{ getContainer: () => holderRef!, open: true, focusTrap: false }\"\n          />\n        </div>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "image",
+          "description": "Image element, sets width, height and vertical alignment styles",
+          "descriptionZh": "图片元素，设置宽度、高度和垂直对齐样式"
+        },
+        {
+          "key": "cover",
+          "description": "Image hover display prompt element, sets absolute positioning, background color, opacity and transition animation styles",
+          "descriptionZh": "悬浮图片显示的提示元素，设置绝对定位、背景色、透明度和过渡动画样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Preview root element, sets fixed positioning, z-index and background mask styles",
+          "descriptionZh": "预览根元素，设置固定定位、层级和背景遮罩样式"
+        },
+        {
+          "key": "popup.mask",
+          "description": "Preview mask element, sets absolute positioning and semi-transparent background styles",
+          "descriptionZh": "预览遮罩元素，设置绝对定位和半透明背景样式"
+        },
+        {
+          "key": "popup.body",
+          "description": "Preview body element, sets flex layout, center alignment and pointer event styles",
+          "descriptionZh": "预览内容元素，设置flex布局、居中对齐和指针事件样式"
+        },
+        {
+          "key": "popup.footer",
+          "description": "Preview footer element, sets absolute positioning, center layout and bottom operation area styles",
+          "descriptionZh": "预览页脚元素，设置绝对定位、居中布局和底部操作区域样式"
+        },
+        {
+          "key": "popup.actions",
+          "description": "Preview actions group element, sets flex layout, background color, border radius and action button styles",
+          "descriptionZh": "预览操作组元素，设置flex布局、背景色、圆角和操作按钮样式"
+        },
+        {
+          "key": "popup.close",
+          "description": "Preview close button element, sets basic button styles",
+          "descriptionZh": "预览关闭按钮元素，设置按钮的基础样式"
         }
       ]
     },
@@ -11686,46 +12228,73 @@
           "description": "You can customize the [semantic dom](#semantic-input) style of Input by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Input 的[语义化结构](#semantic-input)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { InputOTPProps, InputPasswordProps, InputProps, InputSearchProps, TextAreaProps } from 'antdv-next'\n\nconst classes: InputProps['classes'] = {\n  root: 'effect',\n}\n\nconst stylesFn: InputProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      root: {\n        borderColor: '#696FC7',\n      },\n    } satisfies InputProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnTextArea: TextAreaProps['styles'] = (info) => {\n  if (info.props.showCount) {\n    return {\n      root: { borderColor: '#BDE3C3' },\n      textarea: { resize: 'none' },\n      count: { color: '#BDE3C3' },\n    } satisfies TextAreaProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnPassword: InputPasswordProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      root: {\n        borderColor: '#F5D3C4',\n      },\n    } satisfies InputPasswordProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnOTP: InputOTPProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      root: {\n        borderWidth: 0,\n      },\n      input: {\n        borderColor: '#6E8CFB',\n        width: '32px',\n      },\n    } satisfies InputOTPProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnSearch: InputSearchProps['styles'] = (info) => {\n  if (info.props.size === 'large') {\n    return {\n      root: { color: '#4DA8DA', borderWidth: 0 },\n      input: { color: '#4DA8DA', borderColor: '#4DA8DA' },\n      prefix: { color: '#4DA8DA' },\n      suffix: { color: '#4DA8DA' },\n      count: { color: '#4DA8DA' },\n      button: {\n        root: { color: '#4DA8DA', borderColor: '#4DA8DA' },\n        icon: { color: '#4DA8DA' },\n      },\n    } satisfies InputSearchProps['styles']\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-input :classes=\"classes\" placeholder=\"Object\" name=\"input-object\" />\n    <a-input :classes=\"classes\" :styles=\"stylesFn\" placeholder=\"Function\" size=\"middle\" name=\"input-fn\" />\n    <a-textarea :classes=\"classes\" :styles=\"stylesFnTextArea\" placeholder=\"Textarea\" show-count name=\"textarea-fn\" />\n    <a-input-password :classes=\"classes\" :styles=\"stylesFnPassword\" placeholder=\"Password\" size=\"middle\" name=\"password-fn\" />\n    <a-input-otp :classes=\"classes\" :styles=\"stylesFnOTP\" size=\"middle\" :length=\"6\" separator=\"*\" name=\"otp-fn\" />\n    <a-input-search :classes=\"classes\" :styles=\"stylesFnSearch\" placeholder=\"Search\" size=\"large\" name=\"search-fn\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-block display, width, min-width, padding, colors, fonts, line-height, border-radius, transitions and other input container basic styles",
+          "descriptionZh": "根元素，包含相对定位、行内块布局、宽度、最小宽度、内边距、颜色、字体、行高、圆角、过渡动画等输入框容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'count', desc: t('count') },\n  { name: 'clear', desc: t('clear'), version: '1.3.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Input\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-input\n          default-value=\"Hello, Antdv-Next\"\n          show-count\n          allow-clear\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <UserOutlined />\n          </template>\n          <template #suffix>\n            <EditOutlined />\n          </template>\n        </a-input>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "input",
+          "description": "Input element with core interactive styles and text input related styling",
+          "descriptionZh": "输入框元素，包含输入框的核心交互样式和文本输入相关的样式"
         },
         {
-          "name": "_semantic-textarea",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('TextAreaRoot') },\n  { name: 'textarea', desc: t('textarea') },\n  { name: 'count', desc: t('TextAreaCount') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"TextArea\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-textarea\n          default-value=\"Hello, Antdv-Next\"\n          :maxlength=\"100\"\n          show-count\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix wrapper element with layout and styling for prefix content",
+          "descriptionZh": "前缀的包裹元素，包含前缀内容的布局和样式"
         },
         {
-          "name": "_semantic-search",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'count', desc: t('count') },\n  { name: 'button.root', desc: t('button.root') },\n  { name: 'button.icon', desc: t('button.icon') },\n  { name: 'button.content', desc: t('button.content') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputSearch\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-input-search\n          default-value=\"Hello, Antdv-Next\"\n          enter-button=\"Searching...\"\n          loading\n          show-count\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <UserOutlined />\n          </template>\n          <template #suffix>\n            <EditOutlined />\n          </template>\n        </a-input-search>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "suffix",
+          "description": "Suffix wrapper element with layout and styling for suffix content",
+          "descriptionZh": "后缀的包裹元素，包含后缀内容的布局和样式"
         },
         {
-          "name": "_semantic-password",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'count', desc: t('count') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputPassword\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-input-password\n          default-value=\"Hello, Antdv-Next\"\n          show-count\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <UserOutlined />\n          </template>\n          <template #suffix>\n            <EditOutlined />\n          </template>\n        </a-input-password>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "count",
+          "description": "Character count element with font and color styles for count display",
+          "descriptionZh": "文字计数元素，包含字符计数显示的字体和颜色样式"
         },
         {
-          "name": "_semantic-otp",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'input', desc: t('input') },\n  { name: 'separator', desc: t('OTPSeparator') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputOTP\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-input-otp\n        :length=\"6\"\n        separator=\"-\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "clear",
+          "description": "Clear button element with color, size, hover state and transition animation styles",
+          "descriptionZh": "清除按钮元素，包含清除按钮的颜色、尺寸、悬浮态和过渡动画等样式"
+        },
+        {
+          "key": "TextAreaRoot",
+          "description": "Root element with textarea wrapper styles, border, border radius, transition animation and state control",
+          "descriptionZh": "根元素，设置文本域包装器的样式、边框、圆角、过渡动画和状态控制"
+        },
+        {
+          "key": "textarea",
+          "description": "Textarea element with font, line height, padding, color, background, border, text input and multi-line text display styles",
+          "descriptionZh": "文本域元素，设置字体、行高、内边距、颜色、背景、边框、文本输入和多行文本展示样式"
+        },
+        {
+          "key": "TextAreaCount",
+          "description": "Count element with character count display position, font, color and numeric statistics styles",
+          "descriptionZh": "文字计数元素，设置字符计数显示的位置、字体、颜色和数值统计样式"
+        },
+        {
+          "key": "button.root",
+          "description": "Search button root element with button styles, hover effects and click interactions",
+          "descriptionZh": "搜索按钮的根元素，设置按钮的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "button.icon",
+          "description": "Search button icon element with icon styles, hover effects and click interactions",
+          "descriptionZh": "搜索按钮的图标元素，设置图标的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "button.content",
+          "description": "Search button content element with text styles, hover effects and click interactions",
+          "descriptionZh": "搜索按钮的内容元素，设置文本的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "OTPSeparator",
+          "description": "Separator element, set separator display styles between OTP input boxes",
+          "descriptionZh": "分隔符元素，设置OTP输入框之间的分隔符显示样式"
         }
       ]
     },
@@ -12307,14 +12876,38 @@
           "description": "Suffix with form feedback debug.",
           "descriptionZh": "带反馈图标时展示后缀 Debug。",
           "code": "<script setup lang=\"ts\">\n</script>\n\n<template>\n  <a-form layout=\"vertical\" :style=\"{ maxWidth: '320px' }\">\n    <a-form-item label=\"Suffix with feedback\" validate-status=\"success\" has-feedback>\n      <a-input-number :default-value=\"100\" suffix=\"RMB\" :style=\"{ width: '100%' }\" />\n    </a-form-item>\n  </a-form>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets inline-block layout, width, border radius and reset styles",
+          "descriptionZh": "根元素，设置行内块布局、宽度、边框圆角和重置样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'actions', desc: t('actions') },\n  { name: 'action', desc: t('action') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputNumber\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ display: 'flex', flexDirection: 'column', gap: '16px' }\">\n        <a-input-number\n          prefix=\"￥\"\n          suffix=\"RMB\"\n          :default-value=\"100\"\n          :style=\"{ width: '200px' }\"\n          :styles=\"{ actions: { opacity: 1, width: '24px' }, suffix: { marginRight: '28px' } }\"\n          :classes=\"classes\"\n        />\n        <a-input-number\n          :default-value=\"100\"\n          :style=\"{ width: '200px' }\"\n          :styles=\"{ actions: { opacity: 1, width: '24px' }, suffix: { marginRight: '28px' } }\"\n          mode=\"spinner\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "input",
+          "description": "Input element, sets font, line height, text input and interaction styles",
+          "descriptionZh": "输入框元素，设置字体、行高、文本输入和交互样式"
+        },
+        {
+          "key": "prefix",
+          "description": "Prefix wrapper element, sets flex layout, alignment and right margin styles",
+          "descriptionZh": "前缀的包裹元素，设置flex布局、对齐方式和右边距样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix wrapper element, sets flex layout, margin and transition animation styles",
+          "descriptionZh": "后缀的包裹元素，设置flex布局、边距和过渡动画样式"
+        },
+        {
+          "key": "action",
+          "description": "Single action button element, sets button styling, hover effects and click interactions",
+          "descriptionZh": "单个操作按钮元素，设置按钮的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element, sets absolute positioning, width, flex layout and number adjustment button styles",
+          "descriptionZh": "操作元素，设置绝对定位、宽度、flex布局和数值调节按钮样式"
         }
       ]
     },
@@ -12652,7 +13245,8 @@
           "descriptionZh": "当内容较长时，使用固定侧边栏可以提供更好的体验。",
           "code": "<script setup lang=\"ts\">\nimport type { MenuItemType } from 'antdv-next'\nimport type { CSSProperties } from 'vue'\nimport {\n  AppstoreOutlined,\n  BarChartOutlined,\n  CloudOutlined,\n  ShopOutlined,\n  TeamOutlined,\n  UploadOutlined,\n  UserOutlined,\n  VideoCameraOutlined,\n} from '@antdv-next/icons'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\nconst year = new Date().getFullYear()\n\nconst siderStyle: CSSProperties = {\n  overflow: 'auto',\n  height: '100vh',\n  position: 'sticky',\n  insetInlineStart: 0,\n  top: 0,\n  scrollbarWidth: 'thin',\n  scrollbarGutter: 'stable',\n}\n\nconst items: MenuItemType[] = [\n  UserOutlined,\n  VideoCameraOutlined,\n  UploadOutlined,\n  BarChartOutlined,\n  CloudOutlined,\n  AppstoreOutlined,\n  TeamOutlined,\n  ShopOutlined,\n].map((icon, index) => ({\n  key: String(index + 1),\n  icon,\n  label: `nav ${index + 1}`,\n}))\n</script>\n\n<template>\n  <a-layout :has-sider=\"true\">\n    <a-layout-sider :style=\"siderStyle\">\n      <div class=\"demo-logo-vertical\" />\n      <a-menu\n        theme=\"dark\"\n        mode=\"inline\"\n        :default-selected-keys=\"['4']\"\n        :items=\"items\"\n      />\n    </a-layout-sider>\n    <a-layout>\n      <a-layout-header class=\"fixed-header\" :style=\"{ background: token.colorBgContainer }\" />\n      <a-layout-content class=\"fixed-content\">\n        <div\n          class=\"fixed-content-box\"\n          :style=\"{\n            background: token.colorBgContainer,\n            borderRadius: `${token.borderRadiusLG}px`,\n          }\"\n        >\n          <p>long content</p>\n          <template v-for=\"index in 100\" :key=\"index\">\n            {{ index % 20 === 0 && index !== 0 ? 'more' : '...' }}\n            <br>\n          </template>\n        </div>\n      </a-layout-content>\n      <a-layout-footer class=\"fixed-footer\">\n        Antdv Next ©{{ year }} Created by Ant UED\n      </a-layout-footer>\n    </a-layout>\n  </a-layout>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Masonry",
@@ -12774,14 +13368,18 @@
           "description": "When `fresh` is enabled, the masonry will continuously monitor size changes of child items and automatically re-layout. Click on cards to change their height.",
           "descriptionZh": "开启 `fresh` 属性后，瀑布流会持续监听子项的尺寸变化并自动重新布局。点击卡片可以改变其高度。",
           "code": "<script setup lang=\"ts\">\nimport { Card } from 'antdv-next'\nimport { defineComponent, h, ref } from 'vue'\n\nconst RandomHeightCard = defineComponent({\n  props: {\n    index: {\n      type: Number,\n      required: true,\n    },\n    defaultHeight: {\n      type: Number,\n      required: true,\n    },\n  },\n  setup(props) {\n    const height = ref(props.defaultHeight)\n\n    const handleClick = () => {\n      height.value = Math.floor(Math.random() * 100) + 50\n    }\n\n    return () =>\n      h(\n        Card,\n        {\n          size: 'small',\n          style: { height: `${height.value}px`, transition: 'height 0.3s' },\n          onClick: handleClick,\n        },\n        () => `${props.index + 1} - Click`,\n      )\n  },\n})\n\nconst heights = [150, 50, 90, 70, 110, 150, 130, 80, 50, 90, 100, 150, 60, 50, 80].map(\n  (height, index) => {\n    const item: {\n      key: string\n      data: number\n      column?: number\n    } = {\n      key: `item-${index}`,\n      data: height,\n    }\n\n    if (index === 4) {\n      item.column = 0\n    }\n\n    return item\n  },\n)\n</script>\n\n<template>\n  <a-masonry\n    fresh\n    :columns=\"4\"\n    :gutter=\"16\"\n    :items=\"heights\"\n  >\n    <template #itemRender=\"{ data, index }\">\n      <RandomHeightCard :index=\"index\" :default-height=\"data\" />\n    </template>\n  </a-masonry>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets relative positioning, flex layout and masonry container styles",
+          "descriptionZh": "根元素，设置相对定位、flex布局和瀑布流容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n])\n\nconst heights = [75, 50, 70, 60, 85, 75, 50].map((height, index) => ({\n  key: `item-${index}`,\n  data: height,\n}))\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Masonry\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-masonry\n        :columns=\"3\"\n        :gutter=\"16\"\n        :items=\"heights\"\n        style=\"width: 100%\"\n        :classes=\"classes\"\n      >\n        <template #itemRender=\"{ data, index }\">\n          <a-card size=\"small\" :style=\"{ height: data }\">\n            {{ index + 1 }}\n          </a-card>\n        </template>\n      </a-masonry>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element, sets absolute positioning, width calculation, transition animation and masonry item styles",
+          "descriptionZh": "条目元素，设置绝对定位、宽度计算、过渡动画和瀑布流项目样式"
         }
       ]
     },
@@ -13172,14 +13770,28 @@
           "description": "autoSize debug",
           "descriptionZh": "autoSize debug",
           "code": "<script setup lang=\"ts\">\nimport type { MentionsEmits, MentionsProps } from 'antdv-next'\n\nconst options: MentionsProps['options'] = [\n  {\n    value: 'afc163',\n    label: 'afc163',\n  },\n  {\n    value: 'zombieJ',\n    label: 'zombieJ',\n  },\n  {\n    value: 'yesmeck',\n    label: 'yesmeck',\n  },\n]\n\nconst handleChange: MentionsEmits['change'] = (value) => {\n  console.log('Change:', value)\n}\n\nconst handleSelect: MentionsEmits['select'] = (option) => {\n  console.log('select', option)\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-mentions\n      placeholder=\"can resize\"\n      :options=\"options\"\n      @change=\"handleChange\"\n      @select=\"handleSelect\"\n    />\n    <a-mentions\n      placeholder=\"disable resize\"\n      :options=\"options\"\n      :style=\"{ resize: 'none' }\"\n      @change=\"handleChange\"\n      @select=\"handleSelect\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set inline flex layout, relative positioning, padding and border styles",
+          "descriptionZh": "根元素，设置行内flex布局、相对定位、内边距和边框样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'textarea', desc: t('textarea'), version: '1.0.0' },\n  { name: 'suffix', desc: t('suffix'), version: '1.0.0' },\n  { name: 'popup', desc: t('popup'), version: '1.0.0' },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst options = [\n  { value: 'afc163', label: 'afc163' },\n  { value: 'zombieJ', label: 'zombieJ' },\n  { value: 'thinkasany', label: 'thinkasany' },\n  { value: 'meet-student', label: 'meet-student' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Mentions\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <a-mentions\n          placement=\"bottom\"\n          :style=\"{ width: '100%' }\"\n          value=\"Hi, @\"\n          allow-clear\n          open\n          :get-popup-container=\"() => divRef!\"\n          :options=\"options\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "textarea",
+          "description": "Textarea element, set font, line height, text input and background styles",
+          "descriptionZh": "文本域元素，设置字体、行高、文本输入和背景样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup element, set absolute positioning, z-index, background color, border radius, shadow and dropdown options styles",
+          "descriptionZh": "弹出框元素，设置绝对定位、层级、背景色、圆角、阴影和下拉选项样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with layout and styling for suffix content like clear button, etc.",
+          "descriptionZh": "后缀元素，包含后缀内容的布局和样式，如清除按钮等"
         }
       ]
     },
@@ -13921,14 +14533,68 @@
           "description": "Use the `popupRender` prop to customize submenu popup rendering.",
           "descriptionZh": "使用 `popupRender` 属性自定义弹出菜单的渲染。",
           "code": "<script setup lang=\"ts\">\nimport type { MenuItemType, MenuProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\nimport { computed, h } from 'vue'\n\nconst { token } = theme.useToken()\n\nconst popupStyle = computed(() => ({\n  padding: `${token.value.padding}px`,\n  minWidth: '480px',\n  background: token.value.colorBgElevated,\n  borderRadius: `${token.value.borderRadiusLG}px`,\n  boxShadow: token.value.boxShadowSecondary,\n}))\n\nconst headerStyle = computed(() => ({\n  margin: 0,\n  paddingBottom: `${token.value.paddingXS}px`,\n  borderBottom: `1px solid ${token.value.colorSplit}`,\n}))\n\nconst cardStyle = computed(() => ({\n  padding: `${token.value.paddingSM}px`,\n}))\n\nconst cardItemStyle = computed(() => ({\n  borderRadius: `${token.value.borderRadius}px`,\n  transition: `all ${token.value.motionDurationSlow}`,\n  cursor: 'pointer',\n}))\n\nfunction renderMenuCard(title: string, description: string) {\n  return h('div', { class: 'menu-card', style: cardStyle.value }, [\n    h('div', { class: 'menu-card-title' }, title),\n    h('div', { class: 'menu-card-desc' }, description),\n  ])\n}\n\nconst menuItems = computed<MenuItemType[]>(() => [\n  {\n    key: 'home',\n    label: 'Home',\n  },\n  {\n    key: 'features',\n    label: 'Features',\n    children: [\n      {\n        key: 'getting-started',\n        label: renderMenuCard('Getting Started', 'Quick start guide and learn the basics.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n      {\n        key: 'components',\n        label: renderMenuCard('Components', 'Explore our component library.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n      {\n        key: 'templates',\n        label: renderMenuCard('Templates', 'Ready-to-use template designs.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n    ],\n  },\n  {\n    key: 'resources',\n    label: 'Resources',\n    children: [\n      {\n        key: 'blog',\n        label: renderMenuCard('Blog', 'Latest updates and articles.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n      {\n        key: 'community',\n        label: renderMenuCard('Community', 'Join our developer community.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n    ],\n  },\n])\n\nconst popupRender: MenuProps['popupRender'] = (node, info) => {\n  const title = info.item.title || info.item.key\n  return h('div', { class: 'menu-popup', style: popupStyle.value }, [\n    h('div', { class: 'menu-popup-title', style: headerStyle.value }, title),\n    node,\n  ])\n}\n\nconst themeConfig = {\n  components: {\n    Menu: {\n      popupBg: '#fff',\n      horizontalItemSelectedColor: '#1677ff',\n      horizontalItemHoverColor: '#1677ff',\n    },\n  },\n}\n</script>\n\n<template>\n  <a-config-provider :theme=\"themeConfig\">\n    <a-menu mode=\"horizontal\" :items=\"menuItems\" :popup-render=\"popupRender\" />\n  </a-config-provider>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with basic menu container styles and layout",
+          "descriptionZh": "根元素，包含菜单容器的基础样式和布局"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AppstoreOutlined, MailOutlined } from '@antdv-next/icons'\nimport { computed, h, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst mode = ref<'horizontal' | 'vertical' | 'inline'>('horizontal')\nconst current = ref('mail')\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst semantics = computed(() => {\n  const baseLocale = [\n    { name: 'root', desc: t('root') },\n    { name: 'item', desc: t('item') },\n    { name: 'itemIcon', desc: t('itemIcon') },\n    { name: 'itemContent', desc: t('itemContent') },\n  ]\n  const subMenuLocale = [\n    { name: 'subMenu.itemTitle', desc: t('subMenu.itemTitle') },\n    { name: 'subMenu.list', desc: t('subMenu.list') },\n    { name: 'subMenu.item', desc: t('subMenu.item') },\n    { name: 'subMenu.itemIcon', desc: t('subMenu.itemIcon') },\n    { name: 'subMenu.itemContent', desc: t('subMenu.itemContent') },\n  ]\n  const groupLocale = [\n    { name: 'itemTitle', desc: t('itemTitle') },\n    { name: 'list', desc: t('list') },\n  ]\n\n  const additionalPopupLocale = mode.value !== 'inline' ? [{ name: 'popup', desc: t('popup') }] : []\n  const additionalGroupLocale = mode.value !== 'horizontal' ? groupLocale : []\n\n  return [...baseLocale, ...additionalGroupLocale, ...additionalPopupLocale, ...subMenuLocale]\n})\n\nconst items = [\n  { label: 'Navigation One', key: 'mail', icon: h(MailOutlined) },\n  {\n    key: 'SubMenu',\n    label: 'Navigation Two',\n    icon: h(AppstoreOutlined),\n    children: [\n      {\n        key: 'g1',\n        label: 'Item 1',\n        type: 'group',\n        children: [\n          { key: '1', label: 'Option 1', icon: h(MailOutlined) },\n          { key: '2', label: 'Option 2' },\n        ],\n      },\n    ],\n  },\n]\n\nconst groupItem = [\n  {\n    key: 'grp',\n    label: 'Navigation Three',\n    type: 'group',\n    children: [\n      { key: '3', label: 'Option 3' },\n      { key: '4', label: 'Option 4' },\n    ],\n  },\n]\n\nconst itemList = computed(() => {\n  return mode.value === 'horizontal' ? items : [...items, ...groupItem]\n})\n\nfunction onClick(e: { key: string }) {\n  current.value = e.key\n}\n\nfunction getPopupContainer() {\n  const el = ((divRef.value as any)?.$el ?? divRef.value) as HTMLElement | null\n  return el?.parentElement?.parentElement || el!\n}\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Menu\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" vertical gap=\"middle\" align=\"center\">\n        <a-segmented\n          :options=\"['horizontal', 'vertical', 'inline']\"\n          :value=\"mode\"\n          @change=\"(val: 'horizontal' | 'vertical' | 'inline') => mode = val\"\n        />\n        <div :style=\"{ height: '360px' }\">\n          <a-menu\n            :selected-keys=\"[current]\"\n            :mode=\"mode\"\n            :items=\"itemList\"\n            :styles=\"{\n              root: { width: mode === 'horizontal' ? '480px' : '230px' },\n              popup: { root: { zIndex: 1 } },\n            }\"\n            :open-keys=\"['SubMenu']\"\n            :get-popup-container=\"getPopupContainer\"\n            :classes=\"classes\"\n            @click=\"onClick\"\n          />\n        </div>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with relative positioning, block display, margins, whitespace handling, cursor styles, transitions and other basic interactive styles for menu items",
+          "descriptionZh": "条目元素，包含相对定位、块级显示、外边距、空白符处理、光标样式、过渡动画等菜单项的基础交互样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Item content element with layout and typography styles for menu item content",
+          "descriptionZh": "条目内容元素，包含菜单项内容的布局和排版样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Icon element with min-width, font-size, transitions, icon reset styles, and spacing control with text",
+          "descriptionZh": "图标元素，包含最小宽度、字体大小、过渡动画、图标重置样式，以及与文本的间距控制"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Item title element (no effect in horizontal mode) with title text styles and layout",
+          "descriptionZh": "菜单标题元素(horizontal 模式不生效)，包含标题文字的样式和布局"
+        },
+        {
+          "key": "list",
+          "description": "Menu list element (no effect in horizontal mode) with menu list layout and container styles",
+          "descriptionZh": "菜单列表元素(horizontal 模式不生效)，包含菜单列表的布局和容器样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup menu element (no effect in inline mode) with popup layer positioning, z-index, background and other styles",
+          "descriptionZh": "弹出菜单(inline 模式不生效)，包含弹出层的定位、层级、背景等样式"
+        },
+        {
+          "key": "subMenu.itemTitle",
+          "description": "Submenu title element with submenu title styles and interactive effects",
+          "descriptionZh": "子菜单标题元素，包含子菜单标题的样式和交互效果"
+        },
+        {
+          "key": "subMenu.list",
+          "description": "Submenu list element with submenu list layout and container styles",
+          "descriptionZh": "子菜单列表元素，包含子菜单列表的布局和容器样式"
+        },
+        {
+          "key": "subMenu.item",
+          "description": "Submenu item element with submenu item styles and interactive effects",
+          "descriptionZh": "子菜单单项元素，包含子菜单项的样式和交互效果"
+        },
+        {
+          "key": "subMenu.itemIcon",
+          "description": "Submenu item icon element with submenu icon size and styles",
+          "descriptionZh": "子菜单条目图标元素，包含子菜单图标的尺寸和样式"
+        },
+        {
+          "key": "subMenu.itemContent",
+          "description": "Submenu item content element with submenu content layout and typography",
+          "descriptionZh": "子菜单条目内容元素，包含子菜单内容的布局和排版"
         }
       ]
     },
@@ -14050,14 +14716,38 @@
           "description": "Static methods cannot consume Context provided by `ConfigProvider`. When enable `layer`, they may also cause style errors. Please use hooks version or `App` provided instance first.",
           "descriptionZh": "静态方法无法消费 Context，不能动态响应 ConfigProvider 提供的各项配置，启用 `layer` 时还可能导致样式异常。请优先使用 hooks 版本或者 App 组件提供的 `message` 实例。",
           "code": "<script setup lang=\"ts\">\nimport { message } from 'antdv-next'\n\nfunction info() {\n  message.info('This is an info message')\n}\n</script>\n\n<template>\n  <a-button type=\"primary\" @click=\"info\">\n    Static Method\n  </a-button>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "list",
+          "description": "Message list root element, set positioning, z-index, width, scroll area and placement styles",
+          "descriptionZh": "消息列表根元素，设置定位、层级、宽度、滚动区域和位置样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { message } from 'antdv-next'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { _InternalListDoNotUseOrYouWillBeFired: InternalList } = message\n\nconst { t } = useComponentLocale(locales)\n\nconst previewListStyle = {\n  position: 'relative',\n  inset: 'auto',\n  width: '100%',\n  maxWidth: '100%',\n  height: 'auto',\n  padding: '24px',\n  overflow: 'visible',\n  transform: 'none',\n} as const\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'wrapper', desc: t('wrapper'), version: '1.3.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.3.0' },\n  { name: 'list', desc: t('list'), version: '1.3.0' },\n  { name: 'listContent', desc: t('listContent'), version: '1.3.0' },\n])\n\nconst items = computed(() => [\n  {\n    key: 'semantic-message-1',\n    content: 'Hello, Antdv Next!',\n    type: 'success' as const,\n    duration: false as const,\n  },\n  {\n    key: 'semantic-message-2',\n    content: 'Welcome back!',\n    type: 'info' as const,\n    duration: false as const,\n  },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Message\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <InternalList\n        :style=\"previewListStyle\"\n        :items=\"items\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "listContent",
+          "description": "Message list content element, set notice layout, gap and height transition styles",
+          "descriptionZh": "消息列表内容元素，设置消息项排列、间距和高度动画样式"
+        },
+        {
+          "key": "root",
+          "description": "Message item root element, set background color, border radius, shadow, padding and animation styles",
+          "descriptionZh": "消息项根元素，设置背景色、圆角、阴影、内边距和动画样式"
+        },
+        {
+          "key": "wrapper",
+          "description": "Wrapper element for icon and title, set content layout, gap and alignment styles",
+          "descriptionZh": "图标与标题的包裹元素，设置内容布局、间距和对齐样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element, set font size, line height and status color styles",
+          "descriptionZh": "图标元素，设置字体大小、行高和状态颜色样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element, set text color, font size, line height and content display styles",
+          "descriptionZh": "标题元素，设置文本颜色、字号、行高和内容展示样式"
         }
       ]
     },
@@ -14622,14 +15312,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Modal by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Modal 组件的 [语义化结构](#semantic-dom) 样式。",
           "code": "<script setup lang=\"ts\">\nimport type { ModalProps } from 'antdv-next'\nimport { computed, ref } from 'vue'\n\nconst modalOpen = ref(false)\nconst modalFnOpen = ref(false)\n\nconst lineStyle = {\n  lineHeight: '28px',\n}\n\nconst classNames = computed(() => ({\n  container: 'custom-modal-container',\n}))\n\nconst styles: ModalProps['styles'] = {\n  mask: {\n    backgroundImage: `linear-gradient(to top, #18181b 0, rgba(21, 21, 22, 0.2) 100%)`,\n  },\n}\n\nconst stylesFn: ModalProps['styles'] = {\n  container: {\n    borderRadius: '14px',\n    border: '1px solid #ccc',\n    padding: '0',\n    overflow: 'hidden',\n  },\n  header: {\n    padding: '16px',\n  },\n  body: {\n    padding: '16px',\n  },\n  footer: {\n    padding: '16px 10px',\n    backgroundColor: '#fafafa',\n  },\n}\n\nconst sharedProps = computed<ModalProps>(() => ({\n  centered: true,\n  classes: classNames.value,\n}))\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-button @click=\"modalOpen = true\">\n      Open Style Modal\n    </a-button>\n    <a-button type=\"primary\" @click=\"modalFnOpen = true\">\n      Open Function Modal\n    </a-button>\n\n    <a-modal\n      v-bind=\"sharedProps\"\n      v-model:open=\"modalOpen\"\n      :footer=\"null\"\n      title=\"Custom Style Modal\"\n      :styles=\"styles\"\n    >\n      <div :style=\"lineStyle\">\n        Following the Ant Design specification, we developed a React UI library antd that contains a\n        set of high quality components and demos for building rich, interactive user interfaces.\n      </div>\n      <div :style=\"lineStyle\">\n        🌈 Enterprise-class UI designed for web applications.\n      </div>\n      <div :style=\"lineStyle\">\n        📦 A set of high-quality React components out of the box.\n      </div>\n      <div :style=\"lineStyle\">\n        🛡 Written in TypeScript with predictable static types.\n      </div>\n      <div :style=\"lineStyle\">\n        ⚙️ Whole package of design resources and development tools.\n      </div>\n      <div :style=\"lineStyle\">\n        🌍 Internationalization support for dozens of languages.\n      </div>\n      <div :style=\"lineStyle\">\n        🎨 Powerful theme customization in every detail.\n      </div>\n    </a-modal>\n\n    <a-modal\n      v-bind=\"sharedProps\"\n      v-model:open=\"modalFnOpen\"\n      title=\"Custom Function Modal\"\n      :styles=\"stylesFn\"\n      :mask=\"{ enabled: true, blur: true }\"\n    >\n      <div :style=\"lineStyle\">\n        Following the Ant Design specification, we developed a React UI library antd that contains a\n        set of high quality components and demos for building rich, interactive user interfaces.\n      </div>\n      <div :style=\"lineStyle\">\n        🌈 Enterprise-class UI designed for web applications.\n      </div>\n      <div :style=\"lineStyle\">\n        📦 A set of high-quality React components out of the box.\n      </div>\n      <div :style=\"lineStyle\">\n        🛡 Written in TypeScript with predictable static types.\n      </div>\n      <div :style=\"lineStyle\">\n        ⚙️ Whole package of design resources and development tools.\n      </div>\n      <div :style=\"lineStyle\">\n        🌍 Internationalization support for dozens of languages.\n      </div>\n      <div :style=\"lineStyle\">\n        🎨 Powerful theme customization in every detail.\n      </div>\n      <template #footer>\n        <a-button\n          :style=\"{ borderColor: '#ccc', color: '#171717', backgroundColor: '#fff' }\"\n          @click=\"modalFnOpen = false\"\n        >\n          Cancel\n        </a-button>\n        <a-button\n          type=\"primary\"\n          :style=\"{ backgroundColor: '#171717' }\"\n          @click=\"modalOpen = true\"\n        >\n          Submit\n        </a-button>\n      </template>\n    </a-modal>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, top position, width, max-width, margins, bottom padding and other basic layout styles for modal container",
+          "descriptionZh": "根元素，包含相对定位、顶部位置、宽度、最大宽度、外边距、底部内边距等模态框容器的基础布局样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'mask', desc: t('mask'), version: '1.0.0' },\n  { name: 'container', desc: t('container'), version: '1.0.0' },\n  { name: 'wrapper', desc: t('wrapper'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.3.0' },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Modal\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', inset: 0 }\">\n        <a-modal\n          title=\"Title\"\n          open\n          :get-container=\"() => divRef!\"\n          :width=\"400\"\n          :styles=\"{\n            mask: { position: 'absolute', zIndex: 1 },\n            wrapper: { position: 'absolute', zIndex: 1 },\n          }\"\n          :style=\"{ top: '50%', transform: 'translateY(-50%)', marginBottom: 0, paddingBottom: 0 }\"\n          :classes=\"classes\"\n        >\n          <p>Some contents...</p>\n        </a-modal>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "mask",
+          "description": "Mask element with fixed positioning, z-index, background color, animation transitions and other mask layer styles",
+          "descriptionZh": "遮罩层元素，包含固定定位、层级、背景色、动画过渡等遮罩层的样式"
+        },
+        {
+          "key": "wrapper",
+          "description": "Wrapper element used for motion container with animation and transition effect styles",
+          "descriptionZh": "包裹层元素，一般用于动画容器，包含动画和过渡效果的样式"
+        },
+        {
+          "key": "container",
+          "description": "Modal container element with relative positioning, background, background-clip, border, border-radius, box-shadow, pointer-events, padding and other modal body styles",
+          "descriptionZh": "Modal 容器元素，包含相对定位、背景色、背景裁剪、边框、圆角、阴影、指针事件、内边距等模态框主体样式"
+        },
+        {
+          "key": "header",
+          "description": "Header element with padding, bottom border and other header area styles",
+          "descriptionZh": "头部元素，包含头部内边距、下边框等头部区域样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with margin, color, font-weight, font-size, line-height, word-wrap and other title text styles",
+          "descriptionZh": "标题元素，包含外边距、颜色、字体权重、字体大小、行高、文字换行等标题文字样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with content area background color, padding and other content display styles",
+          "descriptionZh": "内容元素，包含内容区域的背景色、内边距等内容展示样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with footer background color, padding, top border, border-radius and other footer area styles",
+          "descriptionZh": "底部元素，包含底部的背景色、内边距、上边框、圆角等底部区域样式"
+        },
+        {
+          "key": "close",
+          "description": "Close button element with base button styles, positioning and interaction effects",
+          "descriptionZh": "关闭按钮元素，包含按钮基础样式、位置和交互效果"
         }
       ]
     },
@@ -14815,14 +15544,63 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Notification by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义通知的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CSSProperties } from 'vue'\nimport { notification } from 'antdv-next'\n\nconst [api, ContextHolder] = notification.useNotification()\n\nconst defaultStyles: Record<string, CSSProperties> = {\n  root: {\n    backgroundColor: '#f6ffed',\n    border: '2px solid #95de64',\n    borderRadius: '16px',\n    boxShadow: '4px 4px 0 #d9f7be',\n  },\n  icon: {\n    color: '#237804',\n  },\n  title: {\n    color: '#237804',\n    fontWeight: 600,\n  },\n  description: {\n    color: '#3f6600',\n  },\n}\n\nfunction styleFn(info: { props: any }): Record<string, CSSProperties> {\n  if (info.props.type === 'error') {\n    return {\n      ...defaultStyles,\n      root: {\n        ...defaultStyles.root,\n        backgroundColor: '#fff2f0',\n        borderColor: '#ffccc7',\n        boxShadow: '4px 4px 0 #ffccc7',\n      },\n      icon: {\n        color: '#cf1322',\n      },\n      title: {\n        color: '#cf1322',\n      },\n      description: {\n        color: '#5c0011',\n      },\n    }\n  }\n  return defaultStyles\n}\n\nconst sharedProps = {\n  title: 'Notification Title',\n  description: 'This is a notification description.',\n  duration: false as const,\n}\n\nfunction openDefault() {\n  api.info({\n    ...sharedProps,\n    styles: defaultStyles,\n  })\n}\n\nfunction openError() {\n  api.error({\n    ...sharedProps,\n    type: 'error',\n    styles: styleFn as any,\n  })\n}\n</script>\n\n<template>\n  <ContextHolder />\n  <a-space>\n    <a-button type=\"primary\" @click=\"openDefault\">\n      Default Notification\n    </a-button>\n    <a-button @click=\"openError\">\n      Error Notification\n    </a-button>\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "list",
+          "description": "Notification list root element, set positioning, z-index, width, scroll area and placement styles",
+          "descriptionZh": "通知列表根元素，设置定位、层级、宽度、滚动区域和位置样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { Button, notification } from 'antdv-next'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { _InternalListDoNotUseOrYouWillBeFired: InternalList } = notification\n\nconst { t } = useComponentLocale(locales)\n\nconst previewListStyle = {\n  position: 'relative',\n  inset: 'auto',\n  width: '432px',\n  maxWidth: '100%',\n  height: 'auto',\n  padding: '24px',\n  transform: 'none',\n} as const\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'wrapper', desc: t('wrapper'), version: '1.3.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.3.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.3.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n  { name: 'progress', desc: t('progress'), version: '1.3.0' },\n  { name: 'list', desc: t('list'), version: '1.3.0' },\n  { name: 'listContent', desc: t('listContent'), version: '1.3.0' },\n])\n\nconst items = computed(() => [\n  {\n    key: 'semantic-notification-1',\n    title: 'Hello World!',\n    description: 'Hello World?',\n    type: 'success' as const,\n    duration: false as const,\n    actions: h(Button, { type: 'primary', size: 'small' }, () => 'My Button'),\n  },\n  {\n    key: 'semantic-notification-2',\n    title: 'Welcome back!',\n    description: 'This is another notification.',\n    type: 'info' as const,\n    duration: 999999,\n    showProgress: true,\n  },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Notification\"\n    :height=\"320\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <InternalList\n        placement=\"topRight\"\n        :style=\"previewListStyle\"\n        :items=\"items\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "listContent",
+          "description": "Notification list content element, set notice layout, gap and height transition styles",
+          "descriptionZh": "通知列表内容元素，设置通知项排列、间距和高度动画样式"
+        },
+        {
+          "key": "root",
+          "description": "Notice root element, set background color, border radius, shadow, padding and animation styles",
+          "descriptionZh": "通知项根元素，设置背景色、圆角、阴影、内边距和动画样式"
+        },
+        {
+          "key": "wrapper",
+          "description": "Wrapper element for icon and content with content layout styles",
+          "descriptionZh": "图标与内容的包裹元素，设置内容布局样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element, set absolute positioning, font size, line height and status color styles",
+          "descriptionZh": "图标元素，设置绝对定位、字体大小、行高和状态颜色样式"
+        },
+        {
+          "key": "section",
+          "description": "Content section element that contains title and description",
+          "descriptionZh": "内容区域元素，包含标题和描述内容"
+        },
+        {
+          "key": "title",
+          "description": "Title element, set color, font size, line height and margin styles",
+          "descriptionZh": "标题元素，设置颜色、字体大小、行高和外边距样式"
+        },
+        {
+          "key": "description",
+          "description": "Description element, set font size, color and margin styles",
+          "descriptionZh": "描述元素，设置字体大小、颜色和外边距样式"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element, set float right, top margin and action button layout styles",
+          "descriptionZh": "操作组元素，设置右浮动、上边距和操作按钮布局样式"
+        },
+        {
+          "key": "close",
+          "description": "Close button element, set position, size and interaction styles",
+          "descriptionZh": "关闭按钮元素，设置位置、尺寸和交互样式"
+        },
+        {
+          "key": "progress",
+          "description": "Progress element, set progress styles for auto-closing notifications",
+          "descriptionZh": "进度条元素，设置自动关闭通知的进度样式"
         }
       ]
     },
@@ -14841,7 +15619,8 @@
       "props": [],
       "tokens": [],
       "faq": [],
-      "demos": []
+      "demos": [],
+      "semanticStructure": []
     },
     {
       "name": "Pagination",
@@ -15264,14 +16043,18 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Pagination by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Pagination 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { PaginationProps } from 'antdv-next'\nimport { useCssModule } from 'vue'\n\nconst moduleStyles = useCssModule()\n\nconst classes: PaginationProps['classes'] = {\n  root: moduleStyles.root,\n}\n\nconst stylesObject: PaginationProps['styles'] = {\n  item: {\n    borderRadius: '999px',\n  },\n}\n\nconst stylesFn: PaginationProps['styles'] = ({ props }) => {\n  if (props.size === 'small') {\n    return {\n      item: {\n        backgroundColor: 'rgba(200, 200, 200, 0.3)',\n        marginInlineEnd: '4px',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-pagination :total=\"500\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-pagination :total=\"500\" size=\"small\" :classes=\"classes\" :styles=\"stylesFn\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set flex layout, alignment, flex wrap and list styles",
+          "descriptionZh": "根元素，设置flex布局、对齐方式、换行和列表样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Pagination\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-pagination :default-current=\"1\" :total=\"50\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element, set size, padding, border, background color, hover state and active state styles",
+          "descriptionZh": "页码元素，设置尺寸、内边距、边框、背景色、悬停态和激活态样式"
         }
       ]
     },
@@ -15483,14 +16266,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Popconfirm by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Popconfirm 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { PopconfirmProps } from 'antdv-next'\n\nconst classes: PopconfirmProps['classes'] = {\n  container: 'demo-popconfirm-container',\n}\n\nconst stylesObject: PopconfirmProps['styles'] = {\n  container: {\n    backgroundColor: '#eee',\n    boxShadow: 'inset 5px 5px 3px #fff, inset -5px -5px 3px #ddd, 0 0 3px rgba(0,0,0,0.2)',\n  },\n  title: {\n    color: '#262626',\n  },\n  content: {\n    color: '#262626',\n  },\n}\n\nconst stylesFn: PopconfirmProps['styles'] = (info) => {\n  if (info?.props?.arrow === false) {\n    return {\n      container: {\n        backgroundColor: 'rgba(53, 71, 125, 0.8)',\n        padding: '12px',\n        borderRadius: '4px',\n      },\n      title: {\n        color: '#fff',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-popconfirm\n      title=\"Object text\"\n      description=\"Object description\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    >\n      <a-button>Object Style</a-button>\n    </a-popconfirm>\n    <a-popconfirm\n      title=\"Function text\"\n      description=\"Function description\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n      :ok-button-props=\"{ styles: { root: { backgroundColor: 'rgba(53, 71, 125, 0.6)', color: '#fff' } } }\"\n      :cancel-button-props=\"{ styles: { root: { borderColor: 'rgba(53, 71, 125, 0.6)', backgroundColor: '#fff', color: 'rgba(53, 71, 125, 0.8)' } } }\"\n    >\n      <a-button type=\"primary\">\n        Function Style\n      </a-button>\n    </a-popconfirm>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set absolute positioning, z-index, transform origin, arrow direction and popover container styles",
+          "descriptionZh": "根元素，设置绝对定位、层级、变换原点、箭头指向和弹层容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'container', desc: t('container') },\n  { name: 'title', desc: t('title') },\n  { name: 'content', desc: t('content') },\n  { name: 'icon', desc: t('icon'), version: '1.3.0' },\n  { name: 'arrow', desc: t('arrow') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Popconfirm\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', marginTop: '60px' }\">\n        <a-popconfirm\n          open\n          placement=\"top\"\n          title=\"Confirm\"\n          description=\"Are you sure you want to perform this action?\"\n          :auto-adjust-overflow=\"false\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "arrow",
+          "description": "Arrow element with width, height, position, color and border styles",
+          "descriptionZh": "箭头元素，设置宽高、位置、颜色和边框样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element, set title text styles and spacing",
+          "descriptionZh": "标题元素，设置标题文本样式和间距"
+        },
+        {
+          "key": "content",
+          "description": "Description element, set content text styles and layout",
+          "descriptionZh": "描述元素，设置描述文本样式和布局"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element, set icon size, color and margin styles",
+          "descriptionZh": "图标元素，设置图标尺寸、颜色和外边距样式"
         }
       ]
     },
@@ -15694,14 +16501,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Popover by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Popover 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { PopoverProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: PopoverProps['classes'] = {\n  container: 'demo-popover-container',\n}\n\nconst stylesObject: PopoverProps['styles'] = {\n  container: {\n    backgroundColor: '#eee',\n    boxShadow: 'inset 5px 5px 3px #fff, inset -5px -5px 3px #ddd, 0 0 3px rgba(0,0,0,0.2)',\n  },\n  title: {\n    color: '#262626',\n  },\n  content: {\n    color: '#262626',\n  },\n}\n\nconst stylesFn: PopoverProps['styles'] = (info) => {\n  if (info?.props?.arrow === false) {\n    return {\n      container: {\n        backgroundColor: 'rgba(53, 71, 125, 0.8)',\n        padding: '12px',\n        borderRadius: '4px',\n      },\n      title: {\n        color: '#fff',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-popover\n      content=\"Object text\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    >\n      <a-button>Object Style</a-button>\n    </a-popover>\n    <a-popover\n      content=\"Function text\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n    >\n      <a-button type=\"primary\">\n        Function Style\n      </a-button>\n    </a-popover>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set absolute positioning, z-index, transform origin, arrow direction and popover container styles",
+          "descriptionZh": "根元素，设置绝对定位、层级、变换原点、箭头指向和弹层容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'container', desc: t('container') },\n  { name: 'title', desc: t('title') },\n  { name: 'content', desc: t('content') },\n  { name: 'arrow', desc: t('arrow') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Popover\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', marginTop: '60px' }\">\n        <a-popover\n          open\n          placement=\"top\"\n          title=\"Hello\"\n          content=\"Ant Design love you!\"\n          :auto-adjust-overflow=\"false\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "arrow",
+          "description": "Arrow element with width, height, position, color and border styles",
+          "descriptionZh": "箭头元素，设置宽高、位置、颜色和边框样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element, set title text styles and spacing",
+          "descriptionZh": "标题元素，设置标题文本样式和间距"
+        },
+        {
+          "key": "content",
+          "description": "Content element, set content text styles and layout",
+          "descriptionZh": "内容元素，设置内容文本样式和布局"
         }
       ]
     },
@@ -16004,14 +16830,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Progress by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Progress 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { ProgressProps } from 'antdv-next'\n\nconst classes: ProgressProps['classes'] = {\n  root: 'demo-progress-root',\n  rail: 'demo-progress-rail',\n  track: 'demo-progress-track',\n}\n\nconst stylesFn: ProgressProps['styles'] = (info) => {\n  const percent = info?.props?.percent ?? 0\n  const hue = 200 - (200 * percent) / 100\n  return {\n    track: {\n      backgroundImage: `\n        linear-gradient(\n          to right,\n          hsla(${hue}, 85%, 65%, 1),\n          hsla(${hue + 30}, 90%, 55%, 0.95)\n        )`,\n      borderRadius: 8,\n      transition: 'all 0.3s ease',\n    },\n    rail: {\n      backgroundColor: 'rgba(0, 0, 0, 0.1)',\n      borderRadius: 8,\n    },\n  } as ProgressProps['styles']\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"10\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"20\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"40\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"60\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"80\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"99\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set relative positioning and basic container styles",
+          "descriptionZh": "根元素，设置相对定位和基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'body', desc: t('body') },\n  { name: 'rail', desc: t('rail') },\n  { name: 'track', desc: t('track') },\n  { name: 'indicator', desc: t('indicator') },\n])\n\nconst gradient = ref(false)\nconst type = ref('line')\n\nconst colorMap = {\n  '0%': '#108ee9',\n  '100%': '#87d068',\n}\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Progress\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical gap=\"middle\" :style=\"{ width: '100%' }\" align=\"center\">\n        <a-flex align=\"center\" gap=\"middle\">\n          <a-segmented\n            :options=\"['line', 'steps', 'circle', 'dashboard']\"\n            :value=\"type\"\n            @change=\"(val: string) => type = val\"\n          />\n          <a-switch\n            :checked=\"gradient\"\n            checked-children=\"Gradient\"\n            un-checked-children=\"Gradient\"\n            @change=\"(val: boolean) => gradient = val\"\n          />\n        </a-flex>\n        <a-flex vertical align=\"center\" :style=\"{ height: '200px', width: '100%' }\">\n          <a-progress\n            :percent=\"80\"\n            :type=\"type === 'steps' ? 'line' : type\"\n            :steps=\"type === 'steps' ? 5 : undefined\"\n            :stroke-color=\"gradient ? colorMap : undefined\"\n            :classes=\"classes\"\n          />\n        </a-flex>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "body",
+          "description": "Body element, set progress bar layout and size styles",
+          "descriptionZh": "主体元素，设置进度条的布局和尺寸样式"
+        },
+        {
+          "key": "rail",
+          "description": "Rail element, set background track color and border radius styles. Not exist in steps mode",
+          "descriptionZh": "导轨元素，设置背景轨道的颜色和圆角样式，steps 模式下没有该元素"
+        },
+        {
+          "key": "track",
+          "description": "Track element, set progress fill color and transition animation styles",
+          "descriptionZh": "轨迹元素，设置进度填充部分的颜色和过渡动画样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element, set percentage text or icon position and font styles",
+          "descriptionZh": "指示器元素，设置百分比文本或图标的位置和字体样式"
         }
       ]
     },
@@ -16232,14 +17077,18 @@
           "description": "With Popover.",
           "descriptionZh": "带气泡卡片的例子。",
           "code": "<script setup lang=\"ts\">\ndefineOptions({ name: 'Popover' })\n</script>\n\n<template>\n  <a-popover>\n    <template #content>\n      <a-qrcode value=\"https://ant.design\" :bordered=\"false\" />\n    </template>\n    <a-button type=\"primary\">\n      Hover me\n    </a-button>\n  </a-popover>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set flex layout, padding, background color, border, border radius and relative positioning styles",
+          "descriptionZh": "根元素，设置flex布局、内边距、背景色、边框、圆角和相对定位样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'cover', desc: t('cover') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"QRCode\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-qrcode value=\"https://ant.design\" status=\"loading\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "cover",
+          "description": "Cover element, set absolute positioning, z-index, background color and loading state overlay styles",
+          "descriptionZh": "遮罩层元素，设置绝对定位、层级、背景色和加载状态覆盖样式"
         }
       ]
     },
@@ -16641,14 +17490,23 @@
           "description": "Solid radio button style.",
           "descriptionZh": "实色填底的单选按钮样式。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst value = shallowRef('a')\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-radio-group v-model:value=\"value\" button-style=\"solid\">\n      <a-radio-button value=\"a\">\n        Hangzhou\n      </a-radio-button>\n      <a-radio-button value=\"b\">\n        Shanghai\n      </a-radio-button>\n      <a-radio-button value=\"c\">\n        Beijing\n      </a-radio-button>\n      <a-radio-button value=\"d\">\n        Chengdu\n      </a-radio-button>\n    </a-radio-group>\n    <a-radio-group v-model:value=\"value\" button-style=\"solid\">\n      <a-radio-button value=\"a\">\n        Hangzhou\n      </a-radio-button>\n      <a-radio-button value=\"b\" disabled>\n        Shanghai\n      </a-radio-button>\n      <a-radio-button value=\"c\">\n        Beijing\n      </a-radio-button>\n      <a-radio-button value=\"d\">\n        Chengdu\n      </a-radio-button>\n    </a-radio-group>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with layout styles, cursor styles, disabled text color and other basic container styles",
+          "descriptionZh": "根元素，包含布局样式、鼠标样式、禁用状态文字颜色等基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Radio\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-radio :classes=\"classes\">\n        Radio\n      </a-radio>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element with border radius, transition animations, border styles, hover states, focus states and other interactive styles",
+          "descriptionZh": "选中框元素，包含圆角样式、过渡动画、边框样式、悬停状态、焦点状态等交互样式"
+        },
+        {
+          "key": "label",
+          "description": "Label element with padding, text color, disabled states, alignment and other text styles",
+          "descriptionZh": "文本元素，包含内边距、文字颜色、禁用状态、对齐方式等文本样式"
         }
       ]
     },
@@ -16910,7 +17768,8 @@
           "descriptionZh": "调试使用。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst value = ref(2.5)\n</script>\n\n<template>\n  <a-config-provider\n    :theme=\"{\n      components: {\n        Rate: {\n          starColor: 'blue',\n          starSize: 40,\n          starHoverScale: 'scale(2)',\n          starBg: 'red',\n        },\n      },\n    }\"\n  >\n    <a-rate v-model:value=\"value\" allow-half />\n  </a-config-provider>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Result",
@@ -17078,14 +17937,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Result by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Result 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { ResultProps } from 'antdv-next'\n\nconst classesObject: ResultProps['classes'] = {\n  root: 'demo-result-root',\n  title: 'demo-result-title',\n  subTitle: 'demo-result-subtitle',\n  icon: 'demo-result-icon',\n  extra: 'demo-result-extra',\n  body: 'demo-result-body',\n}\n\nconst classesFn: ResultProps['classes'] = (info) => {\n  if (info.props.status === 'success') {\n    return {\n      root: 'demo-result-root--success',\n    } satisfies ResultProps['classes']\n  }\n  return {\n    root: 'demo-result-root--default',\n  } satisfies ResultProps['classes']\n}\n\nconst stylesObject: ResultProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed', padding: '16px' },\n  title: { fontStyle: 'italic', color: '#1890ff' },\n  subTitle: { fontWeight: 'bold' },\n  icon: { opacity: 0.8 },\n  extra: { backgroundColor: '#f0f0f0', padding: 'px' },\n  body: { backgroundColor: '#fafafa', padding: '12px' },\n}\n\nconst stylesFn: ResultProps['styles'] = (info) => {\n  if (info.props.status === 'error') {\n    return {\n      root: { backgroundColor: '#fff2f0', borderColor: '#ff4d4f' },\n      title: { color: '#ff4d4f' },\n    } satisfies ResultProps['styles']\n  }\n  else {\n    return {\n      root: { backgroundColor: '#f6ffed', borderColor: '#52c41a' },\n      title: { color: '#52c41a' },\n    } satisfies ResultProps['styles']\n  }\n}\n</script>\n\n<template>\n  <a-result\n    status=\"info\"\n    title=\"classes Object\"\n    sub-title=\"This is a subtitle\"\n    :styles=\"stylesObject\"\n    :classes=\"classesObject\"\n  >\n    <template #extra>\n      <a-button type=\"primary\">\n        Action\n      </a-button>\n    </template>\n    <div>Content area</div>\n  </a-result>\n  <a-result\n    status=\"success\"\n    title=\"classes Function\"\n    sub-title=\"Dynamic class names\"\n    :styles=\"stylesFn\"\n    :classes=\"classesFn\"\n  >\n    <template #extra>\n      <a-button type=\"primary\">\n        Action\n      </a-button>\n    </template>\n  </a-result>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with text alignment, layout styles and other basic container styles",
+          "descriptionZh": "根元素，包含文本对齐、布局样式等基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'subTitle', desc: t('subTitle'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Result\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-result\n        title=\"title\"\n        sub-title=\"subTitle\"\n        :classes=\"classes\"\n      >\n        <template #extra>\n          <a-button type=\"primary\">\n            extra\n          </a-button>\n        </template>\n        <div :style=\"{ textAlign: 'center' }\">\n          The Content of Result\n        </div>\n      </a-result>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "title",
+          "description": "Title element with font size, text color, line height, text alignment and other text styles",
+          "descriptionZh": "标题元素，包含字体大小、文字颜色、行高、对齐方式等文字样式"
+        },
+        {
+          "key": "subTitle",
+          "description": "Subtitle element with font size, text color, line height and other text styles",
+          "descriptionZh": "副标题元素，包含字体大小、文字颜色、行高等文字样式"
+        },
+        {
+          "key": "body",
+          "description": "Content element with margin, padding, background color and other content area styles",
+          "descriptionZh": "内容元素，包含外边距、内边距、背景色等内容区域样式"
+        },
+        {
+          "key": "extra",
+          "description": "Action area element with margin, text alignment, inner element spacing and other layout styles",
+          "descriptionZh": "操作区域元素，包含外边距、文本对齐、内部元素间距等布局样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with margin, text alignment, font size, status colors and other icon styles",
+          "descriptionZh": "图标元素，包含外边距、文本对齐、字体大小、状态颜色等图标样式"
         }
       ]
     },
@@ -17349,14 +18232,28 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Segmented by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Segmented 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { SegmentedProps } from 'antdv-next'\nimport { CloudOutlined, RocketOutlined, ThunderboltOutlined } from '@antdv-next/icons'\nimport { h } from 'vue'\n\nconst classes: SegmentedProps['classes'] = {\n  root: 'custom-segmented-root',\n}\nconst styleFn: SegmentedProps['styles'] = (info) => {\n  if (info.props.vertical) {\n    return {\n      root: {\n        border: '1px solid #77BEF0',\n        padding: '4px',\n        width: '100px',\n      },\n      icon: {\n        color: '#77BEF0',\n      },\n      item: {\n        textAlign: 'start',\n      },\n    } satisfies SegmentedProps['styles']\n  }\n  return {}\n}\n\nconst styles: SegmentedProps['styles'] = {\n  root: {\n    padding: '4px',\n    width: '260px',\n  },\n}\n\nconst options: SegmentedProps['options'] = [\n  {\n    label: 'Boost',\n    value: 'boost',\n    icon: h(RocketOutlined),\n  },\n  {\n    label: 'Stream',\n    value: 'stream',\n    icon: h(ThunderboltOutlined),\n  },\n  {\n    label: 'Cloud',\n    value: 'cloud',\n    icon: h(CloudOutlined),\n  },\n]\nconst segmentedSharedProps: SegmentedProps = {\n  options,\n  classes,\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-segmented v-bind=\"segmentedSharedProps\" :styles=\"styles\" />\n    <a-segmented v-bind=\"segmentedSharedProps\" :styles=\"styleFn\" vertical />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with inline-block layout, padding, background, border radius, transition and container styles",
+          "descriptionZh": "根元素，设置行内块布局、内边距、背景色、圆角、过渡动画和容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AppstoreOutlined, BarsOutlined } from '@antdv-next/icons'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n])\n\nconst options = [\n  { label: 'List', value: 'List', icon: h(BarsOutlined) },\n  { label: 'Kanban', value: 'Kanban', icon: h(AppstoreOutlined) },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Segmented\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-segmented :options=\"options\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Option element with relative positioning, text alignment, cursor style, transition, selected state background and hover styles",
+          "descriptionZh": "选项元素，设置相对定位、文本对齐、光标样式、过渡动画、选中态背景色和悬停态样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with icon size, color and text spacing styles",
+          "descriptionZh": "图标元素，设置图标的尺寸、颜色和与文本的间距样式"
+        },
+        {
+          "key": "label",
+          "description": "Label content element with min height, line height, padding, text ellipsis and content layout styles",
+          "descriptionZh": "标签内容元素，设置最小高度、行高、内边距、文本省略和内容布局样式"
         }
       ]
     },
@@ -18206,14 +19103,73 @@
           "description": "You can customize the semantic dom style of Select by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "您可以通过 `classes` 和 `styles` 传入对象/函数来自定义 Select 的语义化 DOM 样式。",
           "code": "<script setup lang=\"ts\">\nimport { MehOutlined } from '@antdv-next/icons'\n\nconst options = [\n  { value: 'GuangZhou', label: 'GuangZhou' },\n  { value: 'ShenZhen', label: 'ShenZhen' },\n]\n\nconst stylesObject = {\n  prefix: {\n    color: '#1890ff',\n  },\n  suffix: {\n    color: '#1890ff',\n  },\n}\n\nconst stylesFilled = {\n  prefix: {\n    color: '#722ed1',\n  },\n  suffix: {\n    color: '#722ed1',\n  },\n  popup: {\n    root: {\n      border: '1px solid #722ed1',\n    },\n  },\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-select\n      :options=\"options\"\n      :classes=\"{ root: 'custom-select' }\"\n      :styles=\"stylesObject\"\n      placeholder=\"Object\"\n    >\n      <template #prefix>\n        <MehOutlined />\n      </template>\n    </a-select>\n    <a-select\n      :options=\"options\"\n      :classes=\"{ root: 'custom-select' }\"\n      :styles=\"stylesFilled\"\n      placeholder=\"Function\"\n      variant=\"filled\"\n    >\n      <template #prefix>\n        <MehOutlined />\n      </template>\n    </a-select>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, cursor styles, transitions, border and other basic selector container styles",
+          "descriptionZh": "根元素，包含相对定位、行内 flex 布局、光标样式、过渡动画、边框等选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst mode = ref<'single' | 'multiple'>('single')\n\nconst options = [\n  { value: 'aojunhao123', label: 'aojunhao123' },\n  { value: 'thinkasany', label: 'thinkasany' },\n  { value: 'meet-student', label: 'meet-student' },\n]\n\nconst value = computed(() => {\n  if (mode.value !== 'multiple')\n    return []\n\n  return options.length > 0\n    ? [options[0]!.value]\n    : []\n})\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => {\n  const base = [\n    { name: 'root', desc: t('root') },\n    { name: 'prefix', desc: t('prefix') },\n    { name: 'content', desc: t('content') },\n    { name: 'placeholder', desc: t('placeholder') },\n    { name: 'clear', desc: t('clear') },\n    { name: 'input', desc: t('input') },\n    { name: 'suffix', desc: t('suffix') },\n    { name: 'popup.root', desc: t('popup.root') },\n    { name: 'popup.list', desc: t('popup.list') },\n    { name: 'popup.listItem', desc: t('popup.listItem') },\n  ]\n\n  if (mode.value === 'multiple') {\n    return [\n      ...base,\n      { name: 'item', desc: t('item') },\n      { name: 'itemContent', desc: t('itemContent') },\n      { name: 'itemRemove', desc: t('itemRemove') },\n    ]\n  }\n\n  return base\n})\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Select\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <div :style=\"{ display: 'flex', justifyContent: 'center', marginBottom: '12px' }\">\n          <a-segmented v-model:value=\"mode\" :options=\"['single', 'multiple']\" />\n        </div>\n        <div :style=\"{ display: 'flex', flexDirection: 'column', gap: '12px' }\">\n          <a-select\n            prefix=\"prefix\"\n            :style=\"{ width: '300px' }\"\n            :options=\"options\"\n            :value=\"value\"\n            :mode=\"mode === 'multiple' ? 'multiple' : undefined\"\n            open\n            :get-popup-container=\"() => divRef!\"\n            :classes=\"classes\"\n          />\n        </div>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with layout and styling for prefix content",
+          "descriptionZh": "前缀元素，包含前缀内容的布局和样式"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "clear",
+          "description": "Clear button element with layout, styling and interactive effects for clear button",
+          "descriptionZh": "清除按钮元素，包含清除按钮的布局、样式和交互效果"
+        },
+        {
+          "key": "input",
+          "description": "Input element with search input styling, cursor control, font inheritance and other search-related styles. Remove border styles",
+          "descriptionZh": "输入框元素，包含搜索输入框的样式、光标控制、字体继承等搜索相关样式，去除了边框样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with layout and styling for suffix content like clear button, arrow icon, etc.",
+          "descriptionZh": "后缀元素，包含后缀内容的布局和样式，如清除按钮、箭头图标等"
+        },
+        {
+          "key": "item",
+          "description": "Multiple selection item element with border, background, padding, and margin styles",
+          "descriptionZh": "多选项元素，包含边框、背景、内边距、外边距样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Multiple selection item content area with text ellipsis styles",
+          "descriptionZh": "多选项内容区域，包含文字的省略样式"
+        },
+        {
+          "key": "itemRemove",
+          "description": "Multiple selection item remove button with font-related styless",
+          "descriptionZh": "多选项移除按钮，包含字体相关样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with popup layer positioning, z-index, background, border, box-shadow and other popup container styles",
+          "descriptionZh": "弹出菜单元素，包含弹出层的定位、层级、背景、边框、阴影等弹出容器样式"
+        },
+        {
+          "key": "popup.list",
+          "description": "Popup list element with option list layout, scrolling, max-height and other list container styles",
+          "descriptionZh": "弹出菜单列表元素，包含选项列表的布局、滚动、最大高度等列表容器样式"
+        },
+        {
+          "key": "popup.listItem",
+          "description": "Popup item element with option item padding, hover effects, selected states, disabled states and other option interactive styles",
+          "descriptionZh": "弹出菜单条目元素，包含选项项的内边距、悬浮效果、选中状态、禁用状态等选项交互样式"
         }
       ]
     },
@@ -18668,22 +19624,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Skeleton by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Skeleton 组件的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nconst classes = {\n  root: 'skeleton-root',\n  header: 'skeleton-header',\n}\n\nconst styles = {\n  avatar: {\n    border: '1px solid #aaa',\n  },\n  title: {\n    border: '1px solid #aaa',\n  },\n}\n\nfunction stylesFn(info: { props: { active?: boolean } }) {\n  if (info.props?.active) {\n    return {\n      root: {\n        border: '1px solid rgba(229, 243, 254, 0.3)',\n      },\n      title: {\n        backgroundColor: 'rgba(229, 243, 254, 0.5)',\n        height: '20px',\n        borderRadius: '20px',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-skeleton\n      :classes=\"classes\"\n      :styles=\"styles\"\n      avatar\n      :paragraph=\"false\"\n    />\n    <a-skeleton\n      :classes=\"{ ...classes, paragraph: 'skeleton-paragraph' }\"\n      :styles=\"stylesFn\"\n      active\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with table display, width, animation effects, border radius and other skeleton container basic styles",
+          "descriptionZh": "根元素，包含表格显示、宽度、动画效果、圆角等骨架屏容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'avatar', desc: t('avatar'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'paragraph', desc: t('paragraph'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Skeleton\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-skeleton avatar :paragraph=\"{ rows: 4 }\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with table cell, padding, vertical alignment and other avatar placeholder area layout styles",
+          "descriptionZh": "头部元素，包含表格单元格、内边距、垂直对齐等头像占位区域的布局样式"
         },
         {
-          "name": "_semantic_element",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport type { SegmentedOptions } from 'antdv-next'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\ntype SkeletonElement = 'Avatar' | 'Button' | 'Input' | 'Image' | 'Node'\nconst internalOptions: SegmentedOptions = ['Avatar', 'Button', 'Input', 'Image', 'Node']\n\nconst element = ref<SkeletonElement>('Avatar')\n\nconst componentMap: Record<SkeletonElement, string> = {\n  Avatar: 'a-skeleton-avatar',\n  Button: 'a-skeleton-button',\n  Input: 'a-skeleton-input',\n  Image: 'a-skeleton-image',\n  Node: 'a-skeleton-node',\n}\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('element.root'), version: '1.0.0' },\n  { name: 'content', desc: t('element.content'), version: '1.0.0' },\n])\n\nconst componentName = computed(() => `Skeleton.${element.value}`)\nconst currentComponent = computed(() => componentMap[element.value])\n</script>\n\n<template>\n  <SemanticPreview\n    :component-name=\"componentName\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical :style=\"{ width: 'fit-content', marginInlineEnd: 'auto' }\">\n        <a-segmented v-model:value=\"element\" :options=\"internalOptions\" />\n        <a-divider title-placement=\"start\" plain>\n          {{ t('element.preview') }}\n        </a-divider>\n        <component :is=\"currentComponent\" :classes=\"classes\" />\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Section element with skeleton content area layout styles",
+          "descriptionZh": "区块元素，包含骨架屏内容区域的布局样式"
+        },
+        {
+          "key": "avatar",
+          "description": "Avatar element with inline-block display, vertical alignment, background color, size, border radius and other avatar placeholder styles",
+          "descriptionZh": "头像元素，包含行内块显示、垂直对齐、背景色、尺寸、圆角等头像占位的样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with width, height, background color, border radius and other title placeholder styles",
+          "descriptionZh": "标题元素，包含宽度、高度、背景色、圆角等标题占位的样式"
+        },
+        {
+          "key": "paragraph",
+          "description": "Paragraph element with padding, list item styles, background color, border radius and other paragraph placeholder styles",
+          "descriptionZh": "段落元素，包含内边距、列表项样式、背景色、圆角等段落占位的样式"
+        },
+        {
+          "key": "element.root",
+          "description": "Root element",
+          "descriptionZh": "根元素"
+        },
+        {
+          "key": "element.content",
+          "description": "Content element",
+          "descriptionZh": "内容元素"
+        },
+        {
+          "key": "element.preview",
+          "description": "Preview",
+          "descriptionZh": "预览"
         }
       ]
     },
@@ -19089,14 +20076,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Sliders by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Sliders 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst value = ref(30)\nconst valueVertical = ref(30)\n\nconst stylesObject = {\n  track: { backgroundImage: 'linear-gradient(180deg, #91caff, #1677ff)' },\n  handle: { borderColor: '#1677ff', boxShadow: '0 2px 8px #1677ff' },\n}\n\nfunction stylesFn(info: any) {\n  if (info.props.orientation === 'vertical') {\n    return {\n      root: { height: '300px' },\n      track: { backgroundImage: 'linear-gradient(180deg, #722cc0, #722ed1)' },\n      handle: { borderColor: '#722ed1', boxShadow: '0 2px 8px #722ed1' },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-slider v-model:value=\"value\" class=\"custom-slider\" :styles=\"stylesObject\" />\n    <a-slider\n      v-model:value=\"valueVertical\"\n      class=\"custom-slider-vertical\"\n      orientation=\"vertical\"\n      reverse\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, height, margin, padding, cursor style and touch action control",
+          "descriptionZh": "根元素，设置相对定位、高度、边距、内边距、光标样式和触摸事件控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'track', desc: t('track'), version: '1.0.0' },\n  { name: 'tracks', desc: t('tracks'), version: '1.0.0' },\n  { name: 'rail', desc: t('rail'), version: '1.0.0' },\n  { name: 'handle', desc: t('handle'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Slider\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-slider\n        range\n        :default-value=\"[20, 30, 50]\"\n        :style=\"{ width: '100%' }\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "track",
+          "description": "Track selection bar element with absolute positioning, background color, border radius and transition animation styles",
+          "descriptionZh": "轨道选取条元素，设置绝对定位、背景色、圆角和过渡动画样式"
+        },
+        {
+          "key": "tracks",
+          "description": "Multi-segment track container element with absolute positioning and transition animation styles",
+          "descriptionZh": "多段轨道容器元素，设置绝对定位和过渡动画样式"
+        },
+        {
+          "key": "rail",
+          "description": "Background rail element with absolute positioning, background color, border radius and transition animation styles",
+          "descriptionZh": "背景轨道元素，设置绝对定位、背景色、圆角和过渡动画样式"
+        },
+        {
+          "key": "handle",
+          "description": "Slider handle control element with absolute positioning, size, outline, user selection, background color, border shadow, border radius, cursor style and transition animation",
+          "descriptionZh": "滑块控制点元素，设置绝对定位、尺寸、轮廓线、用户选择、背景色、边框阴影、圆角、光标样式和过渡动画"
         }
       ]
     },
@@ -19319,14 +20325,23 @@
           "description": "Customize semantic structure styles and class names. Supports both object and function forms.",
           "descriptionZh": "自定义语义化结构的样式和类名。支持对象和函数两种形式。",
           "code": "<script setup lang=\"ts\">\nimport type { SpaceProps } from 'antdv-next'\n\nconst classNamesObject: SpaceProps['classes'] = {\n  root: 'demo-space-root',\n  item: 'demo-space-item',\n  separator: 'demo-space-separator',\n}\n\nconst classNamesFn: SpaceProps['classes'] = (info) => {\n  if (info.props.orientation === 'vertical') {\n    return {\n      root: 'demo-space-root--vertical',\n    } satisfies SpaceProps['classes']\n  }\n  else {\n    return {\n      root: 'demo-space-root--horizontal',\n    } satisfies SpaceProps['classes']\n  }\n}\n\nconst stylesObject: SpaceProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed', padding: '8px', marginBottom: '10px' },\n  item: { backgroundColor: '#f0f0f0', padding: '4px' },\n  separator: { color: 'red', fontWeight: 'bold' },\n}\n\nconst stylesFn: SpaceProps['styles'] = (info) => {\n  if (info.props.size === 'large') {\n    return {\n      root: {\n        backgroundColor: '#e6f7ff',\n        borderColor: '#1890ff',\n        padding: '8px',\n      },\n    } satisfies SpaceProps['styles']\n  }\n  else {\n    return {\n      root: {\n        backgroundColor: '#fff7e6',\n        borderColor: '#fa8c16',\n      },\n    } satisfies SpaceProps['styles']\n  }\n}\n</script>\n\n<template>\n  <div>\n    <a-space :styles=\"stylesObject\" :classes=\"classNamesObject\" separator=\"•\">\n      <a-button>Styled Button 1</a-button>\n      <a-button>Styled Button 2</a-button>\n      <a-button>Styled Button 3</a-button>\n    </a-space>\n    <a-space size=\"large\" :styles=\"stylesFn\" :classes=\"classNamesFn\">\n      <a-button>Large Space Button 1</a-button>\n      <a-button>Large Space Button 2</a-button>\n      <a-button>Large Space Button 3</a-button>\n    </a-space>\n  </div>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, gap settings, alignment, wrap and other spacing container basic styles",
+          "descriptionZh": "根元素，包含 flex 布局、间隙设置、对齐方式、换行等间距容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n  { name: 'separator', desc: t('separator') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Space\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-space :classes=\"classes\">\n        <template #separator>\n          <a-divider vertical />\n        </template>\n        <a-button type=\"primary\">\n          Primary\n        </a-button>\n        <a-button>Default</a-button>\n        <a-button type=\"dashed\">\n          Dashed\n        </a-button>\n      </a-space>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Wrapped item element with spacing item layout and styles, providing wrapper for each child element for inline alignment",
+          "descriptionZh": "包裹的子组件，包含间距项的布局和样式，为每个子元素提供包装用于内联对齐"
+        },
+        {
+          "key": "separator",
+          "description": "Separator element with divider styling",
+          "descriptionZh": "分隔符，包含分隔元素的样式"
         }
       ]
     },
@@ -19539,14 +20554,18 @@
           "description": "Debug example for standalone Spin components nested inside a wrapping Spin. The inner\nones should not pick up the outer overlay's absolute centering styles.",
           "descriptionZh": "嵌套独立 `Spin` 的调试示例：包裹型 `Spin` 的内容里再放独立 `Spin`，内层不应被外层的居中定位样式影响。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst loading = ref(true)\nconst dataSource = ['Apple', 'Banana']\n</script>\n\n<template>\n  <a-flex gap=\"middle\" vertical>\n    <a-spin :spinning=\"loading\">\n      <a-flex vertical gap=\"small\" :style=\"{ padding: '16px', border: '1px solid #d9d9d9' }\">\n        <a-flex v-for=\"item in dataSource\" :key=\"item\" align=\"center\" justify=\"space-between\">\n          <span>{{ item }}</span>\n          <a-spin size=\"small\" />\n        </a-flex>\n      </a-flex>\n    </a-spin>\n    <a-flex align=\"center\" gap=\"small\">\n      <span>Outer loading state:</span>\n      <a-switch v-model:checked=\"loading\" />\n    </a-flex>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with absolute positioning, display control, color, font size, text alignment, vertical alignment, opacity and transition animation (effective when fullscreen is false)",
+          "descriptionZh": "根元素，设置绝对定位、显示控制、颜色、字体大小、文本对齐、垂直对齐、透明度和过渡动画(fullscreen 为 false 时才有效)"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Spin\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div\n        :style=\"{\n          position: 'relative',\n          width: '500px',\n          height: '100px',\n          display: 'flex',\n          alignItems: 'center',\n          justifyContent: 'center',\n        }\"\n      >\n        <a-spin :percent=\"0\" :classes=\"classes\" />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "indicator",
+          "description": "Indicator element with width, height, font size, inline-block display, transition animation, transform origin, line height and color",
+          "descriptionZh": "指示器元素，设置宽度、高度、字体大小、行内块显示、过渡动画、变换原点、行高和颜色"
         }
       ]
     },
@@ -19829,14 +20848,23 @@
           "description": "Customize semantic structure styles and class names. Supports both object and function forms.",
           "descriptionZh": "自定义语义化结构的样式和类名。支持对象和函数两种形式。",
           "code": "<script setup lang=\"ts\">\nimport type { SplitterProps } from 'antdv-next'\n\nconst stylesObject: SplitterProps['styles'] = {\n  root: { backgroundColor: '#fffbe6' },\n  dragger: { backgroundColor: 'rgba(194,223,252,0.4)' },\n}\n\nconst stylesFn: SplitterProps['styles'] = ({ props }) => {\n  if (props.orientation === 'horizontal') {\n    return {\n      root: {\n        borderWidth: '2px',\n        borderStyle: 'dashed',\n        marginBottom: '10px',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-splitter\n      style=\"height: 200px\"\n      root-class=\"shadow-secondary\"\n      :styles=\"stylesObject\"\n    >\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\" style=\"color: #000\">\n            First\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\" style=\"color: #000\">\n            Second\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n    </a-splitter>\n    <a-splitter\n      style=\"height: 200px\"\n      root-class=\"shadow-secondary\"\n      :styles=\"stylesFn\"\n    >\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\">\n            First\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\">\n            Second\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n    </a-splitter>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, width and height, alignment and stretch styles",
+          "descriptionZh": "根元素，设置flex布局、宽度高度、对齐方式和拉伸样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'panel', desc: t('panel'), version: '1.0.0' },\n  { name: 'dragger', desc: t('dragger'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Splitter\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-splitter\n        :style=\"{ height: '200px', boxShadow: '0 0 10px rgba(0, 0, 0, 0.1)' }\"\n        :classes=\"classes\"\n      >\n        <a-splitter-panel>\n          <div :style=\"{ display: 'flex', height: '100%', alignItems: 'center', justifyContent: 'center' }\">\n            First\n          </div>\n        </a-splitter-panel>\n        <a-splitter-panel>\n          <div :style=\"{ display: 'flex', height: '100%', alignItems: 'center', justifyContent: 'center' }\">\n            Second\n          </div>\n        </a-splitter-panel>\n      </a-splitter>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "panel",
+          "description": "Panel element with flex basis, grow ratio and panel container styles",
+          "descriptionZh": "面板元素，设置flex基础值、增长比例和面板容器样式"
+        },
+        {
+          "key": "dragger",
+          "description": "Drag control element with absolute positioning, user selection, z-index, center alignment, background color, hover and active states styles",
+          "descriptionZh": "拖拽控制元素，设置绝对定位、用户选择、层级、居中对齐、背景色、悬停态和激活态样式"
         }
       ]
     },
@@ -20037,14 +21065,43 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of the Statistic by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Statistic 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { StatisticProps } from 'antdv-next'\nimport { ArrowDownOutlined, ArrowUpOutlined } from '@antdv-next/icons'\n\nconst classes = {\n  root: 'custom-statistic-root',\n}\nconst styleFn: StatisticProps['styles'] = ({ props }) => {\n  const numValue = Number(props.value ?? 0)\n  const isNegative = Number.isFinite(numValue) && numValue < 0\n  if (isNegative) {\n    return {\n      title: {\n        color: '#ff4d4f',\n      },\n      content: {\n        color: '#ff7875',\n      },\n    } satisfies StatisticProps['styles']\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-statistic\n      :value=\"93241\"\n      title=\"Monthly Active Users\"\n      :classes=\"classes\"\n      :styles=\"{ title: { color: '#1890ff', fontWeight: '600px' }, content: { fontSize: '24px' } }\"\n      suffix=\"users\"\n    >\n      <template #prefix>\n        <ArrowUpOutlined />\n      </template>\n    </a-statistic>\n\n    <a-statistic\n      :value=\"-18.7\"\n      title=\"Yearly Loss\"\n      :precision=\"1\"\n      :classes=\"classes\"\n      :styles=\"styleFn\"\n      suffix=\"%\"\n    >\n      <template #prefix>\n        <ArrowDownOutlined />\n      </template>\n    </a-statistic>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with reset styles and overall container styles for statistic component",
+          "descriptionZh": "根元素，包含统计数值组件的重置样式和整体容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { ArrowUpOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'prefix', desc: t('prefix'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'value', desc: t('value'), version: '1.3.0' },\n  { name: 'suffix', desc: t('suffix'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Statistic\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ position: 'absolute' }\">\n        <a-statistic\n          title=\"Active\"\n          :value=\"11.28\"\n          :precision=\"2\"\n          :styles=\"{ content: { color: '#3f8600' } }\"\n          suffix=\"%\"\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <ArrowUpOutlined />\n          </template>\n        </a-statistic>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with bottom padding and title area layout styles",
+          "descriptionZh": "头部元素，包含下内边距和标题区域的布局样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text color, font size and other title text display styles",
+          "descriptionZh": "标题元素，包含文字颜色、字体大小等标题文字的显示样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with text color, font size, font family and other numeric content display styles",
+          "descriptionZh": "内容元素，包含文字颜色、字体大小、字体族等数值内容的展示样式"
+        },
+        {
+          "key": "value",
+          "description": "Value element with text color, font size, font family and other statistic number display styles",
+          "descriptionZh": "数值元素，包含文字颜色、字体大小、字体族等统计数值的展示样式"
+        },
+        {
+          "key": "prefix",
+          "description": "Prefix element with inline-block display, right margin and other prefix content layout styles",
+          "descriptionZh": "前缀元素，包含行内块显示、右外边距等前缀内容的布局样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with inline-block display, left margin and other suffix content layout styles",
+          "descriptionZh": "后缀元素，包含行内块显示、左外边距等后缀内容的布局样式"
         }
       ]
     },
@@ -20357,14 +21414,58 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Steps by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Steps 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { StepsProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: StepsProps['classes'] = {\n  root: 'steps-demo-root',\n}\n\nconst stylesObject: StepsProps['styles'] = {\n  itemIcon: {\n    borderRadius: '30%',\n  },\n  itemContent: {\n    fontStyle: 'italic',\n  },\n}\n\nconst stylesFn: StepsProps['styles'] = (info) => {\n  if (info?.props?.type === 'navigation') {\n    return {\n      root: {\n        borderColor: '#1890ff',\n      },\n    }\n  }\n  return {}\n}\n\nconst items: StepsProps['items'] = [\n  { title: 'Finished', content: 'This is a content.' },\n  { title: 'In Progress', content: 'This is a content.' },\n  { title: 'Waiting', content: 'This is a content.' },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-steps :items=\"items\" :current=\"1\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-steps\n      :items=\"items\"\n      :current=\"1\"\n      type=\"navigation\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, nowrap, alignment, CSS variables and other basic step container styles",
+          "descriptionZh": "根元素，包含 flex 布局、禁止换行、对齐方式、CSS 变量等步骤条容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemWrapper', desc: t('itemWrapper') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n  { name: 'itemHeader', desc: t('itemHeader') },\n  { name: 'itemTitle', desc: t('itemTitle') },\n  { name: 'itemSubtitle', desc: t('itemSubtitle') },\n  { name: 'itemSection', desc: t('itemSection') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'itemRail', desc: t('itemRail') },\n])\n\nconst items = [\n  { title: 'Step 1', subTitle: '00:01', content: 'This is a content.' },\n  { title: 'Step 2', subTitle: '00:02', content: 'This is a content.' },\n  { title: 'Step 3', subTitle: '00:03', content: 'This is a content.' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Steps\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical gap=\"large\" :style=\"{ width: '100%' }\">\n        <a-steps\n          :current=\"1\"\n          :style=\"{ width: '100%' }\"\n          title-placement=\"vertical\"\n          :items=\"items\"\n          :classes=\"classes\"\n        />\n        <a-steps\n          :current=\"1\"\n          :style=\"{ width: '100%' }\"\n          type=\"panel\"\n          size=\"small\"\n          title-placement=\"horizontal\"\n          :items=\"items\"\n          :classes=\"classes\"\n        />\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Step item element with flex layout, relative positioning and other basic step item container styles",
+          "descriptionZh": "步骤项元素，包含 flex 布局、相对定位等单个步骤项的基础容器样式"
+        },
+        {
+          "key": "itemWrapper",
+          "description": "Step item wrapper element with flex layout, nowrap, top padding and other step content wrapping styles",
+          "descriptionZh": "步骤项内裹元素，包含 flex 布局、禁止换行、顶部内边距等步骤项内容的包装样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Step item icon element with icon size, positioning, font-size and other icon display related styles",
+          "descriptionZh": "步骤项图标元素，包含图标的尺寸、定位、字体大小等图标显示相关样式"
+        },
+        {
+          "key": "itemHeader",
+          "description": "Step item header element with flex layout, nowrap, alignment and other header area layout styles",
+          "descriptionZh": "步骤项头部元素，包含 flex 布局、禁止换行、对齐方式等头部区域的布局样式"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Step item title element with color, font-size, line-height, word-break, transitions and other title text styles",
+          "descriptionZh": "步骤项标题元素，包含颜色、字体大小、行高、文字换行、过渡动画等标题文字样式"
+        },
+        {
+          "key": "itemSubtitle",
+          "description": "Step item subtitle element with color, font-weight, font-size, line-height, margin, word-break and other subtitle styles",
+          "descriptionZh": "步骤项副标题元素，包含颜色、字体权重、字体大小、行高、外边距、文字换行等副标题样式"
+        },
+        {
+          "key": "itemSection",
+          "description": "Step item section element with step content area layout and styling",
+          "descriptionZh": "步骤项区域元素，包含步骤项内容区域的布局和样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Step item content element with color, font-size, line-height, word-break, transitions and other content text styles",
+          "descriptionZh": "步骤项内容元素，包含颜色、字体大小、行高、文字换行、过渡动画等内容文字样式"
+        },
+        {
+          "key": "itemRail",
+          "description": "Step item rail element with border-style, border-width, transitions and other connecting line styles",
+          "descriptionZh": "步骤项连接线元素，包含边框样式、边框宽度、过渡动画等连接线的样式"
         }
       ]
     },
@@ -20663,14 +21764,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Switch by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Switch 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes = {\n  root: 'custom-switch-root',\n}\n\nconst stylesObject = {\n  root: {\n    backgroundColor: '#F5D2D2',\n  },\n}\n\nfunction stylesFn(info: any) {\n  if (info.props.size === 'medium') {\n    return {\n      root: {\n        backgroundColor: '#BDE3C3',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical align=\"flex-start\" justify=\"flex-start\" gap=\"medium\">\n    <a-switch\n      size=\"small\"\n      checked-children=\"on\"\n      un-checked-children=\"off\"\n      :styles=\"stylesObject\"\n      :classes=\"{ root: 'custom-switch-root' }\"\n    />\n    <a-switch\n      size=\"medium\"\n      checked-children=\"on\"\n      un-checked-children=\"off\"\n      :styles=\"stylesFn\"\n      :classes=\"classes\"\n    />\n    <a-switch\n      default-checked\n      :classes=\"{ root: 'mui-root', indicator: 'mui-indicator' }\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with min-width, height, line-height, vertical alignment, background color, border, border radius, cursor style, transition animations, user selection and other basic switch container styles",
+          "descriptionZh": "根元素，包含最小宽度、高度、行高、垂直对齐、背景色、边框、圆角、光标样式、过渡动画、用户选择等开关容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.3' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Switch\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-switch\n        checked-children=\"on\"\n        un-checked-children=\"off\"\n        default-checked\n        disabled\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "content",
+          "description": "Content element with block display, overflow hidden, border radius, height, padding, transition animations and other switch content area layout and styles",
+          "descriptionZh": "内容元素，包含块级显示、溢出隐藏、圆角、高度、内边距、过渡动画等开关内容区域的布局和样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element with absolute positioning, width, height, background color, border radius, shadow, transition animations and other switch handle styles and interactive effects",
+          "descriptionZh": "指示器元素,包含绝对定位、宽度、高度、背景色、圆角、阴影、过渡动画等开关把手的样式和交互效果"
         }
       ]
     },
@@ -21530,14 +22640,73 @@
           "description": "Customize header and body cells via the headerCell and bodyCell slots.",
           "descriptionZh": "通过 headerCell 与 bodyCell 插槽自定义表头和单元格内容。",
           "code": "<script setup lang=\"ts\">\nimport type { TableProps } from 'antdv-next'\n\ninterface DataItem {\n  key: string\n  name: string\n  age: number\n  address: string\n}\n\nconst columns: TableProps['columns'] = [\n  {\n    title: 'Name',\n    dataIndex: 'name',\n    key: 'name',\n  },\n  {\n    title: 'Age',\n    dataIndex: 'age',\n    key: 'age',\n  },\n  {\n    title: 'Address',\n    dataIndex: 'address',\n    key: 'address',\n  },\n  {\n    title: 'Action',\n    key: 'action',\n  },\n]\n\nconst dataSource: DataItem[] = [\n  {\n    key: '1',\n    name: 'John Brown',\n    age: 32,\n    address: 'New York No. 1 Lake Park',\n  },\n  {\n    key: '2',\n    name: 'Jim Green',\n    age: 42,\n    address: 'London No. 1 Lake Park',\n  },\n  {\n    key: '3',\n    name: 'Joe Black',\n    age: 32,\n    address: 'Sydney No. 1 Lake Park',\n  },\n]\n\nfunction handleAction(record: Record<string, any>) {\n  console.log('Action:', record.name)\n}\n</script>\n\n<template>\n  <a-table :columns=\"columns\" :data-source=\"dataSource\">\n    <template #headerCell=\"{ column }\">\n      <template v-if=\"column.key === 'name'\">\n        <span class=\"table-header-strong\">{{ column.title }}</span>\n      </template>\n    </template>\n    <template #bodyCell=\"{ column, text, record }\">\n      <template v-if=\"column.key === 'name'\">\n        <a class=\"table-name\" @click.prevent=\"handleAction(record)\">{{ text }}</a>\n      </template>\n      <template v-else-if=\"column.key === 'action'\">\n        <a @click.prevent=\"handleAction(record)\">Action</a>\n      </template>\n    </template>\n  </a-table>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with font-size, background, border-radius, scrollbar-color and other basic table container styles",
+          "descriptionZh": "根元素，包含字体大小、背景色、圆角、滚动条颜色等表格容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'title', desc: t('title') },\n  { name: 'content', desc: t('content') },\n  { name: 'header.wrapper', desc: t('header.wrapper') },\n  { name: 'header.row', desc: t('header.row') },\n  { name: 'header.cell', desc: t('header.cell') },\n  { name: 'section', desc: t('section') },\n  { name: 'body.wrapper', desc: t('body.wrapper') },\n  { name: 'body.row', desc: t('body.row') },\n  { name: 'body.cell', desc: t('body.cell') },\n  { name: 'footer', desc: t('footer') },\n  { name: 'pagination.root', desc: t('pagination.root') },\n  { name: 'pagination.item', desc: t('pagination.item') },\n])\n\nconst columns = [\n  {\n    title: 'Personal Info',\n    children: [\n      { title: 'Name', dataIndex: 'name', key: 'name' },\n      { title: 'Age', dataIndex: 'age', key: 'age' },\n    ],\n  },\n  { title: 'Address', dataIndex: 'address' },\n]\n\nconst data = [\n  { key: '1', name: 'thinkasany', age: 24, address: 'New York No. 1 Lake Park' },\n  { key: '2', name: 'Jim Green', age: 42, address: 'London No. 1 Lake Park' },\n  { key: '3', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n  { key: '4', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n  { key: '5', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n  { key: '6', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Table\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-table\n        bordered\n        :style=\"{ width: '100%' }\"\n        :columns=\"columns\"\n        :data-source=\"data\"\n        size=\"middle\"\n        :pagination=\"{ pageSize: 3 }\"\n        :classes=\"classes\"\n      >\n        <template #title>\n          table title\n        </template>\n        <template #footer>\n          table footer\n        </template>\n      </a-table>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Container element with clear-fix, max-width, scrollbar background and other table wrapper styles",
+          "descriptionZh": "容器元素，包含清除浮动、最大宽度、滚动条背景等表格包装容器样式"
+        },
+        {
+          "key": "header.wrapper",
+          "description": "Header wrapper element with table header layout and container styles",
+          "descriptionZh": "头部容器元素，包含表头的布局和容器样式"
+        },
+        {
+          "key": "header.row",
+          "description": "Header row element with table header row layout and styling",
+          "descriptionZh": "头部行元素，包含表头行的布局和样式"
+        },
+        {
+          "key": "header.cell",
+          "description": "Header cell element with relative positioning, padding, word-wrap, background, text color, font-weight and other header cell styles",
+          "descriptionZh": "头部单元格元素，包含相对定位、内边距、文字换行、背景色、文字颜色、字体权重等表头单元格样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with table title styling and layout",
+          "descriptionZh": "标题元素，包含表格标题的样式和布局"
+        },
+        {
+          "key": "body.wrapper",
+          "description": "Body wrapper element with table body layout and container styles",
+          "descriptionZh": "主体容器元素，包含表格主体的布局和容器样式"
+        },
+        {
+          "key": "body.row",
+          "description": "Body row element with hover effects, selected states, expanded states and other interactive row styles",
+          "descriptionZh": "主体行元素，包含数据行的悬浮效果、选中状态、展开状态等交互样式"
+        },
+        {
+          "key": "body.cell",
+          "description": "Body cell element with relative positioning, padding, word-wrap and other basic data cell styles",
+          "descriptionZh": "主体单元格元素，包含相对定位、内边距、文字换行等数据单元格的基础样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with table footer background color, text color and other footer styles",
+          "descriptionZh": "底部元素，包含表格底部的背景色、文字颜色等样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with table content area styling and layout",
+          "descriptionZh": "内容元素，包含表格内容区域的样式和布局"
+        },
+        {
+          "key": "pagination.root",
+          "description": "Pagination root element with pagination component basic styles and layout",
+          "descriptionZh": "分页根元素，包含分页组件的基础样式和布局"
+        },
+        {
+          "key": "pagination.item",
+          "description": "Pagination item element with pagination item styling and interactive effects",
+          "descriptionZh": "分页单项元素，包含分页项的样式和交互效果"
         }
       ]
     },
@@ -22042,14 +23211,43 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tabs by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tabs 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TabsProps } from 'antdv-next'\n\nconst items: TabsProps['items'] = [\n  { key: '1', label: 'Tab 1', content: 'Content of Tab Pane 1' },\n  { key: '2', label: 'Tab 2', content: 'Content of Tab Pane 2' },\n  { key: '3', label: 'Tab 3', content: 'Content of Tab Pane 3' },\n]\n\nconst classes: TabsProps['classes'] = {\n  root: 'custom-tabs-root',\n}\n\nconst stylesObject: TabsProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed', padding: '16px', marginBottom: '10px' },\n  header: { backgroundColor: 'rgba(245,245,245,0.5)' },\n  item: { fontWeight: 'bold', color: '#1890ff', padding: `6px 10px` },\n  indicator: { backgroundColor: 'rgba(255,77,79, 0.3)', height: '4px' },\n  body: { backgroundColor: 'rgba(230,247,255,0.8)' },\n  content: { padding: '16px' },\n}\n\nconst stylesFn: TabsProps['styles'] = (info) => {\n  if (info.props.type === 'card') {\n    return {\n      root: { backgroundColor: 'rgba(250,250,250, 0.8)', borderColor: '#d9d9d9' },\n      header: { textAlign: 'start' },\n    } satisfies TabsProps['styles']\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-tabs :items=\"items\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-tabs type=\"card\" :items=\"items\" :classes=\"classes\" :styles=\"stylesFn\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with basic tab container styles, layout and direction control",
+          "descriptionZh": "根元素，包含标签页容器的基础样式、布局和方向控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'header', desc: t('header') },\n  { name: 'item', desc: t('item') },\n  { name: 'indicator', desc: t('indicator') },\n  { name: 'body', desc: t('body') },\n  { name: 'content', desc: t('content') },\n  { name: 'popup.root', desc: t('popup.root') },\n])\n\nconst items = computed(() =>\n  Array.from({ length: 30 }, (_, i) => {\n    const id = String(i)\n    return {\n      label: `Tab-${id}`,\n      key: id,\n      disabled: i === 28,\n      content: `Content of tab ${id}`,\n    }\n  }),\n)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tabs\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-tabs\n        default-active-key=\"1\"\n        :style=\"{ height: '220px', width: '100%' }\"\n        :styles=\"{\n          popup: {\n            root: { background: '#fff' },\n          },\n        }\"\n        :items=\"items\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with relative positioning, padding, colors, text ellipsis, border-radius, transitions and other tab item styles and interactive effects",
+          "descriptionZh": "Item 元素，包含相对定位、内边距、颜色、文本省略、圆角、过渡动画等标签项的样式和交互效果"
+        },
+        {
+          "key": "header",
+          "description": "Header element with tab navigation header layout, background, borders and other styles",
+          "descriptionZh": "头部元素，包含标签页头部导航的布局、背景、边框等样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element with indicator bar color, position, dimensions, transitions and other active state indication styles",
+          "descriptionZh": "指示器元素，包含指示条的颜色、位置、尺寸、过渡动画等活跃状态指示样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with tab panel container layout, animation and size control styles",
+          "descriptionZh": "内容区域元素，包含标签页面板容器的布局、动画和尺寸控制"
+        },
+        {
+          "key": "content",
+          "description": "Content element with single tab panel layout, padding and other content display styles",
+          "descriptionZh": "内容元素，包含单个标签页面板的布局、内边距等内容展示样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup menu element with dropdown absolute positioning, z-index, display control, max-height, scrolling and other styles",
+          "descriptionZh": "弹出菜单元素，包含下拉菜单的绝对定位、层级、显示控制、最大高度、滚动等样式"
         }
       ]
     },
@@ -22361,14 +23559,28 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tag by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tag 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { CheckCircleOutlined, CloseCircleOutlined } from '@antdv-next/icons'\n\nconst tagStyles = {\n  root: {\n    backgroundColor: '#e6f7ff',\n  },\n  icon: {\n    color: '#52c41a',\n  },\n  content: {\n    color: '#262626',\n  },\n}\n\nconst filledTagStyles = {\n  root: {\n    backgroundColor: '#F5EFFF',\n  },\n  icon: {\n    color: '#8F87F1',\n  },\n  content: {\n    color: '#8F87F1',\n  },\n}\n\nconst groupStyles = {\n  root: {\n    gap: '12px',\n    padding: '8px 12px',\n    backgroundColor: 'rgba(82, 196, 26, 0.08)',\n    borderRadius: '8px',\n  },\n  item: {\n    backgroundColor: 'rgba(82, 196, 26, 0.1)',\n    borderColor: 'rgba(82, 196, 26, 0.3)',\n    color: '#52c41a',\n  },\n}\n\nconst multipleGroupStyles = {\n  root: {\n    gap: '16px',\n    padding: '8px 12px',\n    backgroundColor: 'rgba(143, 135, 241, 0.08)',\n    borderRadius: '8px',\n  },\n  item: {\n    backgroundColor: 'rgba(143, 135, 241, 0.1)',\n    borderColor: 'rgba(143, 135, 241, 0.3)',\n    color: '#8F87F1',\n    fontWeight: 500,\n  },\n}\n\nconst options1 = ['React', 'Vue', 'Angular']\nconst options2 = ['meet-student', 'thinkasany']\n</script>\n\n<template>\n  <a-space size=\"large\" vertical>\n    <a-flex gap=\"middle\">\n      <a-tag :classes=\"{ root: 'custom-tag-root' }\" :styles=\"tagStyles\">\n        <template #icon>\n          <CheckCircleOutlined />\n        </template>\n        Object\n      </a-tag>\n      <a-tag\n        variant=\"filled\"\n        :classes=\"{ root: 'custom-tag-root' }\"\n        :styles=\"filledTagStyles\"\n      >\n        <template #icon>\n          <CloseCircleOutlined />\n        </template>\n        Function\n      </a-tag>\n    </a-flex>\n    <a-flex vertical gap=\"middle\">\n      <a-checkable-tag-group\n        :classes=\"{ root: 'custom-tag-root' }\"\n        :styles=\"groupStyles\"\n        :options=\"options1\"\n      />\n      <a-checkable-tag-group\n        :classes=\"{ root: 'custom-tag-root' }\"\n        :styles=\"multipleGroupStyles\"\n        :options=\"options2\"\n        multiple\n      />\n    </a-flex>\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with inline-block display, auto height, padding, font size, line height, nowrap, background color, border, border radius, opacity, transition animations, text alignment, relative positioning and other basic tag styles",
+          "descriptionZh": "根元素，包含行内块布局、自动高度、内边距、字体大小、行高、禁止换行、背景色、边框、圆角、透明度、过渡动画、文本对齐、相对定位等标签的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AntDesignOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.3.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tag\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-tag closable :classes=\"classes\">\n        <template #icon>\n          <AntDesignOutlined />\n        </template>\n        Ant Design\n      </a-tag>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element with font size, color, cursor style, transition animations and other icon display styles",
+          "descriptionZh": "图标元素，包含字体大小、颜色、光标样式、过渡动画等图标的显示样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with text content color, font styles and other content area styles",
+          "descriptionZh": "内容元素，包含文本内容的颜色、字体样式等内容区域的样式"
+        },
+        {
+          "key": "close",
+          "description": "Close element with close button layout, cursor styles, transition animations and other interaction styles",
+          "descriptionZh": "关闭元素，包含关闭按钮的布局、光标样式、过渡动画等交互样式"
         }
       ]
     },
@@ -22515,14 +23727,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of TimePicker by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 TimePicker 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TimePickerProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { useToken } = theme\nconst { token } = useToken()\n\nconst customClasses = {\n  root: 'custom-timepicker-root',\n}\n\nconst stylesObject: TimePickerProps['styles'] = {\n  root: {\n    borderColor: '#d9d9d9',\n  },\n}\n\nconst stylesFn: TimePickerProps['styles'] = (info) => {\n  if (info.props.size === 'large') {\n    return {\n      root: {\n        borderColor: '#722ed1',\n      },\n      suffix: {\n        color: '#722ed1',\n      },\n      popup: {\n        container: { border: '1px solid #722ed1', borderRadius: '8px' },\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-time-picker :classes=\"customClasses\" :styles=\"stylesObject\" placeholder=\"Object\" />\n    <a-time-picker :classes=\"customClasses\" :styles=\"stylesFn\" placeholder=\"Function\" size=\"large\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, padding, border-radius, transition animations and other basic styles for time picker container",
+          "descriptionZh": "根元素，包含相对定位、行内flex布局、内边距、边框圆角、过渡动画等时间选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { SmileOutlined } from '@antdv-next/icons'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'popup.root', desc: t('popup') },\n  { name: 'popup.container', desc: t('popup.container') },\n  { name: 'popup.content', desc: t('popup.content') },\n  { name: 'popup.item', desc: t('popup.item') },\n  { name: 'popup.footer', desc: t('popup.footer') },\n])\n\nconst type = ref<'Single' | 'Multiple'>('Single')\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    :component-name=\"type === 'Single' ? 'TimePicker' : 'TimePicker.RangePicker'\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" vertical :style=\"{ alignSelf: 'flex-start' }\" gap=\"middle\" align=\"center\">\n        <a-segmented\n          :options=\"['Single', 'Multiple']\"\n          :value=\"type\"\n          @change=\"(val: 'Single' | 'Multiple') => type = val\"\n        />\n        <a-time-picker\n          v-if=\"type === 'Single'\"\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-time-picker>\n        <a-time-range-picker\n          v-else\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-time-range-picker>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with flex layout and margin styles for prefix content layout",
+          "descriptionZh": "前缀元素，包含flex布局、右外边距等前缀内容的布局样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with relative positioning, width, color, font, line-height, transition animations and other core interactive styles for input field",
+          "descriptionZh": "输入框元素，包含相对定位、宽度、颜色、字体、行高、过渡动画等输入框的核心交互样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with flex layout, color, line-height, pointer events, transition animations and other styles for suffix content",
+          "descriptionZh": "后缀元素，包含flex布局、颜色、行高、指针事件、过渡动画等后缀内容的样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup element",
+          "descriptionZh": "弹出框元素"
+        },
+        {
+          "key": "popup.container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "popup.content",
+          "description": "Popup content element with width, border, cell and other content display styles for time list",
+          "descriptionZh": "弹出框内容元素，包含时间列表的宽度、边框、单元格等内容展示样式"
+        },
+        {
+          "key": "popup.item",
+          "description": "Popup item element with size, background, border-radius, hover state, selected state and other interactive styles for time cells",
+          "descriptionZh": "弹出框单项元素，包含时间单元格的尺寸、背景色、边框圆角、悬停态、选中态等交互样式"
+        },
+        {
+          "key": "popup.footer",
+          "description": "Popup footer element with layout styles for bottom operation area including confirm/cancel buttons",
+          "descriptionZh": "弹出框底部元素，包含确认取消按钮等底部操作区域的布局样式"
         }
       ]
     },
@@ -22759,14 +24010,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Timeline by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Timeline 的[语义化结构](#semantic-dom)样式。",
           "code": "<script lang=\"ts\" setup>\nconst classes = {\n  root: 'custom-timeline-root',\n}\n\nconst styles = {\n  itemIcon: {\n    borderColor: '#1890ff',\n  },\n}\n\nfunction stylesFn(info: any) {\n  if (info.props.orientation === 'vertical') {\n    return {\n      root: {\n        padding: '10px 6px',\n        border: '1px solid #A294F9',\n      },\n      itemIcon: {\n        borderColor: '#A294F9',\n      },\n    }\n  }\n  return {}\n}\n\nconst items = [\n  {\n    title: '2015-09-01',\n    content: 'Create a services site',\n  },\n  {\n    title: '2015-09-01 09:12:11',\n    content: 'Solve initial network problems',\n  },\n  {\n    content: 'Technical testing',\n  },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-timeline :items=\"items\" orientation=\"horizontal\" :styles=\"styles\" :classes=\"classes\" />\n    <a-timeline :items=\"items\" orientation=\"vertical\" :styles=\"stylesFn\" :classes=\"classes\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with timeline container list style reset, vertical layout, dot icon, outlined style, alternate layout and other basic container styles",
+          "descriptionZh": "根元素，设置时间轴容器的列表样式重置、垂直布局、点状图标、轮廓样式、交替布局等基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemWrapper', desc: t('itemWrapper') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n  { name: 'itemSection', desc: t('itemSection') },\n  { name: 'itemHeader', desc: t('itemHeader') },\n  { name: 'itemTitle', desc: t('itemTitle') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'itemRail', desc: t('itemRail') },\n])\n\nconst items = [\n  { title: '2015-09-01', content: 'Create a services' },\n  { title: '2015-09-01 09:12:11', content: 'Solve initial network problems' },\n  { content: 'Technical testing' },\n  { title: '2015-09-01 09:12:11', content: 'Network problems being solved' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Timeline\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-timeline :items=\"items\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with single timeline node relative positioning, margin, padding, font size, finish state, color theme, layout direction and other node basic styles",
+          "descriptionZh": "节点元素，设置单个时间节点的相对定位、外边距、内边距、字体大小、完成状态、颜色主题、布局方向等节点基础样式"
+        },
+        {
+          "key": "itemWrapper",
+          "description": "Item wrapper element with timeline node content wrapping container styles",
+          "descriptionZh": "节点包装元素，设置时间节点内容的包装容器样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Item icon element with node head icon absolute positioning, width/height size, background color, border, border radius, wave animation and other icon styles",
+          "descriptionZh": "节点图标元素，设置节点头部图标的绝对定位、宽高尺寸、背景色、边框、圆角、波纹动画等图标样式"
+        },
+        {
+          "key": "itemHeader",
+          "description": "Item header element with header area layout containing title and rail, alignment, text direction and other styles",
+          "descriptionZh": "节点头部元素，设置包含标题和连接线的头部区域布局、对齐方式、文本方向等样式"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Item title element with node title text font size, line height, color and other text styles",
+          "descriptionZh": "节点标题元素，设置节点标题文字的字体大小、行高、颜色等文本样式"
+        },
+        {
+          "key": "itemSection",
+          "description": "Item section element with section container containing header and content flex layout, wrap, gap and other layout styles",
+          "descriptionZh": "节点区域元素，设置包含头部和内容的区域容器的Flex布局、换行、间距等布局样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Item content element with node detail content relative positioning, top offset, left margin, text color, word break and other content styles",
+          "descriptionZh": "节点内容元素，设置节点详细内容的相对定位、顶部偏移、左侧外边距、文字颜色、词汇换行等内容样式"
+        },
+        {
+          "key": "itemRail",
+          "description": "Item rail element with timeline node connection track line absolute positioning, top offset, left offset, height, border color, width, style and other connection line styles",
+          "descriptionZh": "节点连接线元素，设置连接时间节点的轨道线条的绝对定位、顶部偏移、左侧偏移、高度、边框颜色、宽度、样式等连接线样式"
         }
       ]
     },
@@ -23135,14 +24425,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tooltip by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tooltip 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TooltipProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: TooltipProps['classes'] = {\n  container: 'demo-tooltip-container',\n}\n\nconst stylesObject: TooltipProps['styles'] = {\n  container: {\n    borderRadius: '12px',\n    boxShadow: 'inset 0 0 8px #ccc',\n  },\n}\n\nconst stylesFn: TooltipProps['styles'] = (info) => {\n  if (info?.props?.arrow === false) {\n    return {\n      container: {\n        backgroundColor: 'rgba(53, 71, 125, 0.8)',\n        padding: '12px',\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-tooltip title=\"Object text\" :classes=\"classes\" :styles=\"stylesObject\" :arrow=\"false\">\n      <a-button>Object Style</a-button>\n    </a-tooltip>\n    <a-tooltip title=\"Function text\" :classes=\"classes\" :styles=\"stylesFn\" :arrow=\"false\">\n      <a-button type=\"primary\">\n        Function Style\n      </a-button>\n    </a-tooltip>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element (including arrows, content elements) with absolute positioning, z-index, block display, max width, visibility, transform origin and arrow background color",
+          "descriptionZh": "根元素 (包含箭头、内容元素)，设置绝对定位、层级、块级显示、最大宽度、可见性、变换原点和箭头背景色"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'container', desc: t('container') },\n  { name: 'arrow', desc: t('arrow') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tooltip\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', marginTop: '60px' }\">\n        <a-tooltip\n          open\n          placement=\"top\"\n          title=\"tooltip prompt text\"\n          :auto-adjust-overflow=\"false\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "container",
+          "description": "Content element with min width and height, padding, color, text alignment, background color, border radius, shadow and border styles",
+          "descriptionZh": "内容元素，设置最小宽度高度、内边距、颜色、文本对齐、背景色、圆角、阴影和边框样式"
+        },
+        {
+          "key": "arrow",
+          "description": "Arrow element with width, height, position, color and border styles",
+          "descriptionZh": "箭头元素，设置宽高、位置、颜色和边框样式"
         }
       ]
     },
@@ -23444,14 +24743,68 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tour by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tour 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TourProps, TourStepItem } from 'antdv-next'\nimport { computed, h, shallowRef } from 'vue'\n\nconst ref1 = shallowRef()\nconst ref2 = shallowRef()\nconst ref3 = shallowRef()\nconst open = shallowRef(false)\nconst openFn = shallowRef(false)\n\nconst btnProps = {\n  nextButtonProps: {\n    style: {\n      border: '1px solid #CDC1FF',\n      color: '#CDC1FF',\n    },\n  },\n  prevButtonProps: {\n    style: {\n      backgroundColor: '#CDC1FF',\n      color: '#fff',\n    },\n  },\n}\n\nconst coverNode = h('img', {\n  alt: 'tour.png',\n  src: 'https://user-images.githubusercontent.com/5378891/197385811-55df8480-7ff4-44bd-9d43-a7dade598d70.png',\n})\n\nconst steps: TourStepItem[] = [\n  {\n    title: 'Upload File',\n    description: 'Put your files here.',\n    cover: coverNode,\n    target: ref1,\n    prevButtonProps: {},\n  },\n  {\n    title: 'Save',\n    description: 'Save your changes.',\n    target: ref2,\n  },\n  {\n    title: 'Other Actions',\n    description: 'Click to see other actions.',\n    target: ref3,\n  },\n]\n\nconst stepsWithButtonProps = computed(() => steps.map(step => ({ ...step, ...btnProps })))\n\nconst classes: TourProps['classes'] = {\n  root: 'custom-tour-root',\n  section: 'custom-tour-section',\n}\n\nconst stylesObject: TourProps['styles'] = {\n  mask: {\n    backgroundColor: 'rgba(0, 0, 0, 0.3)',\n  },\n  section: {\n    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',\n    border: '2px solid #4096ff',\n  },\n  cover: {\n    borderRadius: '12px 12px 0 0',\n  },\n}\n\nconst stylesFn: TourProps['styles'] = (info) => {\n  if (info.props.type === 'primary') {\n    return {\n      mask: {\n        backgroundColor: 'rgba(0, 0, 0, 0.3)',\n      },\n      section: {\n        backgroundColor: 'rgba(205, 193, 255, 0.8)',\n        boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',\n      },\n      cover: {\n        borderRadius: '12px 12px 0 0',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-flex gap=\"middle\">\n      <a-button type=\"primary\" @click=\"open = true\">\n        Begin Tour Object\n      </a-button>\n      <a-button type=\"primary\" @click=\"openFn = true\">\n        Begin Tour Function\n      </a-button>\n    </a-flex>\n    <a-divider />\n    <a-tour\n      v-model:open=\"open\"\n      :steps=\"steps\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    />\n    <a-tour\n      v-model:open=\"openFn\"\n      :steps=\"stepsWithButtonProps\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n      type=\"primary\"\n    />\n    <a-space>\n      <a-button ref=\"ref1\" type=\"primary\">\n        Upload\n      </a-button>\n      <a-button ref=\"ref2\">\n        Save\n      </a-button>\n      <a-button ref=\"ref3\" type=\"dashed\">\n        Other Actions\n      </a-button>\n    </a-space>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Tour root container with absolute positioning, z-index control, max width, visibility, arrow background color variable, theme styles and other container styles",
+          "descriptionZh": "引导根容器，设置绝对定位、层级控制、最大宽度、可见性、箭头背景色变量、主题样式等容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'mask', desc: t('mask'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'cover', desc: t('cover'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n  { name: 'indicators', desc: t('indicators'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.3.0' },\n])\n\nconst open = ref(true)\nconst createBtnRef = ref<HTMLButtonElement | null>(null)\n\nconst steps = [\n  {\n    title: 'Hello World!',\n    description: 'Hello World?!',\n    target: () => createBtnRef.value!,\n    mask: true,\n  },\n  {\n    title: 'Save',\n    description: 'Save your changes.',\n    target: () => createBtnRef.value!,\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tour\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div\n        :style=\"{\n          width: '100%',\n          height: '825px',\n          display: 'flex',\n          alignItems: 'center',\n          justifyContent: 'center',\n          position: 'relative',\n          overflow: 'hidden',\n        }\"\n      >\n        <a-button ref=\"createBtnRef\" @click=\"open = true\">\n          Show\n        </a-button>\n        <a-tour\n          v-model:open=\"open\"\n          :z-index=\"1\"\n          :default-current=\"0\"\n          :get-popup-container=\"false\"\n          :steps=\"steps\"\n          :classes=\"classes\"\n        >\n          <template #coverRender=\"{ index }\">\n            <template v-if=\"index === 0\">\n              <img src=\"https://user-images.githubusercontent.com/5378891/197385811-55df8480-7ff4-44bd-9d43-a7dade598d70.png\" alt=\"img\">\n            </template>\n          </template>\n        </a-tour>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "cover",
+          "description": "Card cover area with text center alignment, padding, image width and other image display styles",
+          "descriptionZh": "卡片封面区域，设置文本居中对齐、内边距、图片宽度等图片展示样式"
+        },
+        {
+          "key": "section",
+          "description": "Card main content area with text alignment, border radius, box shadow, relative positioning, background color, border, background clip and other card styles",
+          "descriptionZh": "卡片主要内容区域，设置文本对齐、边框圆角、盒阴影、相对定位、背景色、边框、背景裁剪等卡片样式"
+        },
+        {
+          "key": "footer",
+          "description": "Card bottom action area with padding, text right alignment, border radius, flex layout and other bottom container styles",
+          "descriptionZh": "卡片底部操作区域，设置内边距、文本右对齐、边框圆角、Flex布局等底部容器样式"
+        },
+        {
+          "key": "actions",
+          "description": "Action button group container with left auto margin, button spacing and other button group layout styles",
+          "descriptionZh": "操作按钮组容器，设置左侧自动外边距、按钮间距等按钮组布局样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Single indicator element with width/height size, inline-block display, border radius, background color, right margin, active state and other dot styles",
+          "descriptionZh": "单个指示器元素，设置宽高尺寸、行内块显示、圆角、背景色、右外边距、激活状态等圆点样式"
+        },
+        {
+          "key": "indicators",
+          "description": "Indicator group container with inline-block display and other indicator container styles",
+          "descriptionZh": "指示器组容器，设置行内块显示等指示器容器样式"
+        },
+        {
+          "key": "header",
+          "description": "Card header area with padding, width calculation, word break and other header container styles",
+          "descriptionZh": "卡片头部区域，设置内边距、宽度计算、词汇换行等头部容器样式"
+        },
+        {
+          "key": "title",
+          "description": "Guide title text with font weight and other title text styles",
+          "descriptionZh": "引导标题文字，设置字体粗细等标题文本样式"
+        },
+        {
+          "key": "description",
+          "description": "Guide description text with padding, word wrap and other description text styles",
+          "descriptionZh": "引导描述文字，设置内边距、词汇换行等描述文本样式"
+        },
+        {
+          "key": "mask",
+          "description": "Mask layer element with fixed positioning, full screen coverage, z-index, pointer events, transition animation and other mask styles",
+          "descriptionZh": "遮罩层元素，设置固定定位、全屏覆盖、层级、指针事件、过渡动画等遮罩样式"
+        },
+        {
+          "key": "close",
+          "description": "Close button element with absolute positioning, size, color, hover state and interaction feedback styles",
+          "descriptionZh": "关闭按钮元素，设置绝对定位、尺寸、颜色、悬浮态和交互反馈等关闭按钮样式"
         }
       ]
     },
@@ -23783,14 +25136,73 @@
           "description": "Custom the labels for select all checkboxes.",
           "descriptionZh": "自定义穿梭框全选按钮的文字。",
           "code": "<script setup lang=\"ts\">\nimport type { TransferEmits, TransferProps } from 'antdv-next'\nimport { ref } from 'vue'\n\ninterface RecordType {\n  key: string\n  title: string\n  description: string\n}\n\nconst mockData = Array.from({ length: 10 }).map<RecordType>((_, i) => ({\n  key: i.toString(),\n  title: `content${i + 1}`,\n  description: `description of content${i + 1}`,\n}))\n\nconst oriTargetKeys = mockData.filter(item => Number(item.key) % 3 > 1).map(item => item.key)\n\nconst selectAllLabels: TransferProps['selectAllLabels'] = [\n  'Select All',\n  ({ selectedCount, totalCount }) => `${selectedCount}/${totalCount}`,\n]\n\nconst targetKeys = ref(oriTargetKeys)\n\nconst handleChange: TransferEmits['change'] = (newTargetKeys) => {\n  targetKeys.value = newTargetKeys\n}\n</script>\n\n<template>\n  <a-transfer\n    v-model:target-keys=\"targetKeys\"\n    :data-source=\"mockData\"\n    :render=\"(item: RecordType) => item.title\"\n    :select-all-labels=\"selectAllLabels\"\n    @change=\"handleChange\"\n  />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, transfer container base styles and layout control",
+          "descriptionZh": "根元素，设置flex布局、穿梭框容器的基础样式和布局控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'section', desc: t('section') },\n  { name: 'header', desc: t('header') },\n  { name: 'title', desc: t('title') },\n  { name: 'body', desc: t('body') },\n  { name: 'list', desc: t('list') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'footer', desc: t('footer') },\n  { name: 'actions', desc: t('actions') },\n  { name: 'source', desc: t('source'), version: '1.3.0' },\n  { name: 'target', desc: t('target'), version: '1.3.0' },\n])\n\nconst mockData = Array.from({ length: 20 }).map((_, i) => ({\n  key: i,\n  title: `content ${i + 1}`,\n}))\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Transfer\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-transfer\n        show-search\n        :titles=\"['Source', 'Target']\"\n        :data-source=\"mockData\"\n        :selected-keys=\"[]\"\n        :target-keys=\"[3, 9]\"\n        :render=\"(item: any) => item.title\"\n        :styles=\"{\n          section: { height: '250px', width: '200px' },\n        }\"\n        :classes=\"classes\"\n      >\n        <template #footer>\n          <div :style=\"{ padding: '8px' }\">\n            Custom Footer\n          </div>\n        </template>\n      </a-transfer>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Section element with flex layout, width, height, min height, border, border radius and other single-side transfer container styles",
+          "descriptionZh": "区域元素，设置flex布局、宽度、高度、最小高度、边框、圆角等单侧穿梭框的容器样式"
+        },
+        {
+          "key": "header",
+          "description": "Header element with flex layout, alignment, height, padding, color, background color, bottom border, border radius and other header area styles",
+          "descriptionZh": "头部元素，设置flex布局、对齐方式、高度、内边距、颜色、背景色、下边框、圆角等头部区域的样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text ellipsis, flex ratio, text alignment, auto left margin and other title text layout and styles",
+          "descriptionZh": "标题元素，设置文本省略、flex占比、文本对齐、自动左边距等标题文字的布局和样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with list main area container styles and layout control",
+          "descriptionZh": "内容元素，设置列表主体区域的容器样式和布局控制"
+        },
+        {
+          "key": "list",
+          "description": "List element with list content styles, layout and scroll control",
+          "descriptionZh": "列表元素，设置列表内容的样式、布局和滚动控制"
+        },
+        {
+          "key": "item",
+          "description": "List item element with relative positioning, padding, border, hover state, selected state, disabled state and other list item interaction styles",
+          "descriptionZh": "列表项元素，设置相对定位、内边距、边框、悬停态、选中态、禁用态等列表项的交互样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "List item icon element with checkbox and other icon styles and interaction states",
+          "descriptionZh": "列表项图标元素，设置复选框等图标的样式和交互状态"
+        },
+        {
+          "key": "itemContent",
+          "description": "List item content element with text ellipsis, padding and other list item text content display styles",
+          "descriptionZh": "列表项内容元素，设置文本省略、内边距等列表项文本内容的展示样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with bottom operation area styles and layout",
+          "descriptionZh": "页脚元素，设置底部操作区域的样式和布局"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element with transfer button group styles, layout and interaction states",
+          "descriptionZh": "操作元素，设置穿梭按钮组的样式、布局和交互状态"
+        },
+        {
+          "key": "source",
+          "description": "Source-side (left) overrides nested under the same shared semantic keys (section/header/title/body/list/item/itemIcon/itemContent/footer); only the source list picks them up",
+          "descriptionZh": "源（左侧）区域专属语义，与共享 section/header/title/body/list/item/itemIcon/itemContent/footer 同级，仅覆盖源侧"
+        },
+        {
+          "key": "target",
+          "description": "Target-side (right) overrides nested under the same shared semantic keys (section/header/title/body/list/item/itemIcon/itemContent/footer); only the target list picks them up",
+          "descriptionZh": "目标（右侧）区域专属语义，与共享 section/header/title/body/list/item/itemIcon/itemContent/footer 同级，仅覆盖目标侧"
         }
       ]
     },
@@ -24485,14 +25897,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tree by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tree 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TreeDataNode, TreeProps } from 'antdv-next'\nimport { ref } from 'vue'\n\nconst treeData: TreeDataNode[] = [\n  {\n    title: 'parent 1',\n    key: '0-0',\n    children: [\n      {\n        title: 'parent 1-0',\n        key: '0-0-0',\n        children: [\n          {\n            title: 'leaf',\n            key: '0-0-0-0',\n          },\n          {\n            title: 'leaf',\n            key: '0-0-0-1',\n          },\n        ],\n      },\n      {\n        title: 'parent 1-1',\n        key: '0-0-1',\n        children: [\n          {\n            title: 'leaf',\n            key: '0-0-1-0',\n          },\n        ],\n      },\n    ],\n  },\n]\n\nconst styles: TreeProps['styles'] = {\n  root: { border: '2px solid #d9d9d9' },\n  item: { margin: '2px 0' },\n}\n\nconst stylesFn: TreeProps['styles'] = (info) => {\n  if (!info.props.checkable) {\n    return {\n      root: {\n        border: `2px solid #E5D9F2`,\n        borderRadius: '4px',\n      },\n    }\n  }\n  return {}\n}\n\nconst expandedKeys = ref(['0-0-0', '0-0-1'])\nconst selectedKeys = ref(['0-0-1'])\nconst checkedKeys = ref(['0-0-0', '0-0-1'])\nconst classes = {\n  root: 'root',\n  item: 'item',\n  itemTitle: 'itemTitle',\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-tree\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      auto-expand-parent\n      checkable\n      :styles=\"styles\"\n    />\n    <a-tree\n      v-model:expanded-keys=\"expandedKeys\"\n      v-model:selected-keys=\"selectedKeys\"\n      v-model:checked-keys=\"checkedKeys\"\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      auto-expand-parent\n      :checkable=\"false\"\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with tree control base styles, layout and container control",
+          "descriptionZh": "根元素，设置树形控件的基础样式、布局和容器控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { DownOutlined, FrownFilled, FrownOutlined, MehOutlined, SmileOutlined } from '@antdv-next/icons'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'itemIcon', desc: t('itemIcon'), version: '1.0.0' },\n  { name: 'itemTitle', desc: t('itemTitle'), version: '1.0.0' },\n  { name: 'itemSwitcher', desc: t('itemSwitcher'), version: '1.3.0' },\n])\n\nconst treeData = [\n  {\n    title: 'parent 1',\n    key: '0-0',\n    icon: h(SmileOutlined),\n    children: [\n      { title: 'leaf', key: '0-0-0', icon: h(MehOutlined) },\n      { title: 'leaf', key: '0-0-1', icon: ({ selected }: { selected: boolean }) => selected ? h(FrownFilled) : h(FrownOutlined) },\n    ],\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tree\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-tree\n        show-icon\n        default-expand-all\n        :default-selected-keys=\"['0-0-0']\"\n        :tree-data=\"treeData\"\n        :classes=\"classes\"\n      >\n        <template #switcherIcon>\n          <DownOutlined />\n        </template>\n      </a-tree>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with tree node base styles, drag state, role attributes, indentation, switcher, content wrapper and other node structure",
+          "descriptionZh": "条目元素，设置树节点的基础样式、拖拽状态、角色属性、缩进、切换器、内容包装器等节点结构"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Title element with tree node title text display styles and text content",
+          "descriptionZh": "标题元素，设置树节点标题文字的显示样式和文本内容"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Icon element with tree node icon styles, size and state display",
+          "descriptionZh": "图标元素，设置树节点图标的样式、尺寸和状态显示"
+        },
+        {
+          "key": "itemSwitcher",
+          "description": "Switcher element with tree node expand/collapse button styles and background",
+          "descriptionZh": "切换器元素，设置树节点展开/收起按钮的样式和背景"
         }
       ]
     },
@@ -25075,14 +26506,73 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of TreeSelect by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 TreeSelect 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TreeSelectProps } from 'antdv-next'\n\nconst classes: TreeSelectProps['classes'] = {\n  root: 'custom-tree-select',\n}\n\nconst stylesObject: TreeSelectProps['styles'] = {\n  input: {\n    fontSize: 16,\n  },\n  suffix: {\n    color: '#1890ff',\n  },\n  popup: {\n    root: {\n      border: '1px solid #1890ff',\n    },\n  },\n}\n\nconst stylesFn: TreeSelectProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      suffix: {\n        color: '#722ed1',\n      },\n      popup: {\n        item: {\n          color: '#722ed1',\n        },\n      },\n    }\n  }\n  return {}\n}\n\nconst treeData: TreeSelectProps['treeData'] = [\n  {\n    value: 'parent 1',\n    title: 'parent 1',\n    children: [\n      {\n        value: 'parent 1-0',\n        title: 'parent 1-0',\n        children: [\n          {\n            value: 'leaf1',\n            title: 'leaf1',\n          },\n          {\n            value: 'leaf2',\n            title: 'leaf2',\n          },\n        ],\n      },\n      {\n        value: 'parent 1-1',\n        title: 'parent 1-1',\n        children: [\n          {\n            value: 'leaf3',\n            title: 'leaf3',\n          },\n        ],\n      },\n    ],\n  },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-tree-select\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      placeholder=\"Object\"\n    />\n    <a-tree-select\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      placeholder=\"Function\"\n      size=\"middle\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with tree selector base styles, border, border radius container styles",
+          "descriptionZh": "根元素，设置树选择器的基础样式、边框、圆角容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst mode = ref<'single' | 'multiple'>('single')\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => {\n  const base = [\n    { name: 'root', desc: t('root') },\n    { name: 'prefix', desc: t('prefix') },\n    { name: 'placeholder', desc: t('placeholder') },\n  ]\n\n  if (mode.value === 'multiple') {\n    base.push(\n      ...[\n        { name: 'content', desc: t('content') },\n        { name: 'item', desc: t('item') },\n        { name: 'itemContent', desc: t('itemContent') },\n        { name: 'itemRemove', desc: t('itemRemove') },\n      ],\n    )\n  }\n\n  base.push(\n    ...[\n      { name: 'input', desc: t('input') },\n      { name: 'suffix', desc: t('suffix') },\n      { name: 'popup.root', desc: t('popup.root') },\n      { name: 'popup.item', desc: t('popup.item') },\n      { name: 'popup.itemTitle', desc: t('popup.itemTitle') },\n      { name: 'popup.itemSwitcher', desc: t('popup.itemSwitcher'), version: '1.3.0' },\n    ],\n  )\n\n  return base\n})\n\nconst treeValue = ref<string | string[] | undefined>(undefined)\nfunction handleResetValue(newMode: string | number) {\n  if (newMode === 'multiple') {\n    treeValue.value = ['aojunhao123']\n  }\n  else {\n    treeValue.value = undefined\n  }\n}\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst treeData = [\n  {\n    value: 'contributors',\n    title: 'contributors',\n    children: [\n      { value: 'aojunhao123', title: 'aojunhao123' },\n      { value: 'thinkasany', title: 'thinkasany' },\n      { value: 'meet-student', title: 'meet-student' },\n    ],\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"TreeSelect\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <div :style=\"{ display: 'flex', justifyContent: 'center', marginBottom: '12px' }\">\n          <a-segmented v-model:value=\"mode\" :options=\"['single', 'multiple']\" @change=\"handleResetValue\" />\n        </div>\n\n        <a-tree-select\n          v-model:value=\"treeValue\"\n          prefix=\"prefix\"\n          :style=\"{ width: '300px' }\"\n          :tree-data=\"treeData\"\n          tree-default-expand-all\n          :multiple=\"mode === 'multiple'\"\n          show-search\n          max-tag-count=\"responsive\"\n          placeholder=\"Please select\"\n          allow-clear\n          open\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with prefix content layout and styles",
+          "descriptionZh": "前缀元素，设置前缀内容的布局和样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "input",
+          "description": "Input element with text input, search, selected value display and other input core interaction styles",
+          "descriptionZh": "输入框元素，设置文本输入、搜索、选择值显示等输入框的核心交互样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with suffix content, clear button, dropdown arrow and other suffix area styles",
+          "descriptionZh": "后缀元素，设置后缀内容、清除按钮、下拉箭头等后缀区域的样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with dropdown tree selection panel positioning, z-index, background, border, shadow and other popup layer styles",
+          "descriptionZh": "弹出菜单元素，设置下拉树形选择面板的定位、层级、背景、边框、阴影等弹层样式"
+        },
+        {
+          "key": "popup.item",
+          "description": "Popup item element with tree node option styles, hover state, selected state and other interaction states",
+          "descriptionZh": "弹出菜单条目元素，设置树节点选项的样式、悬停态、选中态等交互状态"
+        },
+        {
+          "key": "popup.itemTitle",
+          "description": "Popup title element with tree node title text display styles",
+          "descriptionZh": "弹出菜单标题元素，设置树节点标题文字的显示样式"
+        },
+        {
+          "key": "popup.itemSwitcher",
+          "description": "Popup switcher element with tree node expand/collapse button styles and background",
+          "descriptionZh": "弹出菜单切换器元素，设置树节点展开/收起按钮的样式和背景"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "item",
+          "description": "Multiple selection item element with border, background, padding, and margin styles",
+          "descriptionZh": "多选项元素，包含边框、背景、内边距、外边距样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Multiple selection item content area with text ellipsis styles",
+          "descriptionZh": "多选项内容区域，包含文字的省略样式"
+        },
+        {
+          "key": "itemRemove",
+          "description": "Multiple selection item remove button with font-related styles",
+          "descriptionZh": "多选项移除按钮，包含字体相关样式"
         }
       ]
     },
@@ -25594,14 +27084,28 @@
           "description": "Add suffix ellipsis support.",
           "descriptionZh": "添加后缀的省略。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst rows = ref(1)\n\nconst article = `To be, or not to be, that is the question: Whether it is nobler in the mind to suffer. The slings and arrows of outrageous fortune Or to take arms against a sea of troubles, And by opposing end them? To die: to sleep; No more; and by a sleep to say we end The heart-ache and the thousand natural shocks That flesh is heir to, 'tis a consummation Devoutly to be wish'd. To die, to sleep To sleep- perchance to dream: ay, there's the rub! For in that sleep of death what dreams may come When we have shuffled off this mortal coil, Must give us pause. There 's the respect That makes calamity of so long life`\n\nfunction onEllipsis(ellipsis: boolean) {\n  console.log('Ellipsis changed:', ellipsis)\n}\n</script>\n\n<template>\n  <div>\n    <a-slider v-model:value=\"rows\" :min=\"1\" :max=\"10\" />\n    <a-typography-paragraph\n      :ellipsis=\"{\n        rows,\n        expandable: true,\n        suffix: '--William Shakespeare',\n        onEllipsis,\n      }\"\n      :title=\"`${article}--William Shakespeare`\"\n    >\n      {{ article }}\n    </a-typography-paragraph>\n  </div>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with base typography styles, layout, and positioning",
+          "descriptionZh": "根元素，包含排版基础样式、布局和定位"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst editing = ref(false)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.3.0' },\n  { name: 'actions', desc: t('actions'), version: '1.3.0' },\n  { name: 'action', desc: t('action'), version: '1.3.0' },\n  { name: 'textarea', desc: t('textarea'), version: '1.3.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Typography\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex\n        vertical\n        gap=\"middle\"\n        align=\"start\"\n        :style=\"{ width: '100%', alignSelf: 'flex-start' }\"\n      >\n        <a-switch\n          v-model:checked=\"editing\"\n          checked-children=\"Editing\"\n          un-checked-children=\"Editing\"\n        />\n        <a-typography-paragraph\n          copyable\n          :editable=\"{ editing }\"\n          :ellipsis=\"{ rows: 2, expandable: true }\"\n          :style=\"{ width: '100%' }\"\n          :classes=\"classes\"\n        >\n          Ant Design is a design language for background applications, refined by Ant UED Team.\n          It aims to uniform the user interface specs for internal background projects, lower the\n          unnecessary cost of design differences and implementation and liberate the resources of\n          design and front-end development.\n        </a-typography-paragraph>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "actions",
+          "description": "Actions element with layout and spacing styles for copy, edit, expand/collapse buttons",
+          "descriptionZh": "操作区域元素，包含复制、编辑、展开/收起等操作按钮的布局和间距样式"
+        },
+        {
+          "key": "action",
+          "description": "Individual action button element including copy, edit, expand, collapse button styles like padding, border radius, colors, etc.",
+          "descriptionZh": "单个操作按钮元素，包括复制、编辑、展开、收起按钮的样式，如内边距、圆角、颜色等"
+        },
+        {
+          "key": "textarea",
+          "description": "TextArea element in editable mode, used to customize className and inline styles for the edit input",
+          "descriptionZh": "可编辑模式下的 TextArea 元素样式，用于自定义编辑输入框的类名和内联样式"
         }
       ]
     },
@@ -26059,14 +27563,33 @@
           "description": "Component Token Debug.",
           "descriptionZh": "Component Token Debug.",
           "code": "<script setup lang=\"ts\">\nimport type { UploadEmits, UploadFile } from 'antdv-next'\nimport { UploadOutlined } from '@antdv-next/icons'\n\nconst defaultFileList: UploadFile[] = [\n  {\n    uid: '1',\n    name: 'xxx.png',\n    status: 'uploading',\n    url: 'http://www.baidu.com/xxx.png',\n    percent: 33,\n  },\n  {\n    uid: '2',\n    name: 'yyy.png',\n    status: 'done',\n    url: 'http://www.baidu.com/yyy.png',\n  },\n  {\n    uid: '3',\n    name: 'zzz.png',\n    status: 'error',\n    response: 'Server Error 500',\n    url: 'http://www.baidu.com/zzz.png',\n  },\n]\n\nconst handleChange: UploadEmits['change'] = ({ file, fileList }) => {\n  if (file.status !== 'uploading') {\n    console.log(file, fileList)\n  }\n}\n</script>\n\n<template>\n  <a-config-provider\n    :theme=\"{\n      components: {\n        Upload: {\n          actionsColor: 'yellow',\n        },\n      },\n    }\"\n  >\n    <a-upload\n      action=\"https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload\"\n      :default-file-list=\"defaultFileList\"\n      @change=\"handleChange\"\n    >\n      <a-button>\n        <template #icon>\n          <UploadOutlined />\n        </template>\n        Upload\n      </a-button>\n    </a-upload>\n  </a-config-provider>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "cropModalTitle",
+          "description": "Edit image",
+          "descriptionZh": "编辑图片"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { UploadOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'list', desc: t('list'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n])\n\nconst defaultFileList = [\n  { uid: '1', name: 'xxx.png', status: 'uploading', url: 'http://www.baidu.com/xxx.png', percent: 33 },\n  { uid: '2', name: 'yyy.png', status: 'done', url: 'http://www.baidu.com/yyy.png' },\n  { uid: '3', name: 'zzz.png', status: 'error', response: 'Server Error 500', url: 'http://www.baidu.com/zzz.png' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Upload\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-upload\n        action=\"https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload\"\n        :default-file-list=\"defaultFileList\"\n        :classes=\"classes\"\n      >\n        <a-button>\n          <template #icon>\n            <UploadOutlined />\n          </template>\n          Upload\n        </a-button>\n      </a-upload>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "cropResetText",
+          "description": "Reset",
+          "descriptionZh": "重置"
+        },
+        {
+          "key": "root",
+          "description": "Root container element with layout styles, disabled text color, user-select control, cursor styles and other basic styles",
+          "descriptionZh": "根元素容器，包含布局样式、禁用状态文字颜色、用户选择控制、鼠标样式等基础样式"
+        },
+        {
+          "key": "list",
+          "description": "File list container with layout arrangement, transition animations, spacing control and other styles",
+          "descriptionZh": "文件列表容器，包含布局排列、过渡动画、间距控制等样式"
+        },
+        {
+          "key": "item",
+          "description": "File item element with padding, background color, border styles, hover effects, status colors, transition animations and other styles",
+          "descriptionZh": "文件项元素，包含内边距、背景色、边框样式、悬停效果、状态颜色、过渡动画等样式"
         }
       ]
     },
@@ -26213,7 +27736,8 @@
           "descriptionZh": "在 Modal 与 Drawer 中使用。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst showModal = shallowRef(false)\nconst showDrawer = shallowRef(false)\nconst showDrawer2 = shallowRef(false)\n\nconst placeholderStyle = {\n  height: '300px',\n  display: 'flex',\n  justifyContent: 'center',\n  alignItems: 'center',\n  backgroundColor: 'rgba(150, 150, 150, 0.2)',\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-button type=\"primary\" @click=\"showModal = true\">\n      Show in Modal\n    </a-button>\n    <a-button type=\"primary\" @click=\"showDrawer = true\">\n      Show in Drawer\n    </a-button>\n    <a-button type=\"primary\" @click=\"showDrawer2 = true\">\n      Not Show in Drawer\n    </a-button>\n  </a-flex>\n  <a-watermark content=\"Antdv Next\">\n    <a-modal\n      v-model:open=\"showModal\"\n      destroy-on-hidden\n      title=\"Modal\"\n      @ok=\"showModal = false\"\n      @cancel=\"showModal = false\"\n    >\n      <div :style=\"placeholderStyle\">\n        A mock height\n      </div>\n    </a-modal>\n    <a-drawer\n      v-model:open=\"showDrawer\"\n      destroy-on-hidden\n      title=\"Drawer\"\n      @close=\"showDrawer = false\"\n    >\n      <div :style=\"placeholderStyle\">\n        A mock height\n      </div>\n    </a-drawer>\n  </a-watermark>\n  <a-watermark content=\"Antdv Next\" :inherit=\"false\">\n    <a-drawer\n      v-model:open=\"showDrawer2\"\n      destroy-on-hidden\n      title=\"Drawer\"\n      @close=\"showDrawer2 = false\"\n    >\n      <div :style=\"placeholderStyle\">\n        A mock height\n      </div>\n    </a-drawer>\n  </a-watermark>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     }
   ],
   "changelog": [

--- a/data/v1.5.1.json
+++ b/data/v1.5.1.json
@@ -1840,7 +1840,8 @@
           "descriptionZh": "用 `target` 设置 `Affix` 需要监听其滚动事件的元素，默认为 `window`。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst container = shallowRef()\n</script>\n\n<template>\n  <div ref=\"container\" style=\"width: 100%;height: 100px;overflow: auto;box-shadow: 0 0 0 1px #1677ff;scrollbar-width: thin;scrollbar-gutter: stable\">\n    <div style=\"width: 100%;height: 1000px\">\n      <a-affix :target=\"() => container\">\n        <a-button type=\"primary\">\n          Fixed at the top of container\n        </a-button>\n      </a-affix>\n    </div>\n  </div>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Alert",
@@ -2144,14 +2145,43 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Alert by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Alert 的 [语义化结构](#semantic-dom) 样式。",
           "code": "<script setup lang=\"ts\">\nimport type { AlertProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: AlertProps['classes'] = {\n  root: 'demo-alert-root',\n}\n\nconst stylesObject: AlertProps['styles'] = {\n  icon: {\n    fontSize: '18px',\n  },\n  section: {\n    fontWeight: 500,\n  },\n}\n\nconst stylesFn: AlertProps['styles'] = (info) => {\n  if (info?.props?.type === 'success') {\n    return {\n      root: {\n        backgroundColor: 'rgba(82, 196, 26, 0.1)',\n        borderColor: '#b7eb8f',\n      },\n      icon: {\n        color: '#52c41a',\n      },\n    }\n  }\n  if (info?.props?.type === 'warning') {\n    return {\n      root: {\n        backgroundColor: 'rgba(250, 173, 20, 0.1)',\n        borderColor: '#ffe58f',\n      },\n      icon: {\n        color: '#faad14',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"small\">\n    <a-alert\n      title=\"Object styles\"\n      type=\"info\"\n      show-icon\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n    >\n      <template #action>\n        <a-button size=\"small\">\n          Action\n        </a-button>\n      </template>\n    </a-alert>\n    <a-alert\n      title=\"Function styles\"\n      type=\"success\"\n      show-icon\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with border, background, padding, border-radius, and positioning styles for the alert container",
+          "descriptionZh": "根元素，包含边框、背景色、内边距、圆角、位置布局等警告提示框的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Alert\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-alert\n        closable\n        title=\"Info Text\"\n        show-icon\n        description=\"Info Description Info Description Info Description Info Description\"\n        type=\"info\"\n        :classes=\"classes\"\n      >\n        <template #action>\n          <a-flex vertical gap=\"small\" :style=\"{ minWidth: '80px' }\">\n            <a-button size=\"small\" type=\"primary\" block>\n              Accept\n            </a-button>\n            <a-button size=\"small\" danger ghost block>\n              Decline\n            </a-button>\n          </a-flex>\n        </template>\n      </a-alert>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Content element with flex layout controlling content area typography and minimum width",
+          "descriptionZh": "内容元素，采用 flex 布局控制内容区域的排版和最小宽度"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with color, line-height, and margin styles, supporting different status icon types",
+          "descriptionZh": "图标元素，包含图标的颜色、行高、外边距等样式，支持不同类型的状态图标"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text color and font styling for the alert title",
+          "descriptionZh": "标题元素，包含标题文字的颜色、字体等样式"
+        },
+        {
+          "key": "description",
+          "description": "Description element with font-size and line-height styles for additional content",
+          "descriptionZh": "描述元素，包含描述文字的字体大小、行高等排版样式"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element with layout and spacing styles for action buttons",
+          "descriptionZh": "操作组元素，包含操作按钮的布局和间距样式"
+        },
+        {
+          "key": "close",
+          "description": "Close button element with basic button styling",
+          "descriptionZh": "关闭按钮元素，包含按钮的基础样式"
         }
       ]
     },
@@ -2389,14 +2419,28 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Anchor by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "您可以通过 `classes` 和 `styles` 传入对象/函数可以自定义 Anchor 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { AnchorProps } from 'antdv-next'\n\nconst classesObject: AnchorProps['classes'] = {\n  root: 'demo-anchor-root',\n  item: 'demo-anchor-item',\n  itemTitle: 'demo-anchor-title',\n  indicator: 'demo-anchor-indicator',\n}\n\nconst stylesFn: AnchorProps['styles'] = (info) => {\n  if (info.props.direction === 'vertical') {\n    return {\n      root: {\n        backgroundColor: 'rgba(255,251,230,0.5)',\n        height: '100vh',\n      },\n    }\n  }\n  return {}\n}\n\nconst items: NonNullable<AnchorProps['items']> = [\n  {\n    key: 'part-1',\n    href: '#part-1',\n    title: 'Part 1',\n  },\n  {\n    key: 'part-2',\n    href: '#part-2',\n    title: 'Part 2',\n  },\n  {\n    key: 'part-3',\n    href: '#part-3',\n    title: 'Part 3',\n  },\n]\n</script>\n\n<template>\n  <a-row>\n    <a-col :span=\"16\">\n      <div id=\"part-1\" style=\"height: 100vh; background: rgba(255, 0, 0, 0.08)\" />\n      <div id=\"part-2\" style=\"height: 100vh; background: rgba(0, 255, 0, 0.08)\" />\n      <div id=\"part-3\" style=\"height: 100vh; background: rgba(0, 0, 255, 0.08)\" />\n    </a-col>\n    <a-col :span=\"8\">\n      <a-anchor replace :items=\"items\" :styles=\"stylesFn\" :classes=\"classesObject\" />\n    </a-col>\n  </a-row>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with layout positioning, padding, margin, background color and other basic styles",
+          "descriptionZh": "根元素，包含布局定位、内边距、边距、背景色等基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'itemTitle', desc: t('itemTitle'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n])\n\nconst items = [\n  {\n    key: 'api',\n    href: '#api',\n    title: 'API',\n    children: [\n      { key: '4', href: '#anchor-props', title: 'Anchor Props' },\n      { key: '5', href: '#link-props', title: 'Link Props' },\n    ],\n  },\n  { key: '1', href: '#anchor-demo-basic', title: 'Basic demo' },\n  { key: '2', href: '#anchor-demo-static', title: 'Static demo' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Anchor\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-anchor :affix=\"false\" :items=\"items\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Link item element with padding, text color, hover states, transition animations and other styles",
+          "descriptionZh": "链接项元素，包含内边距、文字颜色、悬停状态、过渡动画等样式"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Title text element with font styles, color changes, text decoration, transition effects and other styles",
+          "descriptionZh": "标题文字元素，包含字体样式、颜色变化、文本装饰、过渡效果等样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element with width, height, background color, position changes, transition animations and other styles",
+          "descriptionZh": "指示器元素，包含宽度、高度、背景色、位置变化、过渡动画等样式"
         }
       ]
     },
@@ -2459,7 +2503,8 @@
           "descriptionZh": "对 `message`、`notification` 进行配置。。",
           "code": "<script setup lang=\"ts\">\nimport MyPage2 from './myPage2.vue'\n</script>\n\n<template>\n  <a-app :message=\"{ maxCount: 1 }\" :notification=\"{ placement: 'bottomLeft' }\">\n    <MyPage2 />\n  </a-app>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "AutoComplete",
@@ -2800,14 +2845,53 @@
           "description": "Disabled text colour inside a Form, debug. Checks that the input text uses the disabled\ncolour both when the Form is disabled and when the component itself is.",
           "descriptionZh": "禁用文字颜色在 Form 中 Debug。校验 `Form disabled` 与组件自身 `disabled` 两种来源下，\n输入框文字都使用禁用色。",
           "code": "<script setup lang=\"ts\">\nconst options = [{ value: 'Disabled Value' }]\n</script>\n\n<template>\n  <a-flex vertical :gap=\"12\" :style=\"{ width: '240px' }\">\n    <a-form disabled>\n      <a-form-item label=\"Form disabled\" :style=\"{ marginBottom: 0 }\">\n        <a-auto-complete value=\"Disabled Value\" :options=\"options\" />\n      </a-form-item>\n    </a-form>\n    <a-auto-complete disabled value=\"Disabled Value\" :options=\"options\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, cursor styles, transitions, border and other basic selector container styles",
+          "descriptionZh": "根元素，包含相对定位、行内 flex 布局、光标样式、过渡动画、边框等选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'placeholder', desc: t('placeholder') },\n  { name: 'content', desc: t('content') },\n  { name: 'clear', desc: t('clear') },\n  { name: 'popup.root', desc: t('popup.root') },\n  { name: 'popup.list', desc: t('popup.list') },\n  { name: 'popup.listItem', desc: t('popup.listItem') },\n])\n\nconst options = ref([\n  { value: 'aojunhao123', label: 'aojunhao123' },\n  { value: 'thinkasany', label: 'thinkasany' },\n  { value: 'meet-student', label: 'meet-student' },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"AutoComplete\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <a-auto-complete\n          prefix=\"prefix\"\n          :style=\"{ width: '200px' }\"\n          :options=\"options\"\n          placeholder=\"input here\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with layout and styling for prefix content",
+          "descriptionZh": "前缀元素，包含前缀内容的布局和样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with search input styling, cursor control, font inheritance and other search-related styles. Remove border styles",
+          "descriptionZh": "输入框元素，包含搜索输入框的样式、光标控制、字体继承等搜索相关样式，去除了边框样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "clear",
+          "description": "Clear button element with layout, styling and interactive effects for clear button",
+          "descriptionZh": "清除按钮元素，包含清除按钮的布局、样式和交互效果"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with popup layer positioning, z-index, background, border, box-shadow and other popup container styles",
+          "descriptionZh": "弹出菜单元素，包含弹出层的定位、层级、背景、边框、阴影等弹出容器样式"
+        },
+        {
+          "key": "popup.list",
+          "description": "Popup list element with option list layout, scrolling, max-height and other list container styles",
+          "descriptionZh": "弹出菜单列表元素，包含选项列表的布局、滚动、最大高度等列表容器样式"
+        },
+        {
+          "key": "popup.listItem",
+          "description": "Popup item element with option item padding, hover effects, selected states, disabled states and other option interactive styles",
+          "descriptionZh": "弹出菜单条目元素，包含选项项的内边距、悬浮效果、选中状态、禁用状态等选项交互样式"
         }
       ]
     },
@@ -3104,7 +3188,8 @@
           "descriptionZh": "头像大小可以根据屏幕大小自动调整。",
           "code": "<script setup lang=\"ts\">\nimport { AntDesignOutlined } from '@antdv-next/icons'\n</script>\n\n<template>\n  <a-avatar\n    :size=\"{ xs: 24, sm: 32, md: 40, lg: 64, xl: 80, xxl: 100 }\"\n  >\n    <template #icon>\n      <AntDesignOutlined />\n    </template>\n  </a-avatar>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Badge",
@@ -3381,22 +3466,33 @@
           "description": "The badge will display `title` when hovered over, instead of `count`.",
           "descriptionZh": "设置鼠标放在状态点上时显示的文字。",
           "code": "<script setup lang=\"ts\">\n</script>\n\n<template>\n  <a-space size=\"large\">\n    <a-badge :count=\"5\" title=\"Custom hover text\">\n      <a-avatar shape=\"square\" size=\"large\" />\n    </a-badge>\n    <a-badge :count=\"-5\" title=\"Negative\">\n      <a-avatar shape=\"square\" size=\"large\" />\n    </a-badge>\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-block display, and fit-content width for basic layout",
+          "descriptionZh": "根元素，包含相对定位、行内块布局、适应内容宽度等基础布局样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Badge\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-badge :count=\"5\" :classes=\"classes\">\n        <a-avatar shape=\"square\" size=\"large\" />\n      </a-badge>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "indicator",
+          "description": "Indicator element with positioning, z-index, dimensions, colors, fonts, text alignment, background, border-radius, box-shadow, and transition animations for complete badge styling",
+          "descriptionZh": "指示器元素，包含定位、层级、尺寸、颜色、字体、文本对齐、背景、圆角、阴影、过渡动画等完整的徽标样式"
         },
         {
-          "name": "_semantic_ribbon",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('ribbonRoot'), version: '1.0.0' },\n  { name: 'indicator', desc: t('ribbonIndicator'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <div style=\"display: flex; flex-direction: column; gap: 24px;\">\n    <SemanticPreview\n      component-name=\"Badge\"\n      :semantics=\"semantics\"\n    >\n      <template #default=\"{ classes }\">\n        <div style=\"width: 100%;\">\n          <a-badge-ribbon text=\"Hippies\" color=\"magenta\" :classes=\"classes\">\n            <a-card title=\"Pushes open the window\" size=\"small\">\n              and raises the spyglass.\n            </a-card>\n          </a-badge-ribbon>\n        </div>\n      </template>\n    </SemanticPreview>\n  </div>\n</template>"
+          "key": "ribbonRoot",
+          "description": "Root element, set relative positioning and wrapper container styles",
+          "descriptionZh": "根元素，设置相对定位和包装容器样式"
+        },
+        {
+          "key": "ribbonIndicator",
+          "description": "Indicator element, set absolute positioning, padding, background color, border radius and ribbon styles",
+          "descriptionZh": "指示器元素，设置绝对定位、内边距、背景色、圆角和缎带样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element, set text color and ribbon content display styles",
+          "descriptionZh": "文本元素，设置文本颜色和缎带内容显示样式"
         }
       ]
     },
@@ -3560,7 +3656,8 @@
           "descriptionZh": "通过 `ConfigProvider` 的 theme.components 可以覆盖 BorderBeam 的 `lineWidth` token，从而调整流光的线宽。",
           "code": "<script setup lang=\"ts\">\nconst customTheme = {\n  components: {\n    BorderBeam: { lineWidth: 3 },\n  },\n}\n</script>\n\n<template>\n  <a-flex :gap=\"24\" wrap>\n    <div :style=\"{ width: '320px' }\">\n      <a-border-beam>\n        <a-card title=\"Default line width\">\n          <a-typography-text type=\"secondary\">\n            Uses the default global lineWidth token from the current theme.\n          </a-typography-text>\n        </a-card>\n      </a-border-beam>\n    </div>\n    <a-config-provider :theme=\"customTheme\">\n      <div :style=\"{ width: '320px' }\">\n        <a-border-beam>\n          <a-card title=\"Custom line width\">\n            <a-typography-text type=\"secondary\">\n              Override lineWidth from theme.token.\n            </a-typography-text>\n          </a-card>\n        </a-border-beam>\n      </div>\n    </a-config-provider>\n  </a-flex>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Breadcrumb",
@@ -3748,14 +3845,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Breadcrumb by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Breadcrumb 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { BreadcrumbProps } from 'antdv-next'\n\nconst classesObject = {\n  root: 'demo-breadcrumb-root',\n  item: 'demo-breadcrumb-item',\n  separator: 'demo-breadcrumb-separator',\n}\n\nconst stylesObject: BreadcrumbProps['styles'] = {\n  root: { border: '1px solid #f0f0f0', padding: '8px', borderRadius: '4px' },\n  item: { color: '#1890ff' },\n  separator: { color: 'rgba(0, 0, 0, 0.45)' },\n}\n\nconst stylesFn: BreadcrumbProps['styles'] = (info) => {\n  const items = info.props.items || []\n  if (items.length > 2) {\n    return {\n      root: { border: '1px solid #F5EFFF', padding: '8px', borderRadius: '4px' },\n      item: { color: '#8F87F1' },\n    }\n  }\n  return {}\n}\n\nconst items = [\n  { title: 'Antdv Next' },\n  { title: 'Component' },\n  { title: 'Breadcrumb' },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-breadcrumb\n      :classes=\"classesObject\"\n      :items=\"items.slice(0, 2)\"\n      :styles=\"stylesObject\"\n      aria-label=\"Breadcrumb with Object\"\n    />\n    <a-breadcrumb\n      :classes=\"classesObject\"\n      :items=\"items\"\n      :styles=\"stylesFn\"\n      aria-label=\"Breadcrumb with Function\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with text color, font size, icon size and other basic styles, using flex layout with ordered list",
+          "descriptionZh": "根元素，包含文字颜色、字体大小、图标尺寸等基础样式，内部使用 flex 布局的有序列表"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { HomeOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'separator', desc: t('separator'), version: '1.0.0' },\n])\n\nconst items = [\n  { href: '', title: h(HomeOutlined) },\n  { href: '', title: [h(UserOutlined), h('span', 'Application List')] },\n  { title: 'Application' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Breadcrumb\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-breadcrumb :items=\"items\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with text color, link color transitions, hover effects, padding, border-radius, height, and margin styles",
+          "descriptionZh": "Item 元素，包含文字颜色、链接的颜色变化、悬浮效果、内边距、圆角、高度、外边距等样式"
+        },
+        {
+          "key": "separator",
+          "description": "Separator element with margin and color styles for the divider",
+          "descriptionZh": "分隔符元素，包含分隔符的外边距和颜色样式"
         }
       ]
     },
@@ -4276,20 +4382,29 @@
           "code": "<script setup lang=\"ts\">\nimport type { ButtonProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: ButtonProps['classes'] = {\n  root: 'demo-button-root',\n  content: 'demo-button-content',\n}\n\nconst stylesObject: ButtonProps['styles'] = {\n  root: {\n    boxShadow: '0 1px 2px 0 rgba(0,0,0,0.05)',\n  },\n}\n\nconst stylesFn: ButtonProps['styles'] = (info) => {\n  if (info?.props?.type === 'primary') {\n    return {\n      root: {\n        backgroundColor: '#171717',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"small\">\n    <a-button type=\"default\" :classes=\"classes\" :styles=\"stylesObject\">\n      Object\n    </a-button>\n    <a-button type=\"primary\" :classes=\"classes\" :styles=\"stylesFn\">\n      Function\n    </a-button>\n  </a-flex>\n</template>"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AntDesignOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Button\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-button type=\"primary\" :classes=\"classes\">\n        <template #icon>\n          <AntDesignOutlined />\n        </template>\n        Antdv Next\n      </a-button>\n    </template>\n  </SemanticPreview>\n</template>"
-        },
-        {
           "name": "chinese-space",
           "title": "",
           "titleZh": "移除两个汉字之间的空格",
           "description": "We add a space between two Chinese characters by default, which can be removed by setting `autoInsertSpace` to `false`.",
           "descriptionZh": "我们默认在两个汉字之间添加空格，可以通过设置 `autoInsertSpace` 为 `false` 关闭。",
           "code": "<template>\n  <a-flex gap=\"small\" wrap>\n    <a-button type=\"primary\" :auto-insert-space=\"false\">\n      确定\n    </a-button>\n    <a-button type=\"primary\" auto-insert-space>\n      确定\n    </a-button>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with comprehensive button styling including border, background, padding, border-radius, box-shadow, transitions, cursor, font-weight, alignment, and layout properties",
+          "descriptionZh": "根元素，包含边框样式、背景色、内边距、圆角、阴影效果、过渡动画、光标样式、文字权重、对齐方式等完整的按钮外观样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element that wraps button text with typography styles including nowrap, text-align center, and Chinese character spacing optimization",
+          "descriptionZh": "内容元素，包装按钮文本内容，控制文本的不换行显示、居中对齐、中文字符间距优化等文本排版样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with font-size, color inheritance, and SVG style reset for proper icon display",
+          "descriptionZh": "图标元素，包含图标的字体大小、颜色继承、SVG 样式重置等图标显示相关样式"
         }
       ]
     },
@@ -4577,14 +4692,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Calendar by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Calendar 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CalendarProps } from 'antdv-next'\nimport type { Dayjs } from 'dayjs'\n\nconst classes = {\n  root: 'custom-calendar-root',\n}\n\nconst stylesObject: CalendarProps<Dayjs>['styles'] = {\n  root: {\n    borderRadius: '8px',\n    width: '600px',\n  },\n}\n\nconst stylesFunction: CalendarProps<Dayjs>['styles'] = (info) => {\n  if (info.props.fullscreen) {\n    return {\n      root: {\n        border: '2px solid #BDE3C3',\n        borderRadius: '10px',\n        backgroundColor: 'rgba(189,227,195, 0.3)',\n      },\n    } satisfies CalendarProps<Dayjs>['styles']\n  }\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-calendar :fullscreen=\"false\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-calendar :classes=\"classes\" :styles=\"stylesFunction\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element containing background, border, border-radius and overall layout structure of the calendar component",
+          "descriptionZh": "根元素，包含日历组件的背景色、边框、圆角等基础样式和整体布局结构"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'itemContent', desc: t('itemContent'), version: '1.3.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Calendar\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-calendar :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with layout and style control for year selector, month selector and mode switcher",
+          "descriptionZh": "头部元素，包含年份选择器、月份选择器、模式切换器的布局和样式控制"
+        },
+        {
+          "key": "body",
+          "description": "Body element with padding and layout control for the calendar table that contains the calendar grid",
+          "descriptionZh": "主体元素，包含日历表格的内边距、布局控制等样式，用于容纳日历网格"
+        },
+        {
+          "key": "content",
+          "description": "Content element with width, height and table styling control for the calendar table",
+          "descriptionZh": "内容元素，包含日历表格的宽度、高度等尺寸控制和表格样式"
+        },
+        {
+          "key": "item",
+          "description": "Item element with background, border, hover state, selected state and other interactive styles for calendar cells",
+          "descriptionZh": "条目元素，包含日历单元格的背景色、边框、悬停态、选中态等交互样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Item content element with layout and styles for the calendar cell content area",
+          "descriptionZh": "条目内容元素，包含日历单元格内容区域的布局和样式"
         }
       ]
     },
@@ -5070,14 +5209,43 @@
           "description": "Debug vertical alignment of button icons inside Card extra (#57727, #57896, #58428).",
           "descriptionZh": "调试 Card extra 中按钮图标的垂直对齐（#57727、#57896、#58428）。",
           "code": "<script setup lang=\"ts\">\nimport { SmileOutlined } from '@antdv-next/icons'\nimport { Popconfirm } from 'antdv-next'\nimport { h } from 'vue'\n\nconst InternalPopconfirm = Popconfirm._InternalPanelDoNotUseOrYouWillBeFired\n\nconst btnCls = {\n  icon: 'card-btn-debug-icon',\n  content: 'card-btn-debug-content',\n}\n</script>\n\n<template>\n  <a-config-provider :button=\"{ classes: btnCls }\">\n    <a-flex vertical gap=\"middle\">\n      <a-card class=\"line-card\" title=\"#57727 Card extra\">\n        <template #extra>\n          <a-button>\n            <template #icon>\n              <SmileOutlined />\n            </template>\n            Test\n          </a-button>\n        </template>\n        Button in Card extra should be vertically centered with the title.\n      </a-card>\n\n      <a-card title=\"#57896 regression minimum case\">\n        <div class=\"simulate-57896\">\n          <div class=\"inline-buttons\">\n            <a-button>Cancel</a-button>\n            <a-button type=\"primary\" :icon=\"() => h(SmileOutlined)\">\n              Confirm\n            </a-button>\n          </div>\n        </div>\n      </a-card>\n\n      <InternalPopconfirm\n        title=\"Are you OK?\"\n        :ok-button-props=\"{ icon: () => h(SmileOutlined) }\"\n      />\n    </a-flex>\n  </a-config-provider>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Card root element with positioning, background, border, border-radius, box-shadow, padding and other container styles",
+          "descriptionZh": "卡片根元素，包含位置定位、背景色、边框、圆角、阴影、内边距等卡片容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, EllipsisOutlined, SettingOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'cover', desc: t('cover'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Card\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ position: 'absolute' }\">\n        <a-card\n          title=\"Card title\"\n          extra=\"More\"\n          :style=\"{ width: '300px' }\"\n          :classes=\"classes\"\n        >\n          <template #cover>\n            <img\n              draggable=\"false\"\n              alt=\"example\"\n              src=\"https://gw.alipayobjects.com/zos/rmsportal/JiqGstEfoWAOHiTxclqi.png\"\n            >\n          </template>\n          <template #actions>\n            <SettingOutlined key=\"setting\" />\n            <EditOutlined key=\"edit\" />\n            <EllipsisOutlined key=\"ellipsis\" />\n          </template>\n          <a-card-meta\n            title=\"Card Meta title\"\n            description=\"This is the description\"\n          >\n            <template #avatar>\n              <a-avatar src=\"https://api.dicebear.com/7.x/miniavs/svg?seed=8\" />\n            </template>\n          </a-card-meta>\n        </a-card>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Card header area with flex layout, min-height, padding, text color, font-weight, font-size, background, bottom border and top border-radius",
+          "descriptionZh": "卡片头部区域，包含 flex 布局、最小高度、内边距、文字颜色、字体权重、字体大小、背景色、下边框、顶部圆角等样式"
+        },
+        {
+          "key": "body",
+          "description": "Card content area with padding, font-size and other content display styles",
+          "descriptionZh": "卡片内容区域，包含内边距、字体大小等内容展示的基础样式"
+        },
+        {
+          "key": "extra",
+          "description": "Card extra operation area in top-right corner with text color and layout styles for additional content",
+          "descriptionZh": "卡片右上角的操作区域，包含额外内容的文字颜色和布局样式"
+        },
+        {
+          "key": "title",
+          "description": "Card title with inline-block display, flex-grow, text ellipsis and other title display styles",
+          "descriptionZh": "卡片标题，包含行内块布局、flex 占比、文本省略等标题显示样式"
+        },
+        {
+          "key": "actions",
+          "description": "Card bottom action group with flex layout, list-style reset, background, top border and bottom border-radius for action buttons container",
+          "descriptionZh": "卡片底部操作组，包含 flex 布局、列表样式重置、背景色、上边框、底部圆角等操作按钮容器样式"
+        },
+        {
+          "key": "cover",
+          "description": "Title cover with styles for cover image display and layout",
+          "descriptionZh": "标题封面，包含封面图片的显示和布局样式"
         }
       ]
     },
@@ -5343,7 +5511,8 @@
           "descriptionZh": "展示指示点的进度。",
           "code": "<template>\n  <a-carousel :autoplay=\"{ dotDuration: true }\" :autoplay-speed=\"5000\">\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        1\n      </h3>\n    </div>\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        2\n      </h3>\n    </div>\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        3\n      </h3>\n    </div>\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        4\n      </h3>\n    </div>\n  </a-carousel>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Cascader",
@@ -5735,14 +5904,6 @@
           "code": "<script setup lang=\"ts\">\nimport type { CascaderEmits } from 'antdv-next'\nimport { ref } from 'vue'\n\ninterface Option {\n  value: string | number\n  label: string\n  children?: Option[]\n}\n\nconst options: Option[] = [\n  {\n    value: 'zhejiang',\n    label: 'Zhejiang',\n    children: [\n      {\n        value: 'hangzhou',\n        label: 'Hangzhou',\n        children: [\n          {\n            value: 'xihu',\n            label: 'West Lake',\n          },\n        ],\n      },\n    ],\n  },\n  {\n    value: 'jiangsu',\n    label: 'Jiangsu',\n    children: [\n      {\n        value: 'nanjing',\n        label: 'Nanjing',\n        children: [\n          {\n            value: 'zhonghuamen',\n            label: 'Zhong Hua Men',\n          },\n        ],\n      },\n    ],\n  },\n]\n\nconst disabled = ref(false)\n\nconst onChange: CascaderEmits['change'] = (value) => {\n  console.log(value)\n}\n\nconst onMultipleChange: CascaderEmits['change'] = (value) => {\n  console.log(value)\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"small\" align=\"flex-start\">\n    <a-switch\n      v-model:checked=\"disabled\"\n      checked-children=\"Enabled\"\n      un-checked-children=\"Disabled\"\n      aria-label=\"disabled switch\"\n    />\n    <a-cascader-panel :options=\"options\" :disabled=\"disabled\" @change=\"onChange\" />\n    <a-cascader-panel multiple :options=\"options\" :disabled=\"disabled\" @change=\"onMultipleChange\" />\n    <a-cascader-panel />\n  </a-flex>\n</template>"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst mode = ref<'single' | 'multiple'>('single')\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => {\n  const base = [\n    { name: 'root', desc: t('root') },\n    { name: 'prefix', desc: t('prefix') },\n    { name: 'content', desc: t('content') },\n    { name: 'placeholder', desc: t('placeholder') },\n    { name: 'clear', desc: t('clear') },\n    { name: 'input', desc: t('input') },\n    { name: 'suffix', desc: t('suffix') },\n    { name: 'popup.root', desc: t('popup.root') },\n    { name: 'popup.list', desc: t('popup.list') },\n    { name: 'popup.listItem', desc: t('popup.listItem') },\n  ]\n\n  if (mode.value === 'multiple') {\n    return [\n      ...base,\n      { name: 'item', desc: t('item') },\n      { name: 'itemContent', desc: t('itemContent') },\n      { name: 'itemRemove', desc: t('itemRemove') },\n    ]\n  }\n\n  return base\n})\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst options = [\n  {\n    value: 'contributors',\n    label: 'contributors',\n    children: [\n      { value: 'aojunhao123', label: 'aojunhao123' },\n      { value: 'thinkasany', label: 'thinkasany' },\n      { value: 'meet-student', label: 'meet-student' },\n    ],\n  },\n]\n\nconst value = computed(() => {\n  if (mode.value !== 'multiple')\n    return ['contributors', 'thinkasany']\n\n  return [['contributors', 'aojunhao123']]\n})\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Cascader\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <div :style=\"{ display: 'flex', justifyContent: 'center', marginBottom: '12px' }\">\n          <a-segmented v-model:value=\"mode\" :options=\"['single', 'multiple']\" />\n        </div>\n        <div :style=\"{ display: 'flex', flexDirection: 'column', gap: '12px' }\">\n          <a-cascader\n            prefix=\"prefix\"\n            :style=\"{ width: '300px' }\"\n            :options=\"options\"\n            :value=\"value\"\n            :multiple=\"mode === 'multiple'\"\n            open\n            :get-popup-container=\"() => divRef!\"\n            :classes=\"classes\"\n          />\n        </div>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
-        },
-        {
           "name": "basic",
           "title": "",
           "titleZh": "基本",
@@ -5789,6 +5950,73 @@
           "description": "Allows the selection of only parent options.",
           "descriptionZh": "这种交互允许只选中父级选项。",
           "code": "<script setup lang=\"ts\">\nimport type { CascaderEmits } from 'antdv-next'\nimport { shallowRef } from 'vue'\n\ninterface Option {\n  value: string\n  label: string\n  children?: Option[]\n}\n\nconst options: Option[] = [\n  {\n    value: 'zhejiang',\n    label: 'Zhejiang',\n    children: [\n      {\n        value: 'hangzhou',\n        label: 'Hanzhou',\n        children: [\n          {\n            value: 'xihu',\n            label: 'West Lake',\n          },\n        ],\n      },\n    ],\n  },\n  {\n    value: 'jiangsu',\n    label: 'Jiangsu',\n    children: [\n      {\n        value: 'nanjing',\n        label: 'Nanjing',\n        children: [\n          {\n            value: 'zhonghuamen',\n            label: 'Zhong Hua Men',\n          },\n        ],\n      },\n    ],\n  },\n]\n\nconst onChange: CascaderEmits['change'] = (value) => {\n  console.log(value)\n}\nconst value = shallowRef()\n</script>\n\n<template>\n  <a-cascader v-model:value=\"value\" :options=\"options\" change-on-select @change=\"onChange\" />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, cursor styles, transitions, border and other basic selector container styles",
+          "descriptionZh": "根元素，包含相对定位、行内 flex 布局、光标样式、过渡动画、边框等选择器容器的基础样式"
+        },
+        {
+          "key": "prefix",
+          "description": "Prefix element with layout and styling for prefix content",
+          "descriptionZh": "前缀元素，包含前缀内容的布局和样式"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "clear",
+          "description": "Clear button element with layout, styling and interactive effects for clear button式",
+          "descriptionZh": "清除按钮元素，包含清除按钮的布局、样式和交互效果"
+        },
+        {
+          "key": "item",
+          "description": "Multiple selection item element with border, background, padding, and margin styles",
+          "descriptionZh": "多选项元素，包含边框、背景、内边距、外边距样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Multiple selection item content area with text ellipsis styles",
+          "descriptionZh": "多选项内容区域，包含文字的省略样式"
+        },
+        {
+          "key": "itemRemove",
+          "description": "Multiple selection item remove button with font-related styles式",
+          "descriptionZh": "多选项移除按钮，包含字体相关样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with search input styling, cursor control, font inheritance and other search-related styles. Remove border styles",
+          "descriptionZh": "输入框元素，包含搜索输入框的样式、光标控制、字体继承等搜索相关样式，去除了边框样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with layout and styling for suffix content like clear button, arrow icon, etc.",
+          "descriptionZh": "后缀元素，包含后缀内容的布局和样式，如清除按钮、箭头图标等"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with popup layer positioning, z-index, background, border, box-shadow and other popup container styles",
+          "descriptionZh": "弹出菜单元素，包含弹出层的定位、层级、背景、边框、阴影等弹出容器样式"
+        },
+        {
+          "key": "popup.list",
+          "description": "Popup list element with option list layout, scrolling, max-height and other list container styles",
+          "descriptionZh": "弹出菜单列表元素，包含选项列表的布局、滚动、最大高度等列表容器样式"
+        },
+        {
+          "key": "popup.listItem",
+          "description": "Popup item element with option item padding, hover effects, selected states, disabled states and other option interactive styles",
+          "descriptionZh": "弹出菜单条目元素，包含选项项的内边距、悬浮效果、选中状态、禁用状态等选项交互样式式"
         }
       ]
     },
@@ -6017,14 +6245,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Checkbox by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Checkbox 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CheckboxProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\nimport { ref } from 'vue'\n\nconst checked = ref(true)\nconst { token } = theme.useToken()\n\n// Object styles — 静态样式对象\nconst stylesObject: CheckboxProps['styles'] = {\n  icon: {\n    borderRadius: '6px',\n  },\n  label: {\n    color: 'blue',\n  },\n}\n\n// Function classes — 根据 checked 状态动态返回类名\nconst classesFn: CheckboxProps['classes'] = (info) => {\n  const base: Record<string, string> = {\n    root: 'checkbox-demo-root',\n    icon: 'checkbox-demo-icon',\n    label: 'checkbox-demo-label',\n  }\n  if (info.props.checked) {\n    return {\n      root: base.root,\n      icon: `${base.icon} checkbox-demo-icon-checked`,\n      label: `${base.label} checkbox-demo-label-checked`,\n    }\n  }\n  return base\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-checkbox :styles=\"stylesObject\">\n      Object styles\n    </a-checkbox>\n    <a-checkbox\n      v-model:checked=\"checked\"\n      :classes=\"classesFn\"\n    >\n      Function classes\n    </a-checkbox>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with inline-flex layout, baseline alignment, cursor style, reset styles and other basic checkbox container styles",
+          "descriptionZh": "根元素，包含行内 flex 布局、基线对齐、光标样式、重置样式等复选框容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Checkbox\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-checkbox :classes=\"classes\">\n        Checkbox\n      </a-checkbox>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Checkbox icon element with size, direction, background, border, border-radius, transitions, and checked state checkmark styles",
+          "descriptionZh": "选中框元素，包含尺寸、方向、背景色、边框、圆角、过渡动画，以及选中状态的勾选标记样式"
+        },
+        {
+          "key": "label",
+          "description": "Label text element with padding and spacing styles relative to the checkbox",
+          "descriptionZh": "文本元素，包含文本的内边距和与复选框的间距样式"
         }
       ]
     },
@@ -6408,14 +6645,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Collapse by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Collapse 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CollapseProps } from 'antdv-next'\nimport { h } from 'vue'\n\nconst text\n  = 'A dog is a type of domesticated animal. Known for its loyalty and faithfulness, it can be found as a welcome guest in many households across the world.'\n\nconst element = h('p', text)\n\nconst items = [\n  {\n    key: '1',\n    label: 'This is panel header 1',\n    content: element,\n  },\n  {\n    key: '2',\n    label: 'This is panel header 2',\n    content: element,\n  },\n  {\n    key: '3',\n    label: 'This is panel header 3',\n    content: element,\n  },\n]\n\nconst classes: CollapseProps['classes'] = {\n  root: 'demo-collapse-root',\n}\n\nconst stylesObject: CollapseProps['styles'] = {\n  root: {\n    backgroundColor: '#fafafa',\n    border: '1px solid #e0e0e0',\n    borderRadius: '8px',\n  },\n  header: {\n    backgroundColor: '#f0f0f0',\n    padding: '12px 16px',\n    color: '#141414',\n  },\n}\n\nconst stylesFn: CollapseProps['styles'] = (info) => {\n  if (info?.props?.size === 'large') {\n    return {\n      root: {\n        backgroundColor: '#fff',\n        border: '1px solid #696FC7',\n        borderRadius: '8px',\n      },\n      header: {\n        backgroundColor: '#F5EFFF',\n        padding: '12px 16px',\n        color: '#141414',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-collapse :items=\"items\" :classes=\"classes\" :styles=\"stylesObject\" :default-active-key=\"['1']\" />\n    <a-collapse :items=\"items\" :classes=\"classes\" :styles=\"stylesFn\" size=\"large\" :default-active-key=\"['2']\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with border, border-radius, background color and container styles that control the overall layout and appearance of collapse panels",
+          "descriptionZh": "根元素，包含折叠面板的边框、圆角、背景色等容器样式，控制面板的整体布局和外观"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { theme } from 'antdv-next'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n])\n\nconst { token } = theme.useToken()\n\nconst items = computed(() => [\n  {\n    key: '1',\n    label: 'This is panel header',\n    children: 'This is panel body',\n  },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Collapse\"\n    items-a-p-i=\"items\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ position: 'absolute', inset: 0, margin: `${token.marginXL}px` }\">\n        <a-collapse\n          :items=\"items\"\n          :default-active-key=\"['1']\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with flex layout, padding, color, line-height, cursor style, transition animations and other interactive styles for panel headers",
+          "descriptionZh": "头部元素，包含flex布局、内边距、颜色、行高、光标样式、过渡动画等面板头部的交互和样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with flex auto layout and margin styles for title text layout and typography",
+          "descriptionZh": "标题元素，包含flex自适应布局、右边距等标题文字的布局和排版样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with padding, color, background color and other styles for panel content area display",
+          "descriptionZh": "内容元素，包含内边距、颜色、背景色等面板内容区域的展示样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with font size, transition animations, rotation transforms and other styles and animations for expand/collapse arrows",
+          "descriptionZh": "图标元素，包含字体大小、过渡动画、旋转变换等展开收起箭头的样式和动效"
         }
       ]
     },
@@ -6763,14 +7019,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of ColorPicker by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或函数可以自定义 ColorPicker 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst classes = { root: 'custom-color-picker' }\n\nconst color = shallowRef('#1677ff')\nconst colorLarge = shallowRef('#722ed1')\n\nconst stylesObject = {\n  popup: {\n    root: {\n      border: '1px solid #fff',\n    },\n  },\n}\n\nfunction stylesFn(info: any) {\n  if (info?.props?.size === 'large') {\n    return {\n      popup: {\n        root: {\n          border: '1px solid #722ed1',\n        },\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-space size=\"middle\" wrap>\n    <a-color-picker\n      v-model:value=\"color\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    />\n    <a-color-picker\n      v-model:value=\"colorLarge\"\n      size=\"large\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n    />\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Trigger container with border styles, transition animations, size controls, displaying color block and text content",
+          "descriptionZh": "触发器容器，包含边框样式、过渡动画、尺寸控制等样式，显示颜色块和文本内容"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'body', desc: t('body') },\n  { name: 'content', desc: t('content') },\n  { name: 'description', desc: t('description') },\n  { name: 'popup.root', desc: t('popup.root') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\nconst body = document?.body\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"ColorPicker\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" :style=\"{ height: '300px' }\" align=\"flex-start\" gap=\"small\">\n        <a-color-picker\n          default-value=\"#1677ff\"\n          open\n          show-text\n          :get-popup-container=\"() => divRef || body\"\n          :styles=\"{ popup: { root: { zIndex: 1 } } }\"\n          :classes=\"classes\"\n        />\n        <a-color-picker :open=\"false\" allow-clear :classes=\"classes\" />\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "popup.root",
+          "description": "Popup panel root container with background color, shadow effects, color selection panel, slider controls and preset colors",
+          "descriptionZh": "弹出面板根容器，包含背景色、阴影效果、色彩选择面板、滑块控制和预设颜色等样式"
+        },
+        {
+          "key": "body",
+          "description": "Color block container with background color, border styles",
+          "descriptionZh": "色块容器，包含底色、边框等样式"
+        },
+        {
+          "key": "content",
+          "description": "Color block element with actual selected color styles",
+          "descriptionZh": "色块颜色元素，包含实际选择的颜色样式"
+        },
+        {
+          "key": "description",
+          "description": "Description text content with font styles and color",
+          "descriptionZh": "描述文本内容，包含字体样式、颜色等样式"
         }
       ]
     },
@@ -6992,7 +7267,8 @@
           "descriptionZh": "通过 `theme.token.focusOutline` 全局关闭组件聚焦时的可见描边。用 Tab 键在下面的控件间移动即可对比效果。",
           "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\n\nconst focusOutline = ref(true)\n\nconst themeConfig = computed(() => ({\n  token: {\n    focusOutline: focusOutline.value,\n  },\n}))\n\nconst options = [\n  { value: 'apple', label: 'Apple' },\n  { value: 'orange', label: 'Orange' },\n  { value: 'banana', label: 'Banana' },\n]\n\nconst current = ref(0)\n\nfunction onStepChange(value: number) {\n  current.value = value\n}\n</script>\n\n<template>\n  <a-space direction=\"vertical\" style=\"width: 100%\">\n    <a-space>\n      focusOutline\n      <a-switch v-model:checked=\"focusOutline\" />\n    </a-space>\n\n    <a-config-provider :theme=\"themeConfig\">\n      <a-space direction=\"vertical\" style=\"width: 100%\">\n        <a-input placeholder=\"Outlined\" style=\"max-width: 240px\" />\n        <a-input variant=\"borderless\" placeholder=\"Borderless\" style=\"max-width: 240px\" />\n        <a-select :options=\"options\" variant=\"borderless\" placeholder=\"Borderless select\" style=\"width: 240px\" />\n        <a-rate :default-value=\"3\" />\n        <a-steps\n          :current=\"current\"\n          :items=\"[{ title: 'First' }, { title: 'Second' }, { title: 'Third' }]\"\n          @change=\"onStepChange\"\n        />\n        <a-splitter style=\"height: 100px; border: 1px solid var(--ant-color-border)\">\n          <a-splitter-panel collapsible>\n            First\n          </a-splitter-panel>\n          <a-splitter-panel>\n            Second\n          </a-splitter-panel>\n        </a-splitter>\n        <a-button>Button</a-button>\n      </a-space>\n    </a-config-provider>\n  </a-space>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "DatePicker",
@@ -7626,14 +7902,63 @@
           "description": "Custom `prefix` and `suffixIcon`.",
           "descriptionZh": "自定义前缀 `prefix` 和后缀图标 `suffixIcon`。",
           "code": "<script setup lang=\"ts\">\nimport type { Dayjs } from 'dayjs'\nimport { SmileOutlined } from '@antdv-next/icons'\nimport { h } from 'vue'\n\nconst smileIcon = h(SmileOutlined)\n\nfunction handleChange(date: Dayjs | (Dayjs | null)[] | null, dateString: string | string[] | null) {\n  console.log(date, dateString)\n}\n</script>\n\n<template>\n  <a-space vertical :size=\"12\">\n    <a-date-picker :suffix-icon=\"smileIcon\" @change=\"handleChange\" />\n    <a-date-picker :suffix-icon=\"smileIcon\" picker=\"month\" @change=\"handleChange\" />\n    <a-range-picker :suffix-icon=\"smileIcon\" @change=\"handleChange\" />\n    <a-date-picker :suffix-icon=\"smileIcon\" picker=\"week\" @change=\"handleChange\" />\n    <a-date-picker suffix-icon=\"ab\" @change=\"handleChange\" />\n    <a-date-picker suffix-icon=\"ab\" picker=\"month\" @change=\"handleChange\" />\n    <a-range-picker suffix-icon=\"ab\" @change=\"handleChange\" />\n    <a-date-picker suffix-icon=\"ab\" picker=\"week\" @change=\"handleChange\" />\n    <a-date-picker :prefix=\"smileIcon\" picker=\"week\" @change=\"handleChange\" />\n    <a-date-picker prefix=\"Event Period\" picker=\"week\" @change=\"handleChange\" />\n    <a-range-picker :prefix=\"smileIcon\" picker=\"week\" @change=\"handleChange\" />\n    <a-range-picker prefix=\"Event Period\" picker=\"week\" @change=\"handleChange\" />\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, padding, border-radius, transition animations and other basic styles for date picker container",
+          "descriptionZh": "根元素，包含相对定位、行内flex布局、内边距、边框圆角、过渡动画等日期选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { SmileOutlined } from '@antdv-next/icons'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'popup.root', desc: t('popup') },\n  { name: 'popup.container', desc: t('popup.container') },\n  { name: 'popup.header', desc: t('popup.header') },\n  { name: 'popup.body', desc: t('popup.body') },\n  { name: 'popup.content', desc: t('popup.content') },\n  { name: 'popup.item', desc: t('popup.item') },\n  { name: 'popup.footer', desc: t('popup.footer') },\n])\n\nconst type = ref<'Single' | 'Multiple'>('Single')\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    :component-name=\"type === 'Single' ? 'DatePicker' : 'DatePicker.RangePicker'\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" vertical :style=\"{ alignSelf: 'flex-start' }\" gap=\"middle\" align=\"center\">\n        <a-segmented\n          :options=\"['Single', 'Multiple']\"\n          :value=\"type\"\n          @change=\"(val: 'Single' | 'Multiple') => type = val\"\n        />\n        <a-date-picker\n          v-if=\"type === 'Single'\"\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-date-picker>\n        <a-range-picker\n          v-else\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-range-picker>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with flex layout and margin styles for prefix content layout",
+          "descriptionZh": "前缀元素，包含flex布局、右外边距等前缀内容的布局样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with relative positioning, width, color, font, line-height, transition animations and other core interactive styles for input field",
+          "descriptionZh": "输入框元素，包含相对定位、宽度、颜色、字体、行高、过渡动画等输入框的核心交互样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with flex layout, color, line-height, pointer events, transition animations and other styles for suffix content",
+          "descriptionZh": "后缀元素，包含flex布局、颜色、行高、指针事件、过渡动画等后缀内容的样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup element",
+          "descriptionZh": "弹出框元素"
+        },
+        {
+          "key": "popup.container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "popup.header",
+          "description": "Popup header element with navigation buttons, month/year selectors and other header control area layout and styles",
+          "descriptionZh": "弹出框头部元素，包含导航按钮、月份年份选择器等头部控制区域的布局和样式"
+        },
+        {
+          "key": "popup.body",
+          "description": "Popup body element with container layout and styles for date panel table",
+          "descriptionZh": "弹出框主体元素，包含日期面板表格的容器布局和样式"
+        },
+        {
+          "key": "popup.content",
+          "description": "Popup content element with width, border, cell and other content display styles for date table",
+          "descriptionZh": "弹出框内容元素，包含日期表格的宽度、边框、单元格等内容展示样式"
+        },
+        {
+          "key": "popup.item",
+          "description": "Popup item element with size, background, border-radius, hover state, selected state and other interactive styles for date cells",
+          "descriptionZh": "弹出框单项元素，包含日期单元格的尺寸、背景色、边框圆角、悬停态、选中态等交互样式"
+        },
+        {
+          "key": "popup.footer",
+          "description": "Popup footer element with layout styles for bottom operation area including confirm/cancel buttons and shortcuts",
+          "descriptionZh": "弹出框底部元素，包含确认取消按钮、快捷选择等底部操作区域的布局样式"
         }
       ]
     },
@@ -7887,14 +8212,38 @@
           "description": "Display of the entire line.",
           "descriptionZh": "整行的展示。",
           "code": "<script setup lang=\"ts\">\nimport type { DescriptionsItemType } from 'antdv-next'\n\nconst items: DescriptionsItemType[] = [\n  {\n    label: 'UserName',\n    content: 'Zhou Maomao',\n  },\n  {\n    label: 'Live',\n    span: 'filled', // span = 2\n    content: 'Hangzhou, Zhejiang',\n  },\n  {\n    label: 'Remark',\n    span: 'filled', // span = 3\n    content: 'empty',\n  },\n  {\n    label: 'Address',\n    span: 1, // span will be 3 and warning for span is not align to the end\n    content: 'No. 18, Wantang Road, Xihu District, Hangzhou, Zhejiang, China',\n  },\n]\n</script>\n\n<template>\n  <a-descriptions title=\"User Info\" :items=\"items\" bordered />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with basic styles, reset styles, border styles, layout direction and other overall styles for description list container",
+          "descriptionZh": "根元素，包含描述列表容器的基础样式、重置样式、边框样式、布局方向等整体样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n\nconst bordered = ref(false)\n\nconst items = [\n  { key: '1', label: 'Telephone', content: '1810000000' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Descriptions\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ width: '100%', height: '100%' }\">\n        <a-switch v-model:checked=\"bordered\" />\n        Toggle Border\n        <a-divider />\n        <a-descriptions\n          title=\"User Info\"\n          :items=\"items\"\n          :bordered=\"bordered\"\n          :classes=\"classes\"\n        >\n          <template #extra>\n            <a-button type=\"primary\">\n              Edit\n            </a-button>\n          </template>\n        </a-descriptions>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with flex layout, alignment, bottom margin and other layout and style controls for header area",
+          "descriptionZh": "头部元素，包含flex布局、对齐方式、下边距等头部区域的布局和样式控制"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text ellipsis, flex ratio, color, font weight, font size, line height and other title text styles",
+          "descriptionZh": "标题元素，包含文本省略、flex占比、颜色、字体权重、字体大小、行高等标题文字样式"
+        },
+        {
+          "key": "extra",
+          "description": "Extra content element with left margin, color, font size and other styles for additional operation area",
+          "descriptionZh": "额外内容元素，包含左边距、颜色、字体大小等额外操作区域的样式"
+        },
+        {
+          "key": "label",
+          "description": "Label element with color, font weight, font size, line height, text align, colon styles and other label text styles",
+          "descriptionZh": "标签元素，包含颜色、字体权重、字体大小、行高、文本对齐、冒号样式等标签文字的样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with table cell layout, color, font size, line height, word break and other content display styles",
+          "descriptionZh": "内容元素，包含表格单元格布局、颜色、字体大小、行高、文字换行等内容展示样式"
         }
       ]
     },
@@ -8063,14 +8412,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of divider by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义分割线的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { DividerProps } from 'antdv-next'\n\nconst classesObject: DividerProps['classes'] = {\n  root: 'demo-divider-root',\n  content: 'demo-divider-content',\n  rail: 'demo-divider-rail',\n}\n\nconst classesFn: DividerProps['classes'] = (info) => {\n  if (info?.props?.titlePlacement === 'start') {\n    return {\n      root: 'demo-divider-root--start',\n    }\n  }\n  return {\n    root: 'demo-divider-root--default',\n  }\n}\n\nconst stylesObject: DividerProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed' },\n  content: { fontStyle: 'italic' },\n  rail: { opacity: 0.85 },\n}\n\nconst stylesFn: DividerProps['styles'] = (info) => {\n  if (info?.props?.size === 'small') {\n    return {\n      root: { opacity: 0.6, cursor: 'default' },\n    }\n  }\n  return {\n    root: { backgroundColor: '#fafafa', borderColor: '#d9d9d9' },\n  }\n}\n</script>\n\n<template>\n  <div>\n    <a-divider :classes=\"classesObject\">\n      classes Object\n    </a-divider>\n    <a-divider title-placement=\"start\" :classes=\"classesFn\">\n      classes Function\n    </a-divider>\n    <a-divider :styles=\"stylesObject\">\n      styles Object\n    </a-divider>\n    <a-divider size=\"small\" :styles=\"stylesFn\">\n      styles Function\n    </a-divider>\n  </div>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with border-top style, divider styling and other basic divider container styles",
+          "descriptionZh": "根元素，包含边框顶部样式、分隔线样式等分割线容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'rail', desc: t('rail') },\n  { name: 'content', desc: t('content') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Divider\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div>\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider :classes=\"classes\" />\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider :classes=\"classes\">\n          Solid\n        </a-divider>\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider title-placement=\"left\" variant=\"dotted\" :classes=\"classes\">\n          Dotted\n        </a-divider>\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider title-placement=\"right\" variant=\"dashed\" :classes=\"classes\">\n          Dashed\n        </a-divider>\n        These\n        <a-divider orientation=\"vertical\" :classes=\"classes\" />\n        are\n        <a-divider orientation=\"vertical\" :classes=\"classes\" />\n        vertical\n        <a-divider orientation=\"vertical\" :classes=\"classes\" />\n        Dividers\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "content",
+          "description": "Content element with inline-block display, padding and other divider text content styles",
+          "descriptionZh": "内容元素，包含行内块显示、内边距等分割线文本内容的样式"
+        },
+        {
+          "key": "rail",
+          "description": "Background rail element with border-top style and other divider connection line styles",
+          "descriptionZh": "背景条元素，包含边框顶部样式等分割线连接条的样式"
         }
       ]
     },
@@ -8447,14 +8805,58 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Drawer by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Drawer 组件的 [语义化结构](#semantic-dom) 样式。",
           "code": "<script setup lang=\"ts\">\nimport type { DrawerProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\nimport { ref } from 'vue'\n\nconst { token } = theme.useToken()\nconst open = ref(false)\nconst openFn = ref(false)\n\nconst classes: DrawerProps['classes'] = {\n  header: 'demo-drawer-header',\n  body: 'demo-drawer-body',\n}\n\nconst stylesObject: DrawerProps['styles'] = {\n  body: {\n    backgroundColor: '#f5f5f5',\n  },\n  footer: {\n    backgroundColor: '#fafafa',\n  },\n}\n\nconst stylesFn: DrawerProps['styles'] = (info) => {\n  if (info?.props?.placement === 'right') {\n    return {\n      mask: {\n        backgroundColor: 'rgba(0, 0, 0, 0.2)',\n      },\n      wrapper: {\n        boxShadow: '0 8px 24px rgba(0, 0, 0, 0.15)',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-button @click=\"open = true\">\n      Object Style\n    </a-button>\n    <a-button type=\"primary\" @click=\"openFn = true\">\n      Function Style\n    </a-button>\n  </a-flex>\n\n  <a-drawer\n    v-model:open=\"open\"\n    title=\"Custom Style Drawer\"\n    :classes=\"classes\"\n    :styles=\"stylesObject\"\n    @close=\"open = false\"\n  >\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n  </a-drawer>\n\n  <a-drawer\n    v-model:open=\"openFn\"\n    title=\"Custom Function Drawer\"\n    :classes=\"classes\"\n    :styles=\"stylesFn\"\n    @close=\"openFn = false\"\n  >\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n  </a-drawer>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with fixed positioning, z-index control, pointer events, color and other basic styles and layout control for drawer container",
+          "descriptionZh": "根元素，包含固定定位、层级控制、指针事件、颜色等抽屉容器的基础样式和布局控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'mask', desc: t('mask'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n  { name: 'dragger', desc: t('dragger'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Drawer\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-drawer\n        title=\"Title\"\n        placement=\"right\"\n        open\n        :get-container=\"false\"\n        :size=\"300\"\n        :resizable=\"{}\"\n        :classes=\"classes\"\n      >\n        <template #footer>\n          <a-typography-link>Footer</a-typography-link>\n        </template>\n        <template #extra>\n          <a-button>Cancel</a-button>\n        </template>\n        <p>Some contents...</p>\n      </a-drawer>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "mask",
+          "description": "Mask element with absolute positioning, z-index, background color, pointer events and other mask layer styles and interaction controls",
+          "descriptionZh": "遮罩层元素，包含绝对定位、层级、背景色、指针事件等遮罩层的样式和交互控制"
+        },
+        {
+          "key": "section",
+          "description": "Drawer container element with flex layout, width/height, overflow control, background color, pointer events and other drawer body styles",
+          "descriptionZh": "Drawer 容器元素，包含flex布局、宽高、溢出控制、背景色、指针事件等抽屉主体的样式"
+        },
+        {
+          "key": "header",
+          "description": "Header element with flex layout, alignment, padding, font size, line height, bottom border and other header area styles",
+          "descriptionZh": "头部元素，包含flex布局、对齐方式、内边距、字体大小、行高、下边框等头部区域的样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with flex ratio, minimum size, padding, overflow scroll and other content area display and layout styles",
+          "descriptionZh": "内容元素，包含flex占比、最小尺寸、内边距、溢出滚动等内容区域的展示和布局样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with flex shrink, padding, top border and other bottom operation area styles",
+          "descriptionZh": "底部元素，包含flex收缩、内边距、上边框等底部操作区域的样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with flex ratio, margin, font weight, font size, line height and other title text styles",
+          "descriptionZh": "标题元素，包含flex占比、外边距、字体权重、字体大小、行高等标题文字的样式"
+        },
+        {
+          "key": "extra",
+          "description": "Extra element with flex fixed layout and other additional operation content style controls",
+          "descriptionZh": "额外元素，包含flex固定布局等额外操作内容的样式控制"
+        },
+        {
+          "key": "dragger",
+          "description": "Dragger element used to resize the drawer, with absolute positioning, transparent background, pointer events control, hover state styles, and dragging state styles",
+          "descriptionZh": "拖拽元素，用于调整抽屉大小的拖拽手柄，包含绝对定位、背景透明、指针事件控制、hover状态样式、拖拽状态样式等"
+        },
+        {
+          "key": "close",
+          "description": "Close button element with basic button styling",
+          "descriptionZh": "关闭按钮元素，包含按钮的基础样式"
         }
       ]
     },
@@ -8811,14 +9213,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of the Dropdown by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Dropdown 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { DropdownProps, MenuItemType } from 'antdv-next'\nimport { DownOutlined, LogoutOutlined, SettingOutlined } from '@antdv-next/icons'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst items: MenuItemType[] = [\n  {\n    key: '1',\n    label: 'Profile',\n  },\n  {\n    key: '2',\n    label: 'Settings',\n    icon: SettingOutlined,\n  },\n  {\n    type: 'divider',\n  },\n  {\n    key: '3',\n    label: 'Logout',\n    icon: LogoutOutlined,\n    danger: true,\n  },\n]\n\nconst classes: DropdownProps['classes'] = {\n  root: 'demo-dropdown-root',\n}\n\nconst objectStyles: DropdownProps['styles'] = {\n  root: {\n    backgroundColor: '#ffffff',\n    border: '1px solid #d9d9d9',\n    borderRadius: '4px',\n  },\n  item: {\n    padding: '8px 12px',\n    fontSize: '14px',\n  },\n  itemTitle: {\n    fontWeight: '500',\n  },\n  itemIcon: {\n    color: '#1890ff',\n    marginRight: '8px',\n  },\n  itemContent: {\n    backgroundColor: 'transparent',\n  },\n}\n\nconst functionStyles: DropdownProps['styles'] = (info) => {\n  const isClick = info.props.trigger?.includes('click')\n  if (isClick) {\n    return {\n      root: {\n        borderColor: '#1890ff',\n        borderRadius: '8px',\n      },\n    }\n  }\n  return {}\n}\n\nconst sharedProps: DropdownProps = {\n  menu: { items },\n  placement: 'bottomLeft',\n  classes,\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\" wrap=\"wrap\">\n    <a-space direction=\"vertical\" size=\"large\">\n      <a-dropdown v-bind=\"sharedProps\" :styles=\"objectStyles\">\n        <a-button>\n          <a-space>\n            Object Style\n            <DownOutlined />\n          </a-space>\n        </a-button>\n      </a-dropdown>\n\n      <a-dropdown v-bind=\"sharedProps\" :styles=\"functionStyles\" :trigger=\"['click']\">\n        <a-button type=\"primary\">\n          <a-space>\n            Function Style\n            <DownOutlined />\n          </a-space>\n        </a-button>\n      </a-dropdown>\n    </a-space>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element of dropdown, sets positioning, z-index and container styles",
+          "descriptionZh": "dropdown 的根元素，设置定位、层级和容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { DeleteOutlined, DownOutlined, EditOutlined, SaveOutlined } from '@antdv-next/icons'\nimport { computed, h, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'itemTitle', desc: t('itemTitle') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst items: any[] = [\n  {\n    key: '1',\n    type: 'group',\n    label: 'Group title',\n    children: [\n      { key: '1-1', label: '1st menu item', icon: h(SaveOutlined) },\n      { key: '1-2', label: '2nd menu item', icon: h(EditOutlined) },\n    ],\n  },\n  {\n    key: 'SubMenu',\n    label: 'SubMenu',\n    children: [\n      {\n        key: 'g1',\n        label: 'Item 1',\n        type: 'group',\n        children: [\n          { key: '1', label: 'Option 1' },\n          { key: '2', label: 'Option 2' },\n        ],\n      },\n    ],\n  },\n  { key: '3', type: 'divider' },\n  { key: '4', label: 'Delete', icon: h(DeleteOutlined), danger: true },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Dropdown\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ height: '120px', position: 'absolute', top: '50px' }\">\n        <a-dropdown\n          open\n          :menu=\"{ items }\"\n          :styles=\"{ root: { width: '200px', zIndex: 1 } }\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        >\n          <a @click.prevent>\n            <a-space>\n              Hover me\n              <DownOutlined />\n            </a-space>\n          </a>\n        </a-dropdown>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "itemTitle",
+          "description": "Title content area of dropdown option, sets layout and text styles",
+          "descriptionZh": "dropdown 选项的标题内容区域，设置布局和文字样式"
+        },
+        {
+          "key": "item",
+          "description": "Individual dropdown option element, sets interaction states and background styles",
+          "descriptionZh": "dropdown 的单个选项元素，设置选项的交互状态和背景样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Main content area of dropdown option, sets content layout and link styles",
+          "descriptionZh": "dropdown 选项的主要内容区域，设置内容布局和链接样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Icon area of dropdown option, sets icon size and spacing styles",
+          "descriptionZh": "dropdown 选项的图标区域，设置图标的尺寸和间距样式"
         }
       ]
     },
@@ -8928,14 +9349,28 @@
           "description": "Hide default description.",
           "descriptionZh": "隐藏默认描述。",
           "code": "<template>\n  <a-empty :description=\"false\" />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets text alignment, font and line height styles",
+          "descriptionZh": "根元素，设置文本对齐、字体和行高样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'image', desc: t('image'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Empty\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-empty\n        :image=\"1\"\n        :styles=\"{ image: { height: '60px' } }\"\n        :classes=\"classes\"\n      >\n        <template #description>\n          <a-typography-text>\n            Customize <a href=\"#API\">Description</a>\n          </a-typography-text>\n        </template>\n        <a-button type=\"primary\">\n          Create Now\n        </a-button>\n      </a-empty>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "image",
+          "description": "Image element, sets height, opacity, margin and image styles",
+          "descriptionZh": "图标元素，设置高度、透明度、边距和图片样式"
+        },
+        {
+          "key": "description",
+          "description": "Description element, sets text color styles",
+          "descriptionZh": "描述元素，设置文本颜色样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element, sets top margin and action button styles",
+          "descriptionZh": "底部元素，设置顶部边距和操作按钮样式"
         }
       ]
     },
@@ -9045,7 +9480,8 @@
           "descriptionZh": "嵌套使用，可以实现更复杂的布局。",
           "code": "<script setup lang=\"ts\">\nimport type { CSSProperties } from 'vue'\n\nconst cardStyle: CSSProperties = {\n  width: '620px',\n}\nconst imgStyle: CSSProperties = {\n  display: 'block',\n  width: '273px',\n}\n</script>\n\n<template>\n  <a-card :style=\"cardStyle\" :styles=\"{ body: { padding: 0, overflow: 'hidden' } }\">\n    <a-flex justify=\"space-between\">\n      <img\n        alt=\"avatar\"\n        src=\"https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png\"\n        :style=\"imgStyle\"\n      >\n      <a-flex vertical align=\"flex-end\" justify=\"space-between\" :style=\"{ padding: '32px' }\">\n        <a-typography>\n          <a-typography-title :level=\"3\">\n            “antd is an enterprise-class UI design language and Vue UI library.”\n          </a-typography-title>\n        </a-typography>\n        <a-button type=\"primary\" href=\"https://antdv.com\" target=\"_blank\">\n          Get Start\n        </a-button>\n      </a-flex>\n    </a-flex>\n  </a-card>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "FloatButton",
@@ -9471,22 +9907,63 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of FloatButton by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 FloatButton 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { FloatButtonProps } from 'antdv-next'\nimport { QuestionCircleOutlined } from '@antdv-next/icons'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: FloatButtonProps['classes'] = {\n  root: 'demo-float-button-root',\n  content: 'demo-float-button-content',\n}\n\nconst stylesObject: FloatButtonProps['styles'] = {\n  root: {\n    boxShadow: '0 1px 2px 0 rgba(0,0,0,0.05)',\n  },\n}\n\nconst stylesFn: FloatButtonProps['styles'] = (info) => {\n  if (info?.props?.type === 'primary') {\n    return {\n      root: {\n        backgroundColor: '#171717',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-float-button-group shape=\"circle\" style=\"inset-inline-end: 94px;\">\n    <a-float-button\n      type=\"primary\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n    >\n      <template #tooltip>\n        <div>custom style class</div>\n      </template>\n    </a-float-button>\n    <a-float-button\n      type=\"default\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n    >\n      <template #icon>\n        <QuestionCircleOutlined />\n      </template>\n    </a-float-button>\n  </a-float-button-group>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with float button base styles, shape size, type theme, fixed positioning, z-index, shadow, spacing and other container styles",
+          "descriptionZh": "根元素，设置悬浮按钮的基础样式、形状尺寸、类型主题、固定定位、层级、阴影、间距等容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { QuestionCircleOutlined } from '@antdv-next/icons'\nimport { FloatButton } from 'antdv-next'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst PurePanel = (FloatButton as any)._InternalPanelDoNotUseOrYouWillBeFired\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'icon', desc: t('icon') },\n  { name: 'content', desc: t('content') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"FloatButton\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <PurePanel\n        type=\"primary\"\n        shape=\"square\"\n        content=\"HELP\"\n        :classes=\"classes\"\n      >\n        <template #icon>\n          <QuestionCircleOutlined />\n        </template>\n      </PurePanel>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "content",
+          "description": "Content element with button text content font size, color, alignment, line wrap and other text display styles",
+          "descriptionZh": "内容元素，设置按钮内文字内容的字体大小、颜色、对齐、换行等文本显示样式"
         },
         {
-          "name": "_semantic_group",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AlertOutlined, BugOutlined, BulbOutlined } from '@antdv-next/icons'\nimport { FloatButton } from 'antdv-next'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst PurePanel = (FloatButton as any)._InternalPanelDoNotUseOrYouWillBeFired\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('group.root') },\n  { name: 'list', desc: t('group.list') },\n  { name: 'item', desc: t('group.item') },\n  { name: 'itemIcon', desc: t('group.itemIcon') },\n  { name: 'itemContent', desc: t('group.itemContent') },\n  { name: 'trigger', desc: t('group.trigger') },\n  { name: 'triggerIcon', desc: t('group.triggerIcon') },\n  { name: 'triggerContent', desc: t('group.triggerContent') },\n])\n\nconst items = [\n  {\n    icon: h(AlertOutlined),\n    content: 'warn',\n  },\n  {\n    icon: h(BugOutlined),\n    content: 'bug',\n  },\n  {\n    icon: h(BulbOutlined),\n    content: 'idea',\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"FloatButton\"\n    :semantics=\"semantics\"\n    :style=\"{ paddingTop: '100px' }\"\n  >\n    <template #default=\"{ classes }\">\n      <PurePanel\n        type=\"primary\"\n        shape=\"square\"\n        :items=\"items\"\n        trigger=\"hover\"\n        :open=\"true\"\n        content=\"back\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element with button icon size, color, line height, alignment and other icon display styles",
+          "descriptionZh": "图标元素，设置按钮内图标的尺寸、颜色、行高、对齐等图标显示样式"
+        },
+        {
+          "key": "group.root",
+          "description": "Root element with float button group container styles, fixed positioning, z-index, padding, gap, direction mode and other combined layout styles",
+          "descriptionZh": "根元素，设置悬浮按钮组的容器样式、固定定位、层级、内边距、间距、方向模式等组合布局样式"
+        },
+        {
+          "key": "group.list",
+          "description": "List element with button group list flex layout, border radius, shadow, animation transition, vertical alignment and other list container styles",
+          "descriptionZh": "列表元素，设置按钮组列表的Flex布局、圆角、阴影、动画过渡、垂直对齐等列表容器样式"
+        },
+        {
+          "key": "group.item",
+          "description": "Item element with individual float button styles, size, shape, type, state, icon content and other button base styles",
+          "descriptionZh": "列表项元素，设置单个悬浮按钮的样式、尺寸、形状、类型、状态、图标内容等按钮基础样式"
+        },
+        {
+          "key": "group.itemIcon",
+          "description": "Item icon element with float button icon size, color, alignment and other icon display styles",
+          "descriptionZh": "列表项图标元素，设置悬浮按钮内图标的尺寸、颜色、对齐等图标显示样式"
+        },
+        {
+          "key": "group.itemContent",
+          "description": "Item content element with float button text content, badge, description and other content area styles",
+          "descriptionZh": "列表项内容元素，设置悬浮按钮内文字内容、徽标、描述等内容区域样式"
+        },
+        {
+          "key": "group.trigger",
+          "description": "Trigger element with menu mode trigger button styles, shape, icon, hover state, expand/collapse state and other interaction styles",
+          "descriptionZh": "触发元素，设置菜单模式下触发按钮的样式、形状、图标、悬停态、展开收起状态等交互样式"
+        },
+        {
+          "key": "group.triggerIcon",
+          "description": "Trigger icon element with trigger button icon styles, rotation animation, toggle state and other icon interaction styles",
+          "descriptionZh": "触发图标元素，设置触发按钮内图标的样式、旋转动画、切换状态等图标交互样式"
+        },
+        {
+          "key": "group.triggerContent",
+          "description": "Trigger content element with trigger button content area text, identifier, state indicator and other content styles",
+          "descriptionZh": "触发内容元素，设置触发按钮内容区域的文字、标识、状态指示等内容样式"
         }
       ]
     },
@@ -10508,14 +10985,38 @@
           "description": "Label ellipsis debug.",
           "descriptionZh": "label 省略展示调试。",
           "code": "<script setup lang=\"ts\">\nimport { reactive } from 'vue'\n\nconst model = reactive({\n  username: '',\n  password: '',\n})\n</script>\n\n<template>\n  <a-form\n    name=\"label-ellipsis\"\n    :model=\"model\"\n    :label-col=\"{ span: 8 }\"\n    :wrapper-col=\"{ span: 16 }\"\n    style=\"max-width: 600px\"\n  >\n    <a-form-item name=\"username\">\n      <template #label>\n        <a-typography-text ellipsis>\n          longtextlongtextlongtextlongtextlongtextlongtextlongtext\n        </a-typography-text>\n      </template>\n      <a-input v-model:value=\"model.username\" />\n    </a-form-item>\n\n    <a-form-item name=\"password\">\n      <template #label>\n        <a-typography-text ellipsis>\n          longtext longtext longtext longtext longtext longtext longtext\n        </a-typography-text>\n      </template>\n      <a-input-password v-model:value=\"model.password\" />\n    </a-form-item>\n  </a-form>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with form item margin-bottom, vertical-align, transitions, hidden states, error/warning states and other basic form item container styles",
+          "descriptionZh": "根元素，包含表单项的底边距、垂直对齐、过渡动画、隐藏状态、错误警告状态等表单项容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport type { FormInstance } from 'antdv-next'\nimport { computed, onMounted, shallowRef } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst formRef = shallowRef<FormInstance>()\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'help', desc: t('help'), version: '1.3.0' },\n  { name: 'helpItem', desc: t('helpItem'), version: '1.3.0' },\n  { name: 'extra', desc: t('extra'), version: '1.3.0' },\n])\n\nonMounted(() => {\n  formRef.value?.setFields?.([\n    {\n      name: 'password',\n      errors: ['Please input your password!', 'Use at least 8 characters.'],\n    },\n  ])\n})\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Form\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-form\n        ref=\"formRef\"\n        name=\"basic\"\n        :label-col=\"{ span: 8 }\"\n        :wrapper-col=\"{ span: 16 }\"\n        :style=\"{ maxWidth: '600px' }\"\n        :initial-values=\"{ remember: true }\"\n        autocomplete=\"off\"\n        :classes=\"classes\"\n      >\n        <a-form-item\n          label=\"Username\"\n          name=\"username\"\n          help=\"Use 4 to 16 characters.\"\n          :rules=\"[{ required: true, message: 'Please input your username!' }]\"\n        >\n          <a-input />\n        </a-form-item>\n        <a-form-item\n          label=\"Password\"\n          name=\"password\"\n          extra=\"Password must contain letters and numbers.\"\n          :rules=\"[\n            { required: true, message: 'Please input your password!' },\n            { min: 8, message: 'Use at least 8 characters.' },\n          ]\"\n        >\n          <a-input-password />\n        </a-form-item>\n      </a-form>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "label",
+          "description": "Label element with flex layout, overflow hidden, whitespace nowrap, text alignment, vertical alignment, plus label color, font size, height, required marks and other label display styles",
+          "descriptionZh": "标签元素，包含 flex 布局、溢出隐藏、文本不换行、文本对齐、垂直对齐，以及标签的颜色、字体大小、高度、必填标记等标签显示样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with form content area layout, styling and control container related styles",
+          "descriptionZh": "内容元素，包含表单内容区域的布局、样式和控件容器的相关样式"
+        },
+        {
+          "key": "help",
+          "description": "Help container element with spacing, motion, and presentation styles for help and validation areas",
+          "descriptionZh": "帮助信息容器元素，包含帮助文案与校验信息区域的间距、过渡与展示样式"
+        },
+        {
+          "key": "helpItem",
+          "description": "Single help message item with typography styles for prompt, error, and warning text",
+          "descriptionZh": "帮助信息单项元素，包含错误、警告与提示文案的排版样式"
+        },
+        {
+          "key": "extra",
+          "description": "Extra prompt container element with spacing, color, and typography styles for supplementary text",
+          "descriptionZh": "额外提示容器元素，包含补充说明文案的间距、颜色与排版样式"
         }
       ]
     },
@@ -10793,7 +11294,8 @@
           "descriptionZh": "使用 `useBreakpoint` Hook 实现个性化布局，其中 `xs` 仅当满足最小宽度时生效。",
           "code": "<script setup lang=\"ts\">\nimport { useBreakpoint } from 'antdv-next'\nimport { computed } from 'vue'\n\nconst screens = useBreakpoint()\nconst screenKeys = computed(() => Object.entries(screens.value ?? {}).filter(screen => !!screen[1]))\n</script>\n\n<template>\n  Current break point:\n  <div class=\"gap-2 inline-flex\">\n    <template v-for=\"item in screenKeys\" :key=\"item[0]\">\n      <a-tag color=\"blue\">\n        {{ item[0] }}\n      </a-tag>\n    </template>\n  </div>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Icon",
@@ -10856,7 +11358,8 @@
           "descriptionZh": "`scriptUrl` 可引用多个资源，用户可灵活的管理 [iconfont.cn](http://iconfont.cn/) 图标。如果资源的图标出现重名，会按照数组顺序进行覆盖。",
           "code": "<script setup lang=\"ts\">\nimport { createFromIconfontCN } from '@antdv-next/icons'\n\nconst IconFont = createFromIconfontCN({\n  scriptUrl: [\n    '//at.alicdn.com/t/font_1788044_0dwu4guekcwr.js', // icon-javascript, icon-java, icon-shoppingcart (overridden)\n    '//at.alicdn.com/t/font_1788592_a5xf2bdic3u.js', // icon-shoppingcart, icon-python\n  ],\n})\n</script>\n\n<template>\n  <a-space>\n    <IconFont type=\"icon-javascript\" />\n    <IconFont type=\"icon-java\" />\n    <IconFont type=\"icon-shoppingcart\" />\n    <IconFont type=\"icon-python\" />\n  </a-space>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Image",
@@ -11083,14 +11586,53 @@
           "description": "Nested in the modal.",
           "descriptionZh": "嵌套在弹框当中使用。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst show1 = ref(false)\nconst show2 = ref(false)\nconst show3 = ref(false)\n\nfunction handlePreviewGroupChange(current: number, prev: number) {\n  console.log(`current index: ${current}, prev index: ${prev}`)\n}\n</script>\n\n<template>\n  <a-button @click=\"show1 = true\">\n    showModal\n  </a-button>\n  <a-modal\n    v-model:open=\"show1\"\n    @cancel=\"show1 = false\"\n    @ok=\"show1 = false\"\n  >\n    <a-button @click=\"show2 = true\">\n      test2\n    </a-button>\n    <a-modal\n      v-model:open=\"show2\"\n      @cancel=\"show2 = false\"\n      @ok=\"show2 = false\"\n    >\n      <a-button @click=\"show3 = true\">\n        test3\n      </a-button>\n      <a-modal\n        v-model:open=\"show3\"\n        @cancel=\"show3 = false\"\n        @ok=\"show3 = false\"\n      >\n        <a-image\n          :width=\"200\"\n          alt=\"svg image\"\n          src=\"https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg\"\n        />\n        <a-divider />\n        <a-image-preview-group\n          :preview=\"{\n            onChange: handlePreviewGroupChange,\n          }\"\n        >\n          <a-image\n            :width=\"200\"\n            alt=\"svg image\"\n            src=\"https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg\"\n          />\n          <a-image\n            :width=\"200\"\n            src=\"https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg\"\n          />\n        </a-image-preview-group>\n      </a-modal>\n    </a-modal>\n  </a-modal>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets relative positioning and inline-block layout styles",
+          "descriptionZh": "根元素，设置相对定位和行内块布局样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { theme } from 'antdv-next'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'image', desc: t('image') },\n  { name: 'cover', desc: t('cover') },\n  { name: 'popup.root', desc: t('popup.root') },\n  { name: 'popup.mask', desc: t('popup.mask') },\n  { name: 'popup.body', desc: t('popup.body') },\n  { name: 'popup.footer', desc: t('popup.footer') },\n  { name: 'popup.actions', desc: t('popup.actions') },\n  { name: 'popup.close', desc: t('popup.close'), version: '1.3.0' },\n])\n\nconst { token } = theme.useToken()\nconst holderRef = ref<HTMLDivElement | null>(null)\n\nconst previewItems = [\n  'https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg',\n  'https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg',\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Image\"\n    :padding=\"false\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical align=\"center\" :style=\"{ minHeight: '100%', width: '100%' }\">\n        <a-flex :style=\"{ padding: `${token.padding}px`, flex: 'none' }\" justify=\"center\">\n          <a-image\n            :width=\"200\"\n            src=\"https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png\"\n            :classes=\"classes\"\n          />\n        </a-flex>\n        <div ref=\"holderRef\" :style=\"{ flex: 1, position: 'relative', minHeight: '500px', width: '100%' }\">\n          <a-image-preview-group\n            :items=\"previewItems\"\n            :classes=\"classes\"\n            :styles=\"{ popup: { root: { position: 'absolute' } } }\"\n            :preview=\"{ getContainer: () => holderRef!, open: true, focusTrap: false }\"\n          />\n        </div>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "image",
+          "description": "Image element, sets width, height and vertical alignment styles",
+          "descriptionZh": "图片元素，设置宽度、高度和垂直对齐样式"
+        },
+        {
+          "key": "cover",
+          "description": "Image hover display prompt element, sets absolute positioning, background color, opacity and transition animation styles",
+          "descriptionZh": "悬浮图片显示的提示元素，设置绝对定位、背景色、透明度和过渡动画样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Preview root element, sets fixed positioning, z-index and background mask styles",
+          "descriptionZh": "预览根元素，设置固定定位、层级和背景遮罩样式"
+        },
+        {
+          "key": "popup.mask",
+          "description": "Preview mask element, sets absolute positioning and semi-transparent background styles",
+          "descriptionZh": "预览遮罩元素，设置绝对定位和半透明背景样式"
+        },
+        {
+          "key": "popup.body",
+          "description": "Preview body element, sets flex layout, center alignment and pointer event styles",
+          "descriptionZh": "预览内容元素，设置flex布局、居中对齐和指针事件样式"
+        },
+        {
+          "key": "popup.footer",
+          "description": "Preview footer element, sets absolute positioning, center layout and bottom operation area styles",
+          "descriptionZh": "预览页脚元素，设置绝对定位、居中布局和底部操作区域样式"
+        },
+        {
+          "key": "popup.actions",
+          "description": "Preview actions group element, sets flex layout, background color, border radius and action button styles",
+          "descriptionZh": "预览操作组元素，设置flex布局、背景色、圆角和操作按钮样式"
+        },
+        {
+          "key": "popup.close",
+          "description": "Preview close button element, sets basic button styles",
+          "descriptionZh": "预览关闭按钮元素，设置按钮的基础样式"
         }
       ]
     },
@@ -11839,46 +12381,73 @@
           "description": "You can customize the [semantic dom](#semantic-input) style of Input by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Input 的[语义化结构](#semantic-input)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { InputOTPProps, InputPasswordProps, InputProps, InputSearchProps, TextAreaProps } from 'antdv-next'\n\nconst classes: InputProps['classes'] = {\n  root: 'effect',\n}\n\nconst stylesFn: InputProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      root: {\n        borderColor: '#696FC7',\n      },\n    } satisfies InputProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnTextArea: TextAreaProps['styles'] = (info) => {\n  if (info.props.showCount) {\n    return {\n      root: { borderColor: '#BDE3C3' },\n      textarea: { resize: 'none' },\n      count: { color: '#BDE3C3' },\n    } satisfies TextAreaProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnPassword: InputPasswordProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      root: {\n        borderColor: '#F5D3C4',\n      },\n    } satisfies InputPasswordProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnOTP: InputOTPProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      root: {\n        borderWidth: 0,\n      },\n      input: {\n        borderColor: '#6E8CFB',\n        width: '32px',\n      },\n    } satisfies InputOTPProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnSearch: InputSearchProps['styles'] = (info) => {\n  if (info.props.size === 'large') {\n    return {\n      root: { color: '#4DA8DA', borderWidth: 0 },\n      input: { color: '#4DA8DA', borderColor: '#4DA8DA' },\n      prefix: { color: '#4DA8DA' },\n      suffix: { color: '#4DA8DA' },\n      count: { color: '#4DA8DA' },\n      button: {\n        root: { color: '#4DA8DA', borderColor: '#4DA8DA' },\n        icon: { color: '#4DA8DA' },\n      },\n    } satisfies InputSearchProps['styles']\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-input :classes=\"classes\" placeholder=\"Object\" name=\"input-object\" />\n    <a-input :classes=\"classes\" :styles=\"stylesFn\" placeholder=\"Function\" size=\"middle\" name=\"input-fn\" />\n    <a-textarea :classes=\"classes\" :styles=\"stylesFnTextArea\" placeholder=\"Textarea\" show-count name=\"textarea-fn\" />\n    <a-input-password :classes=\"classes\" :styles=\"stylesFnPassword\" placeholder=\"Password\" size=\"middle\" name=\"password-fn\" />\n    <a-input-otp :classes=\"classes\" :styles=\"stylesFnOTP\" size=\"middle\" :length=\"6\" separator=\"*\" name=\"otp-fn\" />\n    <a-input-search :classes=\"classes\" :styles=\"stylesFnSearch\" placeholder=\"Search\" size=\"large\" name=\"search-fn\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-block display, width, min-width, padding, colors, fonts, line-height, border-radius, transitions and other input container basic styles",
+          "descriptionZh": "根元素，包含相对定位、行内块布局、宽度、最小宽度、内边距、颜色、字体、行高、圆角、过渡动画等输入框容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'count', desc: t('count') },\n  { name: 'clear', desc: t('clear'), version: '1.3.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Input\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-input\n          default-value=\"Hello, Antdv-Next\"\n          show-count\n          allow-clear\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <UserOutlined />\n          </template>\n          <template #suffix>\n            <EditOutlined />\n          </template>\n        </a-input>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "input",
+          "description": "Input element with core interactive styles and text input related styling",
+          "descriptionZh": "输入框元素，包含输入框的核心交互样式和文本输入相关的样式"
         },
         {
-          "name": "_semantic-textarea",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('TextAreaRoot') },\n  { name: 'textarea', desc: t('textarea') },\n  { name: 'count', desc: t('TextAreaCount') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"TextArea\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-textarea\n          default-value=\"Hello, Antdv-Next\"\n          :maxlength=\"100\"\n          show-count\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix wrapper element with layout and styling for prefix content",
+          "descriptionZh": "前缀的包裹元素，包含前缀内容的布局和样式"
         },
         {
-          "name": "_semantic-search",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'count', desc: t('count') },\n  { name: 'button.root', desc: t('button.root') },\n  { name: 'button.icon', desc: t('button.icon') },\n  { name: 'button.content', desc: t('button.content') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputSearch\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-input-search\n          default-value=\"Hello, Antdv-Next\"\n          enter-button=\"Searching...\"\n          loading\n          show-count\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <UserOutlined />\n          </template>\n          <template #suffix>\n            <EditOutlined />\n          </template>\n        </a-input-search>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "suffix",
+          "description": "Suffix wrapper element with layout and styling for suffix content",
+          "descriptionZh": "后缀的包裹元素，包含后缀内容的布局和样式"
         },
         {
-          "name": "_semantic-password",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'count', desc: t('count') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputPassword\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-input-password\n          default-value=\"Hello, Antdv-Next\"\n          show-count\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <UserOutlined />\n          </template>\n          <template #suffix>\n            <EditOutlined />\n          </template>\n        </a-input-password>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "count",
+          "description": "Character count element with font and color styles for count display",
+          "descriptionZh": "文字计数元素，包含字符计数显示的字体和颜色样式"
         },
         {
-          "name": "_semantic-otp",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'input', desc: t('input') },\n  { name: 'separator', desc: t('OTPSeparator') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputOTP\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-input-otp\n        :length=\"6\"\n        separator=\"-\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "clear",
+          "description": "Clear button element with color, size, hover state and transition animation styles",
+          "descriptionZh": "清除按钮元素，包含清除按钮的颜色、尺寸、悬浮态和过渡动画等样式"
+        },
+        {
+          "key": "TextAreaRoot",
+          "description": "Root element with textarea wrapper styles, border, border radius, transition animation and state control",
+          "descriptionZh": "根元素，设置文本域包装器的样式、边框、圆角、过渡动画和状态控制"
+        },
+        {
+          "key": "textarea",
+          "description": "Textarea element with font, line height, padding, color, background, border, text input and multi-line text display styles",
+          "descriptionZh": "文本域元素，设置字体、行高、内边距、颜色、背景、边框、文本输入和多行文本展示样式"
+        },
+        {
+          "key": "TextAreaCount",
+          "description": "Count element with character count display position, font, color and numeric statistics styles",
+          "descriptionZh": "文字计数元素，设置字符计数显示的位置、字体、颜色和数值统计样式"
+        },
+        {
+          "key": "button.root",
+          "description": "Search button root element with button styles, hover effects and click interactions",
+          "descriptionZh": "搜索按钮的根元素，设置按钮的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "button.icon",
+          "description": "Search button icon element with icon styles, hover effects and click interactions",
+          "descriptionZh": "搜索按钮的图标元素，设置图标的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "button.content",
+          "description": "Search button content element with text styles, hover effects and click interactions",
+          "descriptionZh": "搜索按钮的内容元素，设置文本的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "OTPSeparator",
+          "description": "Separator element, set separator display styles between OTP input boxes",
+          "descriptionZh": "分隔符元素，设置OTP输入框之间的分隔符显示样式"
         }
       ]
     },
@@ -12460,14 +13029,38 @@
           "description": "Suffix with form feedback debug.",
           "descriptionZh": "带反馈图标时展示后缀 Debug。",
           "code": "<script setup lang=\"ts\">\n</script>\n\n<template>\n  <a-form layout=\"vertical\" :style=\"{ maxWidth: '320px' }\">\n    <a-form-item label=\"Suffix with feedback\" validate-status=\"success\" has-feedback>\n      <a-input-number :default-value=\"100\" suffix=\"RMB\" :style=\"{ width: '100%' }\" />\n    </a-form-item>\n  </a-form>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets inline-block layout, width, border radius and reset styles",
+          "descriptionZh": "根元素，设置行内块布局、宽度、边框圆角和重置样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'actions', desc: t('actions') },\n  { name: 'action', desc: t('action') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputNumber\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ display: 'flex', flexDirection: 'column', gap: '16px' }\">\n        <a-input-number\n          prefix=\"￥\"\n          suffix=\"RMB\"\n          :default-value=\"100\"\n          :style=\"{ width: '200px' }\"\n          :styles=\"{ actions: { opacity: 1, width: '24px' }, suffix: { marginRight: '28px' } }\"\n          :classes=\"classes\"\n        />\n        <a-input-number\n          :default-value=\"100\"\n          :style=\"{ width: '200px' }\"\n          :styles=\"{ actions: { opacity: 1, width: '24px' }, suffix: { marginRight: '28px' } }\"\n          mode=\"spinner\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "input",
+          "description": "Input element, sets font, line height, text input and interaction styles",
+          "descriptionZh": "输入框元素，设置字体、行高、文本输入和交互样式"
+        },
+        {
+          "key": "prefix",
+          "description": "Prefix wrapper element, sets flex layout, alignment and right margin styles",
+          "descriptionZh": "前缀的包裹元素，设置flex布局、对齐方式和右边距样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix wrapper element, sets flex layout, margin and transition animation styles",
+          "descriptionZh": "后缀的包裹元素，设置flex布局、边距和过渡动画样式"
+        },
+        {
+          "key": "action",
+          "description": "Single action button element, sets button styling, hover effects and click interactions",
+          "descriptionZh": "单个操作按钮元素，设置按钮的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element, sets absolute positioning, width, flex layout and number adjustment button styles",
+          "descriptionZh": "操作元素，设置绝对定位、宽度、flex布局和数值调节按钮样式"
         }
       ]
     },
@@ -12805,7 +13398,8 @@
           "descriptionZh": "当内容较长时，使用固定侧边栏可以提供更好的体验。",
           "code": "<script setup lang=\"ts\">\nimport type { MenuItemType } from 'antdv-next'\nimport type { CSSProperties } from 'vue'\nimport {\n  AppstoreOutlined,\n  BarChartOutlined,\n  CloudOutlined,\n  ShopOutlined,\n  TeamOutlined,\n  UploadOutlined,\n  UserOutlined,\n  VideoCameraOutlined,\n} from '@antdv-next/icons'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\nconst year = new Date().getFullYear()\n\nconst siderStyle: CSSProperties = {\n  overflow: 'auto',\n  height: '100vh',\n  position: 'sticky',\n  insetInlineStart: 0,\n  top: 0,\n  scrollbarWidth: 'thin',\n  scrollbarGutter: 'stable',\n}\n\nconst items: MenuItemType[] = [\n  UserOutlined,\n  VideoCameraOutlined,\n  UploadOutlined,\n  BarChartOutlined,\n  CloudOutlined,\n  AppstoreOutlined,\n  TeamOutlined,\n  ShopOutlined,\n].map((icon, index) => ({\n  key: String(index + 1),\n  icon,\n  label: `nav ${index + 1}`,\n}))\n</script>\n\n<template>\n  <a-layout :has-sider=\"true\">\n    <a-layout-sider :style=\"siderStyle\">\n      <div class=\"demo-logo-vertical\" />\n      <a-menu\n        theme=\"dark\"\n        mode=\"inline\"\n        :default-selected-keys=\"['4']\"\n        :items=\"items\"\n      />\n    </a-layout-sider>\n    <a-layout>\n      <a-layout-header class=\"fixed-header\" :style=\"{ background: token.colorBgContainer }\" />\n      <a-layout-content class=\"fixed-content\">\n        <div\n          class=\"fixed-content-box\"\n          :style=\"{\n            background: token.colorBgContainer,\n            borderRadius: `${token.borderRadiusLG}px`,\n          }\"\n        >\n          <p>long content</p>\n          <template v-for=\"index in 100\" :key=\"index\">\n            {{ index % 20 === 0 && index !== 0 ? 'more' : '...' }}\n            <br>\n          </template>\n        </div>\n      </a-layout-content>\n      <a-layout-footer class=\"fixed-footer\">\n        Antdv Next ©{{ year }} Created by Ant UED\n      </a-layout-footer>\n    </a-layout>\n  </a-layout>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Listy",
@@ -12901,14 +13495,23 @@
           "description": "Customize the [semantic DOM](#semantic-dom) styles of Listy with `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 自定义 Listy 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { ListyProps } from 'antdv-next'\n\ninterface User {\n  id: number\n  name: string\n  team: string\n}\n\nconst users: User[] = [\n  { id: 0, name: 'Olivia', team: 'Design' },\n  { id: 1, name: 'Liam', team: 'Design' },\n  { id: 2, name: 'Emma', team: 'Design' },\n  { id: 3, name: 'Noah', team: 'Engineering' },\n  { id: 4, name: 'Ava', team: 'Engineering' },\n  { id: 5, name: 'Ethan', team: 'Engineering' },\n  { id: 6, name: 'Sophia', team: 'Marketing' },\n  { id: 7, name: 'Lucas', team: 'Marketing' },\n]\n\nconst classNames: ListyProps['classes'] = {\n  root: 'listy-custom-root',\n  groupHeader: 'listy-custom-group-header',\n}\n\nconst styles: ListyProps['styles'] = {\n  item: { fontStyle: 'italic' },\n}\n</script>\n\n<template>\n  <a-listy\n    :items=\"users\"\n    :row-key=\"(item: User) => item.id\"\n    :height=\"260\"\n    sticky\n    :group=\"{ key: (user: User) => user.team, title: (team: unknown) => team }\"\n    :item-render=\"(user: User) => user.name\"\n    :classes=\"classNames\"\n    :styles=\"styles\"\n  />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, the scroll container, with font and relative positioning",
+          "descriptionZh": "根元素，即滚动容器，设置字体与相对定位"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\ninterface User {\n  id: number\n  name: string\n  team: string\n}\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n  { name: 'groupHeader', desc: t('groupHeader') },\n])\n\nconst users: User[] = [\n  { id: 0, name: 'Olivia', team: 'Design' },\n  { id: 1, name: 'Liam', team: 'Design' },\n  { id: 2, name: 'Emma', team: 'Design' },\n  { id: 3, name: 'Noah', team: 'Engineering' },\n  { id: 4, name: 'Ava', team: 'Engineering' },\n  { id: 5, name: 'Ethan', team: 'Engineering' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Listy\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-listy\n        :items=\"users\"\n        :row-key=\"(item: User) => item.id\"\n        :height=\"260\"\n        sticky\n        :group=\"{ key: (user: User) => user.team, title: (team: unknown) => team }\"\n        :item-render=\"(user: User) => user.name\"\n        :classes=\"classes\"\n        style=\"width: 100%\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element, with padding, split line and hover background",
+          "descriptionZh": "条目元素，设置内间距、分割线与悬浮背景"
+        },
+        {
+          "key": "groupHeader",
+          "description": "Group header element, with sticky positioning and background color",
+          "descriptionZh": "分组标题元素，设置吸顶定位与背景色"
         }
       ]
     },
@@ -13032,14 +13635,18 @@
           "description": "When `fresh` is enabled, the masonry will continuously monitor size changes of child items and automatically re-layout. Click on cards to change their height.",
           "descriptionZh": "开启 `fresh` 属性后，瀑布流会持续监听子项的尺寸变化并自动重新布局。点击卡片可以改变其高度。",
           "code": "<script setup lang=\"ts\">\nimport { Card } from 'antdv-next'\nimport { defineComponent, h, ref } from 'vue'\n\nconst RandomHeightCard = defineComponent({\n  props: {\n    index: {\n      type: Number,\n      required: true,\n    },\n    defaultHeight: {\n      type: Number,\n      required: true,\n    },\n  },\n  setup(props) {\n    const height = ref(props.defaultHeight)\n\n    const handleClick = () => {\n      height.value = Math.floor(Math.random() * 100) + 50\n    }\n\n    return () =>\n      h(\n        Card,\n        {\n          size: 'small',\n          style: { height: `${height.value}px`, transition: 'height 0.3s' },\n          onClick: handleClick,\n        },\n        () => `${props.index + 1} - Click`,\n      )\n  },\n})\n\nconst heights = [150, 50, 90, 70, 110, 150, 130, 80, 50, 90, 100, 150, 60, 50, 80].map(\n  (height, index) => {\n    const item: {\n      key: string\n      data: number\n      column?: number\n    } = {\n      key: `item-${index}`,\n      data: height,\n    }\n\n    if (index === 4) {\n      item.column = 0\n    }\n\n    return item\n  },\n)\n</script>\n\n<template>\n  <a-masonry\n    fresh\n    :columns=\"4\"\n    :gutter=\"16\"\n    :items=\"heights\"\n  >\n    <template #itemRender=\"{ data, index }\">\n      <RandomHeightCard :index=\"index\" :default-height=\"data\" />\n    </template>\n  </a-masonry>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets relative positioning, flex layout and masonry container styles",
+          "descriptionZh": "根元素，设置相对定位、flex布局和瀑布流容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n])\n\nconst heights = [75, 50, 70, 60, 85, 75, 50].map((height, index) => ({\n  key: `item-${index}`,\n  data: height,\n}))\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Masonry\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-masonry\n        :columns=\"3\"\n        :gutter=\"16\"\n        :items=\"heights\"\n        style=\"width: 100%\"\n        :classes=\"classes\"\n      >\n        <template #itemRender=\"{ data, index }\">\n          <a-card size=\"small\" :style=\"{ height: data }\">\n            {{ index + 1 }}\n          </a-card>\n        </template>\n      </a-masonry>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element, sets absolute positioning, width calculation, transition animation and masonry item styles",
+          "descriptionZh": "条目元素，设置绝对定位、宽度计算、过渡动画和瀑布流项目样式"
         }
       ]
     },
@@ -13445,14 +14052,28 @@
           "description": "autoSize debug",
           "descriptionZh": "autoSize debug",
           "code": "<script setup lang=\"ts\">\nimport type { MentionsEmits, MentionsProps } from 'antdv-next'\n\nconst options: MentionsProps['options'] = [\n  {\n    value: 'afc163',\n    label: 'afc163',\n  },\n  {\n    value: 'zombieJ',\n    label: 'zombieJ',\n  },\n  {\n    value: 'yesmeck',\n    label: 'yesmeck',\n  },\n]\n\nconst handleChange: MentionsEmits['change'] = (value) => {\n  console.log('Change:', value)\n}\n\nconst handleSelect: MentionsEmits['select'] = (option) => {\n  console.log('select', option)\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-mentions\n      placeholder=\"can resize\"\n      :options=\"options\"\n      @change=\"handleChange\"\n      @select=\"handleSelect\"\n    />\n    <a-mentions\n      placeholder=\"disable resize\"\n      :options=\"options\"\n      :style=\"{ resize: 'none' }\"\n      @change=\"handleChange\"\n      @select=\"handleSelect\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set inline flex layout, relative positioning, padding and border styles",
+          "descriptionZh": "根元素，设置行内flex布局、相对定位、内边距和边框样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'textarea', desc: t('textarea'), version: '1.0.0' },\n  { name: 'suffix', desc: t('suffix'), version: '1.0.0' },\n  { name: 'popup', desc: t('popup'), version: '1.0.0' },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst options = [\n  { value: 'afc163', label: 'afc163' },\n  { value: 'zombieJ', label: 'zombieJ' },\n  { value: 'thinkasany', label: 'thinkasany' },\n  { value: 'meet-student', label: 'meet-student' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Mentions\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <a-mentions\n          placement=\"bottom\"\n          :style=\"{ width: '100%' }\"\n          value=\"Hi, @\"\n          allow-clear\n          open\n          :get-popup-container=\"() => divRef!\"\n          :options=\"options\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "textarea",
+          "description": "Textarea element, set font, line height, text input and background styles",
+          "descriptionZh": "文本域元素，设置字体、行高、文本输入和背景样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup element, set absolute positioning, z-index, background color, border radius, shadow and dropdown options styles",
+          "descriptionZh": "弹出框元素，设置绝对定位、层级、背景色、圆角、阴影和下拉选项样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with layout and styling for suffix content like clear button, etc.",
+          "descriptionZh": "后缀元素，包含后缀内容的布局和样式，如清除按钮等"
         }
       ]
     },
@@ -14194,14 +14815,68 @@
           "description": "Use the `popupRender` prop to customize submenu popup rendering.",
           "descriptionZh": "使用 `popupRender` 属性自定义弹出菜单的渲染。",
           "code": "<script setup lang=\"ts\">\nimport type { MenuItemType, MenuProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\nimport { computed, h } from 'vue'\n\nconst { token } = theme.useToken()\n\nconst popupStyle = computed(() => ({\n  padding: `${token.value.padding}px`,\n  minWidth: '480px',\n  background: token.value.colorBgElevated,\n  borderRadius: `${token.value.borderRadiusLG}px`,\n  boxShadow: token.value.boxShadowSecondary,\n}))\n\nconst headerStyle = computed(() => ({\n  margin: 0,\n  paddingBottom: `${token.value.paddingXS}px`,\n  borderBottom: `1px solid ${token.value.colorSplit}`,\n}))\n\nconst cardStyle = computed(() => ({\n  padding: `${token.value.paddingSM}px`,\n}))\n\nconst cardItemStyle = computed(() => ({\n  borderRadius: `${token.value.borderRadius}px`,\n  transition: `all ${token.value.motionDurationSlow}`,\n  cursor: 'pointer',\n}))\n\nfunction renderMenuCard(title: string, description: string) {\n  return h('div', { class: 'menu-card', style: cardStyle.value }, [\n    h('div', { class: 'menu-card-title' }, title),\n    h('div', { class: 'menu-card-desc' }, description),\n  ])\n}\n\nconst menuItems = computed<MenuItemType[]>(() => [\n  {\n    key: 'home',\n    label: 'Home',\n  },\n  {\n    key: 'features',\n    label: 'Features',\n    children: [\n      {\n        key: 'getting-started',\n        label: renderMenuCard('Getting Started', 'Quick start guide and learn the basics.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n      {\n        key: 'components',\n        label: renderMenuCard('Components', 'Explore our component library.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n      {\n        key: 'templates',\n        label: renderMenuCard('Templates', 'Ready-to-use template designs.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n    ],\n  },\n  {\n    key: 'resources',\n    label: 'Resources',\n    children: [\n      {\n        key: 'blog',\n        label: renderMenuCard('Blog', 'Latest updates and articles.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n      {\n        key: 'community',\n        label: renderMenuCard('Community', 'Join our developer community.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n    ],\n  },\n])\n\nconst popupRender: MenuProps['popupRender'] = (node, info) => {\n  const title = info.item.title || info.item.key\n  return h('div', { class: 'menu-popup', style: popupStyle.value }, [\n    h('div', { class: 'menu-popup-title', style: headerStyle.value }, title),\n    node,\n  ])\n}\n\nconst themeConfig = {\n  components: {\n    Menu: {\n      popupBg: '#fff',\n      horizontalItemSelectedColor: '#1677ff',\n      horizontalItemHoverColor: '#1677ff',\n    },\n  },\n}\n</script>\n\n<template>\n  <a-config-provider :theme=\"themeConfig\">\n    <a-menu mode=\"horizontal\" :items=\"menuItems\" :popup-render=\"popupRender\" />\n  </a-config-provider>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with basic menu container styles and layout",
+          "descriptionZh": "根元素，包含菜单容器的基础样式和布局"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AppstoreOutlined, MailOutlined } from '@antdv-next/icons'\nimport { computed, h, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst mode = ref<'horizontal' | 'vertical' | 'inline'>('horizontal')\nconst current = ref('mail')\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst semantics = computed(() => {\n  const baseLocale = [\n    { name: 'root', desc: t('root') },\n    { name: 'item', desc: t('item') },\n    { name: 'itemIcon', desc: t('itemIcon') },\n    { name: 'itemContent', desc: t('itemContent') },\n  ]\n  const subMenuLocale = [\n    { name: 'subMenu.itemTitle', desc: t('subMenu.itemTitle') },\n    { name: 'subMenu.list', desc: t('subMenu.list') },\n    { name: 'subMenu.item', desc: t('subMenu.item') },\n    { name: 'subMenu.itemIcon', desc: t('subMenu.itemIcon') },\n    { name: 'subMenu.itemContent', desc: t('subMenu.itemContent') },\n  ]\n  const groupLocale = [\n    { name: 'itemTitle', desc: t('itemTitle') },\n    { name: 'list', desc: t('list') },\n  ]\n\n  const additionalPopupLocale = mode.value !== 'inline' ? [{ name: 'popup', desc: t('popup') }] : []\n  const additionalGroupLocale = mode.value !== 'horizontal' ? groupLocale : []\n\n  return [...baseLocale, ...additionalGroupLocale, ...additionalPopupLocale, ...subMenuLocale]\n})\n\nconst items = [\n  { label: 'Navigation One', key: 'mail', icon: h(MailOutlined) },\n  {\n    key: 'SubMenu',\n    label: 'Navigation Two',\n    icon: h(AppstoreOutlined),\n    children: [\n      {\n        key: 'g1',\n        label: 'Item 1',\n        type: 'group',\n        children: [\n          { key: '1', label: 'Option 1', icon: h(MailOutlined) },\n          { key: '2', label: 'Option 2' },\n        ],\n      },\n    ],\n  },\n]\n\nconst groupItem = [\n  {\n    key: 'grp',\n    label: 'Navigation Three',\n    type: 'group',\n    children: [\n      { key: '3', label: 'Option 3' },\n      { key: '4', label: 'Option 4' },\n    ],\n  },\n]\n\nconst itemList = computed(() => {\n  return mode.value === 'horizontal' ? items : [...items, ...groupItem]\n})\n\nfunction onClick(e: { key: string }) {\n  current.value = e.key\n}\n\nfunction getPopupContainer() {\n  const el = ((divRef.value as any)?.$el ?? divRef.value) as HTMLElement | null\n  return el?.parentElement?.parentElement || el!\n}\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Menu\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" vertical gap=\"middle\" align=\"center\">\n        <a-segmented\n          :options=\"['horizontal', 'vertical', 'inline']\"\n          :value=\"mode\"\n          @change=\"(val: 'horizontal' | 'vertical' | 'inline') => mode = val\"\n        />\n        <div :style=\"{ height: '360px' }\">\n          <a-menu\n            :selected-keys=\"[current]\"\n            :mode=\"mode\"\n            :items=\"itemList\"\n            :styles=\"{\n              root: { width: mode === 'horizontal' ? '480px' : '230px' },\n              popup: { root: { zIndex: 1 } },\n            }\"\n            :open-keys=\"['SubMenu']\"\n            :get-popup-container=\"getPopupContainer\"\n            :classes=\"classes\"\n            @click=\"onClick\"\n          />\n        </div>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with relative positioning, block display, margins, whitespace handling, cursor styles, transitions and other basic interactive styles for menu items",
+          "descriptionZh": "条目元素，包含相对定位、块级显示、外边距、空白符处理、光标样式、过渡动画等菜单项的基础交互样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Item content element with layout and typography styles for menu item content",
+          "descriptionZh": "条目内容元素，包含菜单项内容的布局和排版样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Icon element with min-width, font-size, transitions, icon reset styles, and spacing control with text",
+          "descriptionZh": "图标元素，包含最小宽度、字体大小、过渡动画、图标重置样式，以及与文本的间距控制"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Item title element (no effect in horizontal mode) with title text styles and layout",
+          "descriptionZh": "菜单标题元素(horizontal 模式不生效)，包含标题文字的样式和布局"
+        },
+        {
+          "key": "list",
+          "description": "Menu list element (no effect in horizontal mode) with menu list layout and container styles",
+          "descriptionZh": "菜单列表元素(horizontal 模式不生效)，包含菜单列表的布局和容器样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup menu element (no effect in inline mode) with popup layer positioning, z-index, background and other styles",
+          "descriptionZh": "弹出菜单(inline 模式不生效)，包含弹出层的定位、层级、背景等样式"
+        },
+        {
+          "key": "subMenu.itemTitle",
+          "description": "Submenu title element with submenu title styles and interactive effects",
+          "descriptionZh": "子菜单标题元素，包含子菜单标题的样式和交互效果"
+        },
+        {
+          "key": "subMenu.list",
+          "description": "Submenu list element with submenu list layout and container styles",
+          "descriptionZh": "子菜单列表元素，包含子菜单列表的布局和容器样式"
+        },
+        {
+          "key": "subMenu.item",
+          "description": "Submenu item element with submenu item styles and interactive effects",
+          "descriptionZh": "子菜单单项元素，包含子菜单项的样式和交互效果"
+        },
+        {
+          "key": "subMenu.itemIcon",
+          "description": "Submenu item icon element with submenu icon size and styles",
+          "descriptionZh": "子菜单条目图标元素，包含子菜单图标的尺寸和样式"
+        },
+        {
+          "key": "subMenu.itemContent",
+          "description": "Submenu item content element with submenu content layout and typography",
+          "descriptionZh": "子菜单条目内容元素，包含子菜单内容的布局和排版"
         }
       ]
     },
@@ -14323,14 +14998,38 @@
           "description": "Static methods cannot consume Context provided by `ConfigProvider`. When enable `layer`, they may also cause style errors. Please use hooks version or `App` provided instance first.",
           "descriptionZh": "静态方法无法消费 Context，不能动态响应 ConfigProvider 提供的各项配置，启用 `layer` 时还可能导致样式异常。请优先使用 hooks 版本或者 App 组件提供的 `message` 实例。",
           "code": "<script setup lang=\"ts\">\nimport { message } from 'antdv-next'\n\nfunction info() {\n  message.info('This is an info message')\n}\n</script>\n\n<template>\n  <a-button type=\"primary\" @click=\"info\">\n    Static Method\n  </a-button>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "list",
+          "description": "Message list root element, set positioning, z-index, width, scroll area and placement styles",
+          "descriptionZh": "消息列表根元素，设置定位、层级、宽度、滚动区域和位置样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { message } from 'antdv-next'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { _InternalListDoNotUseOrYouWillBeFired: InternalList } = message\n\nconst { t } = useComponentLocale(locales)\n\nconst previewListStyle = {\n  position: 'relative',\n  inset: 'auto',\n  width: '100%',\n  maxWidth: '100%',\n  height: 'auto',\n  padding: '24px',\n  overflow: 'visible',\n  transform: 'none',\n} as const\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'wrapper', desc: t('wrapper'), version: '1.3.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.3.0' },\n  { name: 'list', desc: t('list'), version: '1.3.0' },\n  { name: 'listContent', desc: t('listContent'), version: '1.3.0' },\n])\n\nconst items = computed(() => [\n  {\n    key: 'semantic-message-1',\n    content: 'Hello, Antdv Next!',\n    type: 'success' as const,\n    duration: false as const,\n  },\n  {\n    key: 'semantic-message-2',\n    content: 'Welcome back!',\n    type: 'info' as const,\n    duration: false as const,\n  },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Message\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <InternalList\n        :style=\"previewListStyle\"\n        :items=\"items\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "listContent",
+          "description": "Message list content element, set notice layout, gap and height transition styles",
+          "descriptionZh": "消息列表内容元素，设置消息项排列、间距和高度动画样式"
+        },
+        {
+          "key": "root",
+          "description": "Message item root element, set background color, border radius, shadow, padding and animation styles",
+          "descriptionZh": "消息项根元素，设置背景色、圆角、阴影、内边距和动画样式"
+        },
+        {
+          "key": "wrapper",
+          "description": "Wrapper element for icon and title, set content layout, gap and alignment styles",
+          "descriptionZh": "图标与标题的包裹元素，设置内容布局、间距和对齐样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element, set font size, line height and status color styles",
+          "descriptionZh": "图标元素，设置字体大小、行高和状态颜色样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element, set text color, font size, line height and content display styles",
+          "descriptionZh": "标题元素，设置文本颜色、字号、行高和内容展示样式"
         }
       ]
     },
@@ -14895,14 +15594,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Modal by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Modal 组件的 [语义化结构](#semantic-dom) 样式。",
           "code": "<script setup lang=\"ts\">\nimport type { ModalProps } from 'antdv-next'\nimport { computed, ref } from 'vue'\n\nconst modalOpen = ref(false)\nconst modalFnOpen = ref(false)\n\nconst lineStyle = {\n  lineHeight: '28px',\n}\n\nconst classNames = computed(() => ({\n  container: 'custom-modal-container',\n}))\n\nconst styles: ModalProps['styles'] = {\n  mask: {\n    backgroundImage: `linear-gradient(to top, #18181b 0, rgba(21, 21, 22, 0.2) 100%)`,\n  },\n}\n\nconst stylesFn: ModalProps['styles'] = {\n  container: {\n    borderRadius: '14px',\n    border: '1px solid #ccc',\n    padding: '0',\n    overflow: 'hidden',\n  },\n  header: {\n    padding: '16px',\n  },\n  body: {\n    padding: '16px',\n  },\n  footer: {\n    padding: '16px 10px',\n    backgroundColor: '#fafafa',\n  },\n}\n\nconst sharedProps = computed<ModalProps>(() => ({\n  centered: true,\n  classes: classNames.value,\n}))\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-button @click=\"modalOpen = true\">\n      Open Style Modal\n    </a-button>\n    <a-button type=\"primary\" @click=\"modalFnOpen = true\">\n      Open Function Modal\n    </a-button>\n\n    <a-modal\n      v-bind=\"sharedProps\"\n      v-model:open=\"modalOpen\"\n      :footer=\"null\"\n      title=\"Custom Style Modal\"\n      :styles=\"styles\"\n    >\n      <div :style=\"lineStyle\">\n        Following the Ant Design specification, we developed a React UI library antd that contains a\n        set of high quality components and demos for building rich, interactive user interfaces.\n      </div>\n      <div :style=\"lineStyle\">\n        🌈 Enterprise-class UI designed for web applications.\n      </div>\n      <div :style=\"lineStyle\">\n        📦 A set of high-quality React components out of the box.\n      </div>\n      <div :style=\"lineStyle\">\n        🛡 Written in TypeScript with predictable static types.\n      </div>\n      <div :style=\"lineStyle\">\n        ⚙️ Whole package of design resources and development tools.\n      </div>\n      <div :style=\"lineStyle\">\n        🌍 Internationalization support for dozens of languages.\n      </div>\n      <div :style=\"lineStyle\">\n        🎨 Powerful theme customization in every detail.\n      </div>\n    </a-modal>\n\n    <a-modal\n      v-bind=\"sharedProps\"\n      v-model:open=\"modalFnOpen\"\n      title=\"Custom Function Modal\"\n      :styles=\"stylesFn\"\n      :mask=\"{ enabled: true, blur: true }\"\n    >\n      <div :style=\"lineStyle\">\n        Following the Ant Design specification, we developed a React UI library antd that contains a\n        set of high quality components and demos for building rich, interactive user interfaces.\n      </div>\n      <div :style=\"lineStyle\">\n        🌈 Enterprise-class UI designed for web applications.\n      </div>\n      <div :style=\"lineStyle\">\n        📦 A set of high-quality React components out of the box.\n      </div>\n      <div :style=\"lineStyle\">\n        🛡 Written in TypeScript with predictable static types.\n      </div>\n      <div :style=\"lineStyle\">\n        ⚙️ Whole package of design resources and development tools.\n      </div>\n      <div :style=\"lineStyle\">\n        🌍 Internationalization support for dozens of languages.\n      </div>\n      <div :style=\"lineStyle\">\n        🎨 Powerful theme customization in every detail.\n      </div>\n      <template #footer>\n        <a-button\n          :style=\"{ borderColor: '#ccc', color: '#171717', backgroundColor: '#fff' }\"\n          @click=\"modalFnOpen = false\"\n        >\n          Cancel\n        </a-button>\n        <a-button\n          type=\"primary\"\n          :style=\"{ backgroundColor: '#171717' }\"\n          @click=\"modalOpen = true\"\n        >\n          Submit\n        </a-button>\n      </template>\n    </a-modal>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, top position, width, max-width, margins, bottom padding and other basic layout styles for modal container",
+          "descriptionZh": "根元素，包含相对定位、顶部位置、宽度、最大宽度、外边距、底部内边距等模态框容器的基础布局样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'mask', desc: t('mask'), version: '1.0.0' },\n  { name: 'container', desc: t('container'), version: '1.0.0' },\n  { name: 'wrapper', desc: t('wrapper'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.3.0' },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Modal\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', inset: 0 }\">\n        <a-modal\n          title=\"Title\"\n          open\n          :get-container=\"() => divRef!\"\n          :width=\"400\"\n          :styles=\"{\n            mask: { position: 'absolute', zIndex: 1 },\n            wrapper: { position: 'absolute', zIndex: 1 },\n          }\"\n          :style=\"{ top: '50%', transform: 'translateY(-50%)', marginBottom: 0, paddingBottom: 0 }\"\n          :classes=\"classes\"\n        >\n          <p>Some contents...</p>\n        </a-modal>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "mask",
+          "description": "Mask element with fixed positioning, z-index, background color, animation transitions and other mask layer styles",
+          "descriptionZh": "遮罩层元素，包含固定定位、层级、背景色、动画过渡等遮罩层的样式"
+        },
+        {
+          "key": "wrapper",
+          "description": "Wrapper element used for motion container with animation and transition effect styles",
+          "descriptionZh": "包裹层元素，一般用于动画容器，包含动画和过渡效果的样式"
+        },
+        {
+          "key": "container",
+          "description": "Modal container element with relative positioning, background, background-clip, border, border-radius, box-shadow, pointer-events, padding and other modal body styles",
+          "descriptionZh": "Modal 容器元素，包含相对定位、背景色、背景裁剪、边框、圆角、阴影、指针事件、内边距等模态框主体样式"
+        },
+        {
+          "key": "header",
+          "description": "Header element with padding, bottom border and other header area styles",
+          "descriptionZh": "头部元素，包含头部内边距、下边框等头部区域样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with margin, color, font-weight, font-size, line-height, word-wrap and other title text styles",
+          "descriptionZh": "标题元素，包含外边距、颜色、字体权重、字体大小、行高、文字换行等标题文字样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with content area background color, padding and other content display styles",
+          "descriptionZh": "内容元素，包含内容区域的背景色、内边距等内容展示样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with footer background color, padding, top border, border-radius and other footer area styles",
+          "descriptionZh": "底部元素，包含底部的背景色、内边距、上边框、圆角等底部区域样式"
+        },
+        {
+          "key": "close",
+          "description": "Close button element with base button styles, positioning and interaction effects",
+          "descriptionZh": "关闭按钮元素，包含按钮基础样式、位置和交互效果"
         }
       ]
     },
@@ -15088,14 +15826,63 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Notification by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义通知的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CSSProperties } from 'vue'\nimport { notification } from 'antdv-next'\n\nconst [api, ContextHolder] = notification.useNotification()\n\nconst defaultStyles: Record<string, CSSProperties> = {\n  root: {\n    backgroundColor: '#f6ffed',\n    border: '2px solid #95de64',\n    borderRadius: '16px',\n    boxShadow: '4px 4px 0 #d9f7be',\n  },\n  icon: {\n    color: '#237804',\n  },\n  title: {\n    color: '#237804',\n    fontWeight: 600,\n  },\n  description: {\n    color: '#3f6600',\n  },\n}\n\nfunction styleFn(info: { props: any }): Record<string, CSSProperties> {\n  if (info.props.type === 'error') {\n    return {\n      ...defaultStyles,\n      root: {\n        ...defaultStyles.root,\n        backgroundColor: '#fff2f0',\n        borderColor: '#ffccc7',\n        boxShadow: '4px 4px 0 #ffccc7',\n      },\n      icon: {\n        color: '#cf1322',\n      },\n      title: {\n        color: '#cf1322',\n      },\n      description: {\n        color: '#5c0011',\n      },\n    }\n  }\n  return defaultStyles\n}\n\nconst sharedProps = {\n  title: 'Notification Title',\n  description: 'This is a notification description.',\n  duration: false as const,\n}\n\nfunction openDefault() {\n  api.info({\n    ...sharedProps,\n    styles: defaultStyles,\n  })\n}\n\nfunction openError() {\n  api.error({\n    ...sharedProps,\n    type: 'error',\n    styles: styleFn as any,\n  })\n}\n</script>\n\n<template>\n  <ContextHolder />\n  <a-space>\n    <a-button type=\"primary\" @click=\"openDefault\">\n      Default Notification\n    </a-button>\n    <a-button @click=\"openError\">\n      Error Notification\n    </a-button>\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "list",
+          "description": "Notification list root element, set positioning, z-index, width, scroll area and placement styles",
+          "descriptionZh": "通知列表根元素，设置定位、层级、宽度、滚动区域和位置样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { Button, notification } from 'antdv-next'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { _InternalListDoNotUseOrYouWillBeFired: InternalList } = notification\n\nconst { t } = useComponentLocale(locales)\n\nconst previewListStyle = {\n  position: 'relative',\n  inset: 'auto',\n  width: '432px',\n  maxWidth: '100%',\n  height: 'auto',\n  padding: '24px',\n  transform: 'none',\n} as const\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'wrapper', desc: t('wrapper'), version: '1.3.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.3.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.3.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n  { name: 'progress', desc: t('progress'), version: '1.3.0' },\n  { name: 'list', desc: t('list'), version: '1.3.0' },\n  { name: 'listContent', desc: t('listContent'), version: '1.3.0' },\n])\n\nconst items = computed(() => [\n  {\n    key: 'semantic-notification-1',\n    title: 'Hello World!',\n    description: 'Hello World?',\n    type: 'success' as const,\n    duration: false as const,\n    actions: h(Button, { type: 'primary', size: 'small' }, () => 'My Button'),\n  },\n  {\n    key: 'semantic-notification-2',\n    title: 'Welcome back!',\n    description: 'This is another notification.',\n    type: 'info' as const,\n    duration: 999999,\n    showProgress: true,\n  },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Notification\"\n    :height=\"320\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <InternalList\n        placement=\"topRight\"\n        :style=\"previewListStyle\"\n        :items=\"items\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "listContent",
+          "description": "Notification list content element, set notice layout, gap and height transition styles",
+          "descriptionZh": "通知列表内容元素，设置通知项排列、间距和高度动画样式"
+        },
+        {
+          "key": "root",
+          "description": "Notice root element, set background color, border radius, shadow, padding and animation styles",
+          "descriptionZh": "通知项根元素，设置背景色、圆角、阴影、内边距和动画样式"
+        },
+        {
+          "key": "wrapper",
+          "description": "Wrapper element for icon and content with content layout styles",
+          "descriptionZh": "图标与内容的包裹元素，设置内容布局样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element, set absolute positioning, font size, line height and status color styles",
+          "descriptionZh": "图标元素，设置绝对定位、字体大小、行高和状态颜色样式"
+        },
+        {
+          "key": "section",
+          "description": "Content section element that contains title and description",
+          "descriptionZh": "内容区域元素，包含标题和描述内容"
+        },
+        {
+          "key": "title",
+          "description": "Title element, set color, font size, line height and margin styles",
+          "descriptionZh": "标题元素，设置颜色、字体大小、行高和外边距样式"
+        },
+        {
+          "key": "description",
+          "description": "Description element, set font size, color and margin styles",
+          "descriptionZh": "描述元素，设置字体大小、颜色和外边距样式"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element, set float right, top margin and action button layout styles",
+          "descriptionZh": "操作组元素，设置右浮动、上边距和操作按钮布局样式"
+        },
+        {
+          "key": "close",
+          "description": "Close button element, set position, size and interaction styles",
+          "descriptionZh": "关闭按钮元素，设置位置、尺寸和交互样式"
+        },
+        {
+          "key": "progress",
+          "description": "Progress element, set progress styles for auto-closing notifications",
+          "descriptionZh": "进度条元素，设置自动关闭通知的进度样式"
         }
       ]
     },
@@ -15114,7 +15901,8 @@
       "props": [],
       "tokens": [],
       "faq": [],
-      "demos": []
+      "demos": [],
+      "semanticStructure": []
     },
     {
       "name": "Pagination",
@@ -15552,14 +16340,18 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Pagination by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Pagination 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { PaginationProps } from 'antdv-next'\nimport { useCssModule } from 'vue'\n\nconst moduleStyles = useCssModule()\n\nconst classes: PaginationProps['classes'] = {\n  root: moduleStyles.root,\n}\n\nconst stylesObject: PaginationProps['styles'] = {\n  item: {\n    borderRadius: '999px',\n  },\n}\n\nconst stylesFn: PaginationProps['styles'] = ({ props }) => {\n  if (props.size === 'small') {\n    return {\n      item: {\n        backgroundColor: 'rgba(200, 200, 200, 0.3)',\n        marginInlineEnd: '4px',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-pagination :total=\"500\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-pagination :total=\"500\" size=\"small\" :classes=\"classes\" :styles=\"stylesFn\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set flex layout, alignment, flex wrap and list styles",
+          "descriptionZh": "根元素，设置flex布局、对齐方式、换行和列表样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Pagination\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-pagination :default-current=\"1\" :total=\"50\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element, set size, padding, border, background color, hover state and active state styles",
+          "descriptionZh": "页码元素，设置尺寸、内边距、边框、背景色、悬停态和激活态样式"
         }
       ]
     },
@@ -15771,14 +16563,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Popconfirm by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Popconfirm 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { PopconfirmProps } from 'antdv-next'\n\nconst classes: PopconfirmProps['classes'] = {\n  container: 'demo-popconfirm-container',\n}\n\nconst stylesObject: PopconfirmProps['styles'] = {\n  container: {\n    backgroundColor: '#eee',\n    boxShadow: 'inset 5px 5px 3px #fff, inset -5px -5px 3px #ddd, 0 0 3px rgba(0,0,0,0.2)',\n  },\n  title: {\n    color: '#262626',\n  },\n  content: {\n    color: '#262626',\n  },\n}\n\nconst stylesFn: PopconfirmProps['styles'] = (info) => {\n  if (info?.props?.arrow === false) {\n    return {\n      container: {\n        backgroundColor: 'rgba(53, 71, 125, 0.8)',\n        padding: '12px',\n        borderRadius: '4px',\n      },\n      title: {\n        color: '#fff',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-popconfirm\n      title=\"Object text\"\n      description=\"Object description\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    >\n      <a-button>Object Style</a-button>\n    </a-popconfirm>\n    <a-popconfirm\n      title=\"Function text\"\n      description=\"Function description\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n      :ok-button-props=\"{ styles: { root: { backgroundColor: 'rgba(53, 71, 125, 0.6)', color: '#fff' } } }\"\n      :cancel-button-props=\"{ styles: { root: { borderColor: 'rgba(53, 71, 125, 0.6)', backgroundColor: '#fff', color: 'rgba(53, 71, 125, 0.8)' } } }\"\n    >\n      <a-button type=\"primary\">\n        Function Style\n      </a-button>\n    </a-popconfirm>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set absolute positioning, z-index, transform origin, arrow direction and popover container styles",
+          "descriptionZh": "根元素，设置绝对定位、层级、变换原点、箭头指向和弹层容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'container', desc: t('container') },\n  { name: 'title', desc: t('title') },\n  { name: 'content', desc: t('content') },\n  { name: 'icon', desc: t('icon'), version: '1.3.0' },\n  { name: 'arrow', desc: t('arrow') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Popconfirm\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', marginTop: '60px' }\">\n        <a-popconfirm\n          open\n          placement=\"top\"\n          title=\"Confirm\"\n          description=\"Are you sure you want to perform this action?\"\n          :auto-adjust-overflow=\"false\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "arrow",
+          "description": "Arrow element with width, height, position, color and border styles",
+          "descriptionZh": "箭头元素，设置宽高、位置、颜色和边框样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element, set title text styles and spacing",
+          "descriptionZh": "标题元素，设置标题文本样式和间距"
+        },
+        {
+          "key": "content",
+          "description": "Description element, set content text styles and layout",
+          "descriptionZh": "描述元素，设置描述文本样式和布局"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element, set icon size, color and margin styles",
+          "descriptionZh": "图标元素，设置图标尺寸、颜色和外边距样式"
         }
       ]
     },
@@ -15982,14 +16798,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Popover by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Popover 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { PopoverProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: PopoverProps['classes'] = {\n  container: 'demo-popover-container',\n}\n\nconst stylesObject: PopoverProps['styles'] = {\n  container: {\n    backgroundColor: '#eee',\n    boxShadow: 'inset 5px 5px 3px #fff, inset -5px -5px 3px #ddd, 0 0 3px rgba(0,0,0,0.2)',\n  },\n  title: {\n    color: '#262626',\n  },\n  content: {\n    color: '#262626',\n  },\n}\n\nconst stylesFn: PopoverProps['styles'] = (info) => {\n  if (info?.props?.arrow === false) {\n    return {\n      container: {\n        backgroundColor: 'rgba(53, 71, 125, 0.8)',\n        padding: '12px',\n        borderRadius: '4px',\n      },\n      title: {\n        color: '#fff',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-popover\n      content=\"Object text\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    >\n      <a-button>Object Style</a-button>\n    </a-popover>\n    <a-popover\n      content=\"Function text\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n    >\n      <a-button type=\"primary\">\n        Function Style\n      </a-button>\n    </a-popover>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set absolute positioning, z-index, transform origin, arrow direction and popover container styles",
+          "descriptionZh": "根元素，设置绝对定位、层级、变换原点、箭头指向和弹层容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'container', desc: t('container') },\n  { name: 'title', desc: t('title') },\n  { name: 'content', desc: t('content') },\n  { name: 'arrow', desc: t('arrow') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Popover\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', marginTop: '60px' }\">\n        <a-popover\n          open\n          placement=\"top\"\n          title=\"Hello\"\n          content=\"Ant Design love you!\"\n          :auto-adjust-overflow=\"false\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "arrow",
+          "description": "Arrow element with width, height, position, color and border styles",
+          "descriptionZh": "箭头元素，设置宽高、位置、颜色和边框样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element, set title text styles and spacing",
+          "descriptionZh": "标题元素，设置标题文本样式和间距"
+        },
+        {
+          "key": "content",
+          "description": "Content element, set content text styles and layout",
+          "descriptionZh": "内容元素，设置内容文本样式和布局"
         }
       ]
     },
@@ -16292,14 +17127,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Progress by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Progress 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { ProgressProps } from 'antdv-next'\n\nconst classes: ProgressProps['classes'] = {\n  root: 'demo-progress-root',\n  rail: 'demo-progress-rail',\n  track: 'demo-progress-track',\n}\n\nconst stylesFn: ProgressProps['styles'] = (info) => {\n  const percent = info?.props?.percent ?? 0\n  const hue = 200 - (200 * percent) / 100\n  return {\n    track: {\n      backgroundImage: `\n        linear-gradient(\n          to right,\n          hsla(${hue}, 85%, 65%, 1),\n          hsla(${hue + 30}, 90%, 55%, 0.95)\n        )`,\n      borderRadius: 8,\n      transition: 'all 0.3s ease',\n    },\n    rail: {\n      backgroundColor: 'rgba(0, 0, 0, 0.1)',\n      borderRadius: 8,\n    },\n  } as ProgressProps['styles']\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"10\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"20\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"40\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"60\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"80\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"99\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set relative positioning and basic container styles",
+          "descriptionZh": "根元素，设置相对定位和基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'body', desc: t('body') },\n  { name: 'rail', desc: t('rail') },\n  { name: 'track', desc: t('track') },\n  { name: 'indicator', desc: t('indicator') },\n])\n\nconst gradient = ref(false)\nconst type = ref('line')\n\nconst colorMap = {\n  '0%': '#108ee9',\n  '100%': '#87d068',\n}\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Progress\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical gap=\"middle\" :style=\"{ width: '100%' }\" align=\"center\">\n        <a-flex align=\"center\" gap=\"middle\">\n          <a-segmented\n            :options=\"['line', 'steps', 'circle', 'dashboard']\"\n            :value=\"type\"\n            @change=\"(val: string) => type = val\"\n          />\n          <a-switch\n            :checked=\"gradient\"\n            checked-children=\"Gradient\"\n            un-checked-children=\"Gradient\"\n            @change=\"(val: boolean) => gradient = val\"\n          />\n        </a-flex>\n        <a-flex vertical align=\"center\" :style=\"{ height: '200px', width: '100%' }\">\n          <a-progress\n            :percent=\"80\"\n            :type=\"type === 'steps' ? 'line' : type\"\n            :steps=\"type === 'steps' ? 5 : undefined\"\n            :stroke-color=\"gradient ? colorMap : undefined\"\n            :classes=\"classes\"\n          />\n        </a-flex>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "body",
+          "description": "Body element, set progress bar layout and size styles",
+          "descriptionZh": "主体元素，设置进度条的布局和尺寸样式"
+        },
+        {
+          "key": "rail",
+          "description": "Rail element, set background track color and border radius styles. Not exist in steps mode",
+          "descriptionZh": "导轨元素，设置背景轨道的颜色和圆角样式，steps 模式下没有该元素"
+        },
+        {
+          "key": "track",
+          "description": "Track element, set progress fill color and transition animation styles",
+          "descriptionZh": "轨迹元素，设置进度填充部分的颜色和过渡动画样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element, set percentage text or icon position and font styles",
+          "descriptionZh": "指示器元素，设置百分比文本或图标的位置和字体样式"
         }
       ]
     },
@@ -16520,14 +17374,18 @@
           "description": "With Popover.",
           "descriptionZh": "带气泡卡片的例子。",
           "code": "<script setup lang=\"ts\">\ndefineOptions({ name: 'Popover' })\n</script>\n\n<template>\n  <a-popover>\n    <template #content>\n      <a-qrcode value=\"https://ant.design\" :bordered=\"false\" />\n    </template>\n    <a-button type=\"primary\">\n      Hover me\n    </a-button>\n  </a-popover>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set flex layout, padding, background color, border, border radius and relative positioning styles",
+          "descriptionZh": "根元素，设置flex布局、内边距、背景色、边框、圆角和相对定位样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'cover', desc: t('cover') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"QRCode\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-qrcode value=\"https://ant.design\" status=\"loading\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "cover",
+          "description": "Cover element, set absolute positioning, z-index, background color and loading state overlay styles",
+          "descriptionZh": "遮罩层元素，设置绝对定位、层级、背景色和加载状态覆盖样式"
         }
       ]
     },
@@ -16929,14 +17787,23 @@
           "description": "Solid radio button style.",
           "descriptionZh": "实色填底的单选按钮样式。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst value = shallowRef('a')\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-radio-group v-model:value=\"value\" button-style=\"solid\">\n      <a-radio-button value=\"a\">\n        Hangzhou\n      </a-radio-button>\n      <a-radio-button value=\"b\">\n        Shanghai\n      </a-radio-button>\n      <a-radio-button value=\"c\">\n        Beijing\n      </a-radio-button>\n      <a-radio-button value=\"d\">\n        Chengdu\n      </a-radio-button>\n    </a-radio-group>\n    <a-radio-group v-model:value=\"value\" button-style=\"solid\">\n      <a-radio-button value=\"a\">\n        Hangzhou\n      </a-radio-button>\n      <a-radio-button value=\"b\" disabled>\n        Shanghai\n      </a-radio-button>\n      <a-radio-button value=\"c\">\n        Beijing\n      </a-radio-button>\n      <a-radio-button value=\"d\">\n        Chengdu\n      </a-radio-button>\n    </a-radio-group>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with layout styles, cursor styles, disabled text color and other basic container styles",
+          "descriptionZh": "根元素，包含布局样式、鼠标样式、禁用状态文字颜色等基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Radio\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-radio :classes=\"classes\">\n        Radio\n      </a-radio>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element with border radius, transition animations, border styles, hover states, focus states and other interactive styles",
+          "descriptionZh": "选中框元素，包含圆角样式、过渡动画、边框样式、悬停状态、焦点状态等交互样式"
+        },
+        {
+          "key": "label",
+          "description": "Label element with padding, text color, disabled states, alignment and other text styles",
+          "descriptionZh": "文本元素，包含内边距、文字颜色、禁用状态、对齐方式等文本样式"
         }
       ]
     },
@@ -17198,7 +18065,8 @@
           "descriptionZh": "调试使用。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst value = ref(2.5)\n</script>\n\n<template>\n  <a-config-provider\n    :theme=\"{\n      components: {\n        Rate: {\n          starColor: 'blue',\n          starSize: 40,\n          starHoverScale: 'scale(2)',\n          starBg: 'red',\n        },\n      },\n    }\"\n  >\n    <a-rate v-model:value=\"value\" allow-half />\n  </a-config-provider>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Result",
@@ -17366,14 +18234,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Result by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Result 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { ResultProps } from 'antdv-next'\n\nconst classesObject: ResultProps['classes'] = {\n  root: 'demo-result-root',\n  title: 'demo-result-title',\n  subTitle: 'demo-result-subtitle',\n  icon: 'demo-result-icon',\n  extra: 'demo-result-extra',\n  body: 'demo-result-body',\n}\n\nconst classesFn: ResultProps['classes'] = (info) => {\n  if (info.props.status === 'success') {\n    return {\n      root: 'demo-result-root--success',\n    } satisfies ResultProps['classes']\n  }\n  return {\n    root: 'demo-result-root--default',\n  } satisfies ResultProps['classes']\n}\n\nconst stylesObject: ResultProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed', padding: '16px' },\n  title: { fontStyle: 'italic', color: '#1890ff' },\n  subTitle: { fontWeight: 'bold' },\n  icon: { opacity: 0.8 },\n  extra: { backgroundColor: '#f0f0f0', padding: 'px' },\n  body: { backgroundColor: '#fafafa', padding: '12px' },\n}\n\nconst stylesFn: ResultProps['styles'] = (info) => {\n  if (info.props.status === 'error') {\n    return {\n      root: { backgroundColor: '#fff2f0', borderColor: '#ff4d4f' },\n      title: { color: '#ff4d4f' },\n    } satisfies ResultProps['styles']\n  }\n  else {\n    return {\n      root: { backgroundColor: '#f6ffed', borderColor: '#52c41a' },\n      title: { color: '#52c41a' },\n    } satisfies ResultProps['styles']\n  }\n}\n</script>\n\n<template>\n  <a-result\n    status=\"info\"\n    title=\"classes Object\"\n    sub-title=\"This is a subtitle\"\n    :styles=\"stylesObject\"\n    :classes=\"classesObject\"\n  >\n    <template #extra>\n      <a-button type=\"primary\">\n        Action\n      </a-button>\n    </template>\n    <div>Content area</div>\n  </a-result>\n  <a-result\n    status=\"success\"\n    title=\"classes Function\"\n    sub-title=\"Dynamic class names\"\n    :styles=\"stylesFn\"\n    :classes=\"classesFn\"\n  >\n    <template #extra>\n      <a-button type=\"primary\">\n        Action\n      </a-button>\n    </template>\n  </a-result>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with text alignment, layout styles and other basic container styles",
+          "descriptionZh": "根元素，包含文本对齐、布局样式等基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'subTitle', desc: t('subTitle'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Result\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-result\n        title=\"title\"\n        sub-title=\"subTitle\"\n        :classes=\"classes\"\n      >\n        <template #extra>\n          <a-button type=\"primary\">\n            extra\n          </a-button>\n        </template>\n        <div :style=\"{ textAlign: 'center' }\">\n          The Content of Result\n        </div>\n      </a-result>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "title",
+          "description": "Title element with font size, text color, line height, text alignment and other text styles",
+          "descriptionZh": "标题元素，包含字体大小、文字颜色、行高、对齐方式等文字样式"
+        },
+        {
+          "key": "subTitle",
+          "description": "Subtitle element with font size, text color, line height and other text styles",
+          "descriptionZh": "副标题元素，包含字体大小、文字颜色、行高等文字样式"
+        },
+        {
+          "key": "body",
+          "description": "Content element with margin, padding, background color and other content area styles",
+          "descriptionZh": "内容元素，包含外边距、内边距、背景色等内容区域样式"
+        },
+        {
+          "key": "extra",
+          "description": "Action area element with margin, text alignment, inner element spacing and other layout styles",
+          "descriptionZh": "操作区域元素，包含外边距、文本对齐、内部元素间距等布局样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with margin, text alignment, font size, status colors and other icon styles",
+          "descriptionZh": "图标元素，包含外边距、文本对齐、字体大小、状态颜色等图标样式"
         }
       ]
     },
@@ -17637,14 +18529,28 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Segmented by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Segmented 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { SegmentedProps } from 'antdv-next'\nimport { CloudOutlined, RocketOutlined, ThunderboltOutlined } from '@antdv-next/icons'\nimport { h } from 'vue'\n\nconst classes: SegmentedProps['classes'] = {\n  root: 'custom-segmented-root',\n}\nconst styleFn: SegmentedProps['styles'] = (info) => {\n  if (info.props.vertical) {\n    return {\n      root: {\n        border: '1px solid #77BEF0',\n        padding: '4px',\n        width: '100px',\n      },\n      icon: {\n        color: '#77BEF0',\n      },\n      item: {\n        textAlign: 'start',\n      },\n    } satisfies SegmentedProps['styles']\n  }\n  return {}\n}\n\nconst styles: SegmentedProps['styles'] = {\n  root: {\n    padding: '4px',\n    width: '260px',\n  },\n}\n\nconst options: SegmentedProps['options'] = [\n  {\n    label: 'Boost',\n    value: 'boost',\n    icon: h(RocketOutlined),\n  },\n  {\n    label: 'Stream',\n    value: 'stream',\n    icon: h(ThunderboltOutlined),\n  },\n  {\n    label: 'Cloud',\n    value: 'cloud',\n    icon: h(CloudOutlined),\n  },\n]\nconst segmentedSharedProps: SegmentedProps = {\n  options,\n  classes,\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-segmented v-bind=\"segmentedSharedProps\" :styles=\"styles\" />\n    <a-segmented v-bind=\"segmentedSharedProps\" :styles=\"styleFn\" vertical />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with inline-block layout, padding, background, border radius, transition and container styles",
+          "descriptionZh": "根元素，设置行内块布局、内边距、背景色、圆角、过渡动画和容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AppstoreOutlined, BarsOutlined } from '@antdv-next/icons'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n])\n\nconst options = [\n  { label: 'List', value: 'List', icon: h(BarsOutlined) },\n  { label: 'Kanban', value: 'Kanban', icon: h(AppstoreOutlined) },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Segmented\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-segmented :options=\"options\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Option element with relative positioning, text alignment, cursor style, transition, selected state background and hover styles",
+          "descriptionZh": "选项元素，设置相对定位、文本对齐、光标样式、过渡动画、选中态背景色和悬停态样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with icon size, color and text spacing styles",
+          "descriptionZh": "图标元素，设置图标的尺寸、颜色和与文本的间距样式"
+        },
+        {
+          "key": "label",
+          "description": "Label content element with min height, line height, padding, text ellipsis and content layout styles",
+          "descriptionZh": "标签内容元素，设置最小高度、行高、内边距、文本省略和内容布局样式"
         }
       ]
     },
@@ -18494,14 +19400,73 @@
           "description": "You can customize the semantic dom style of Select by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "您可以通过 `classes` 和 `styles` 传入对象/函数来自定义 Select 的语义化 DOM 样式。",
           "code": "<script setup lang=\"ts\">\nimport { MehOutlined } from '@antdv-next/icons'\n\nconst options = [\n  { value: 'GuangZhou', label: 'GuangZhou' },\n  { value: 'ShenZhen', label: 'ShenZhen' },\n]\n\nconst stylesObject = {\n  prefix: {\n    color: '#1890ff',\n  },\n  suffix: {\n    color: '#1890ff',\n  },\n}\n\nconst stylesFilled = {\n  prefix: {\n    color: '#722ed1',\n  },\n  suffix: {\n    color: '#722ed1',\n  },\n  popup: {\n    root: {\n      border: '1px solid #722ed1',\n    },\n  },\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-select\n      :options=\"options\"\n      :classes=\"{ root: 'custom-select' }\"\n      :styles=\"stylesObject\"\n      placeholder=\"Object\"\n    >\n      <template #prefix>\n        <MehOutlined />\n      </template>\n    </a-select>\n    <a-select\n      :options=\"options\"\n      :classes=\"{ root: 'custom-select' }\"\n      :styles=\"stylesFilled\"\n      placeholder=\"Function\"\n      variant=\"filled\"\n    >\n      <template #prefix>\n        <MehOutlined />\n      </template>\n    </a-select>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, cursor styles, transitions, border and other basic selector container styles",
+          "descriptionZh": "根元素，包含相对定位、行内 flex 布局、光标样式、过渡动画、边框等选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst mode = ref<'single' | 'multiple'>('single')\n\nconst options = [\n  { value: 'aojunhao123', label: 'aojunhao123' },\n  { value: 'thinkasany', label: 'thinkasany' },\n  { value: 'meet-student', label: 'meet-student' },\n]\n\nconst value = computed(() => {\n  if (mode.value !== 'multiple')\n    return []\n\n  return options.length > 0\n    ? [options[0]!.value]\n    : []\n})\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => {\n  const base = [\n    { name: 'root', desc: t('root') },\n    { name: 'prefix', desc: t('prefix') },\n    { name: 'content', desc: t('content') },\n    { name: 'placeholder', desc: t('placeholder') },\n    { name: 'clear', desc: t('clear') },\n    { name: 'input', desc: t('input') },\n    { name: 'suffix', desc: t('suffix') },\n    { name: 'popup.root', desc: t('popup.root') },\n    { name: 'popup.list', desc: t('popup.list') },\n    { name: 'popup.listItem', desc: t('popup.listItem') },\n  ]\n\n  if (mode.value === 'multiple') {\n    return [\n      ...base,\n      { name: 'item', desc: t('item') },\n      { name: 'itemContent', desc: t('itemContent') },\n      { name: 'itemRemove', desc: t('itemRemove') },\n    ]\n  }\n\n  return base\n})\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Select\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <div :style=\"{ display: 'flex', justifyContent: 'center', marginBottom: '12px' }\">\n          <a-segmented v-model:value=\"mode\" :options=\"['single', 'multiple']\" />\n        </div>\n        <div :style=\"{ display: 'flex', flexDirection: 'column', gap: '12px' }\">\n          <a-select\n            prefix=\"prefix\"\n            :style=\"{ width: '300px' }\"\n            :options=\"options\"\n            :value=\"value\"\n            :mode=\"mode === 'multiple' ? 'multiple' : undefined\"\n            open\n            :get-popup-container=\"() => divRef!\"\n            :classes=\"classes\"\n          />\n        </div>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with layout and styling for prefix content",
+          "descriptionZh": "前缀元素，包含前缀内容的布局和样式"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "clear",
+          "description": "Clear button element with layout, styling and interactive effects for clear button",
+          "descriptionZh": "清除按钮元素，包含清除按钮的布局、样式和交互效果"
+        },
+        {
+          "key": "input",
+          "description": "Input element with search input styling, cursor control, font inheritance and other search-related styles. Remove border styles",
+          "descriptionZh": "输入框元素，包含搜索输入框的样式、光标控制、字体继承等搜索相关样式，去除了边框样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with layout and styling for suffix content like clear button, arrow icon, etc.",
+          "descriptionZh": "后缀元素，包含后缀内容的布局和样式，如清除按钮、箭头图标等"
+        },
+        {
+          "key": "item",
+          "description": "Multiple selection item element with border, background, padding, and margin styles",
+          "descriptionZh": "多选项元素，包含边框、背景、内边距、外边距样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Multiple selection item content area with text ellipsis styles",
+          "descriptionZh": "多选项内容区域，包含文字的省略样式"
+        },
+        {
+          "key": "itemRemove",
+          "description": "Multiple selection item remove button with font-related styless",
+          "descriptionZh": "多选项移除按钮，包含字体相关样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with popup layer positioning, z-index, background, border, box-shadow and other popup container styles",
+          "descriptionZh": "弹出菜单元素，包含弹出层的定位、层级、背景、边框、阴影等弹出容器样式"
+        },
+        {
+          "key": "popup.list",
+          "description": "Popup list element with option list layout, scrolling, max-height and other list container styles",
+          "descriptionZh": "弹出菜单列表元素，包含选项列表的布局、滚动、最大高度等列表容器样式"
+        },
+        {
+          "key": "popup.listItem",
+          "description": "Popup item element with option item padding, hover effects, selected states, disabled states and other option interactive styles",
+          "descriptionZh": "弹出菜单条目元素，包含选项项的内边距、悬浮效果、选中状态、禁用状态等选项交互样式"
         }
       ]
     },
@@ -18956,22 +19921,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Skeleton by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Skeleton 组件的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nconst classes = {\n  root: 'skeleton-root',\n  header: 'skeleton-header',\n}\n\nconst styles = {\n  avatar: {\n    border: '1px solid #aaa',\n  },\n  title: {\n    border: '1px solid #aaa',\n  },\n}\n\nfunction stylesFn(info: { props: { active?: boolean } }) {\n  if (info.props?.active) {\n    return {\n      root: {\n        border: '1px solid rgba(229, 243, 254, 0.3)',\n      },\n      title: {\n        backgroundColor: 'rgba(229, 243, 254, 0.5)',\n        height: '20px',\n        borderRadius: '20px',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-skeleton\n      :classes=\"classes\"\n      :styles=\"styles\"\n      avatar\n      :paragraph=\"false\"\n    />\n    <a-skeleton\n      :classes=\"{ ...classes, paragraph: 'skeleton-paragraph' }\"\n      :styles=\"stylesFn\"\n      active\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with table display, width, animation effects, border radius and other skeleton container basic styles",
+          "descriptionZh": "根元素，包含表格显示、宽度、动画效果、圆角等骨架屏容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'avatar', desc: t('avatar'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'paragraph', desc: t('paragraph'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Skeleton\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-skeleton avatar :paragraph=\"{ rows: 4 }\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with table cell, padding, vertical alignment and other avatar placeholder area layout styles",
+          "descriptionZh": "头部元素，包含表格单元格、内边距、垂直对齐等头像占位区域的布局样式"
         },
         {
-          "name": "_semantic_element",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport type { SegmentedOptions } from 'antdv-next'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\ntype SkeletonElement = 'Avatar' | 'Button' | 'Input' | 'Image' | 'Node'\nconst internalOptions: SegmentedOptions = ['Avatar', 'Button', 'Input', 'Image', 'Node']\n\nconst element = ref<SkeletonElement>('Avatar')\n\nconst componentMap: Record<SkeletonElement, string> = {\n  Avatar: 'a-skeleton-avatar',\n  Button: 'a-skeleton-button',\n  Input: 'a-skeleton-input',\n  Image: 'a-skeleton-image',\n  Node: 'a-skeleton-node',\n}\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('element.root'), version: '1.0.0' },\n  { name: 'content', desc: t('element.content'), version: '1.0.0' },\n])\n\nconst componentName = computed(() => `Skeleton.${element.value}`)\nconst currentComponent = computed(() => componentMap[element.value])\n</script>\n\n<template>\n  <SemanticPreview\n    :component-name=\"componentName\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical :style=\"{ width: 'fit-content', marginInlineEnd: 'auto' }\">\n        <a-segmented v-model:value=\"element\" :options=\"internalOptions\" />\n        <a-divider title-placement=\"start\" plain>\n          {{ t('element.preview') }}\n        </a-divider>\n        <component :is=\"currentComponent\" :classes=\"classes\" />\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Section element with skeleton content area layout styles",
+          "descriptionZh": "区块元素，包含骨架屏内容区域的布局样式"
+        },
+        {
+          "key": "avatar",
+          "description": "Avatar element with inline-block display, vertical alignment, background color, size, border radius and other avatar placeholder styles",
+          "descriptionZh": "头像元素，包含行内块显示、垂直对齐、背景色、尺寸、圆角等头像占位的样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with width, height, background color, border radius and other title placeholder styles",
+          "descriptionZh": "标题元素，包含宽度、高度、背景色、圆角等标题占位的样式"
+        },
+        {
+          "key": "paragraph",
+          "description": "Paragraph element with padding, list item styles, background color, border radius and other paragraph placeholder styles",
+          "descriptionZh": "段落元素，包含内边距、列表项样式、背景色、圆角等段落占位的样式"
+        },
+        {
+          "key": "element.root",
+          "description": "Root element",
+          "descriptionZh": "根元素"
+        },
+        {
+          "key": "element.content",
+          "description": "Content element",
+          "descriptionZh": "内容元素"
+        },
+        {
+          "key": "element.preview",
+          "description": "Preview",
+          "descriptionZh": "预览"
         }
       ]
     },
@@ -19377,14 +20373,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Sliders by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Sliders 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst value = ref(30)\nconst valueVertical = ref(30)\n\nconst stylesObject = {\n  track: { backgroundImage: 'linear-gradient(180deg, #91caff, #1677ff)' },\n  handle: { borderColor: '#1677ff', boxShadow: '0 2px 8px #1677ff' },\n}\n\nfunction stylesFn(info: any) {\n  if (info.props.orientation === 'vertical') {\n    return {\n      root: { height: '300px' },\n      track: { backgroundImage: 'linear-gradient(180deg, #722cc0, #722ed1)' },\n      handle: { borderColor: '#722ed1', boxShadow: '0 2px 8px #722ed1' },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-slider v-model:value=\"value\" class=\"custom-slider\" :styles=\"stylesObject\" />\n    <a-slider\n      v-model:value=\"valueVertical\"\n      class=\"custom-slider-vertical\"\n      orientation=\"vertical\"\n      reverse\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, height, margin, padding, cursor style and touch action control",
+          "descriptionZh": "根元素，设置相对定位、高度、边距、内边距、光标样式和触摸事件控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'track', desc: t('track'), version: '1.0.0' },\n  { name: 'tracks', desc: t('tracks'), version: '1.0.0' },\n  { name: 'rail', desc: t('rail'), version: '1.0.0' },\n  { name: 'handle', desc: t('handle'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Slider\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-slider\n        range\n        :default-value=\"[20, 30, 50]\"\n        :style=\"{ width: '100%' }\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "track",
+          "description": "Track selection bar element with absolute positioning, background color, border radius and transition animation styles",
+          "descriptionZh": "轨道选取条元素，设置绝对定位、背景色、圆角和过渡动画样式"
+        },
+        {
+          "key": "tracks",
+          "description": "Multi-segment track container element with absolute positioning and transition animation styles",
+          "descriptionZh": "多段轨道容器元素，设置绝对定位和过渡动画样式"
+        },
+        {
+          "key": "rail",
+          "description": "Background rail element with absolute positioning, background color, border radius and transition animation styles",
+          "descriptionZh": "背景轨道元素，设置绝对定位、背景色、圆角和过渡动画样式"
+        },
+        {
+          "key": "handle",
+          "description": "Slider handle control element with absolute positioning, size, outline, user selection, background color, border shadow, border radius, cursor style and transition animation",
+          "descriptionZh": "滑块控制点元素，设置绝对定位、尺寸、轮廓线、用户选择、背景色、边框阴影、圆角、光标样式和过渡动画"
         }
       ]
     },
@@ -19607,14 +20622,23 @@
           "description": "Customize semantic structure styles and class names. Supports both object and function forms.",
           "descriptionZh": "自定义语义化结构的样式和类名。支持对象和函数两种形式。",
           "code": "<script setup lang=\"ts\">\nimport type { SpaceProps } from 'antdv-next'\n\nconst classNamesObject: SpaceProps['classes'] = {\n  root: 'demo-space-root',\n  item: 'demo-space-item',\n  separator: 'demo-space-separator',\n}\n\nconst classNamesFn: SpaceProps['classes'] = (info) => {\n  if (info.props.orientation === 'vertical') {\n    return {\n      root: 'demo-space-root--vertical',\n    } satisfies SpaceProps['classes']\n  }\n  else {\n    return {\n      root: 'demo-space-root--horizontal',\n    } satisfies SpaceProps['classes']\n  }\n}\n\nconst stylesObject: SpaceProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed', padding: '8px', marginBottom: '10px' },\n  item: { backgroundColor: '#f0f0f0', padding: '4px' },\n  separator: { color: 'red', fontWeight: 'bold' },\n}\n\nconst stylesFn: SpaceProps['styles'] = (info) => {\n  if (info.props.size === 'large') {\n    return {\n      root: {\n        backgroundColor: '#e6f7ff',\n        borderColor: '#1890ff',\n        padding: '8px',\n      },\n    } satisfies SpaceProps['styles']\n  }\n  else {\n    return {\n      root: {\n        backgroundColor: '#fff7e6',\n        borderColor: '#fa8c16',\n      },\n    } satisfies SpaceProps['styles']\n  }\n}\n</script>\n\n<template>\n  <div>\n    <a-space :styles=\"stylesObject\" :classes=\"classNamesObject\" separator=\"•\">\n      <a-button>Styled Button 1</a-button>\n      <a-button>Styled Button 2</a-button>\n      <a-button>Styled Button 3</a-button>\n    </a-space>\n    <a-space size=\"large\" :styles=\"stylesFn\" :classes=\"classNamesFn\">\n      <a-button>Large Space Button 1</a-button>\n      <a-button>Large Space Button 2</a-button>\n      <a-button>Large Space Button 3</a-button>\n    </a-space>\n  </div>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, gap settings, alignment, wrap and other spacing container basic styles",
+          "descriptionZh": "根元素，包含 flex 布局、间隙设置、对齐方式、换行等间距容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n  { name: 'separator', desc: t('separator') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Space\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-space :classes=\"classes\">\n        <template #separator>\n          <a-divider vertical />\n        </template>\n        <a-button type=\"primary\">\n          Primary\n        </a-button>\n        <a-button>Default</a-button>\n        <a-button type=\"dashed\">\n          Dashed\n        </a-button>\n      </a-space>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Wrapped item element with spacing item layout and styles, providing wrapper for each child element for inline alignment",
+          "descriptionZh": "包裹的子组件，包含间距项的布局和样式，为每个子元素提供包装用于内联对齐"
+        },
+        {
+          "key": "separator",
+          "description": "Separator element with divider styling",
+          "descriptionZh": "分隔符，包含分隔元素的样式"
         }
       ]
     },
@@ -19827,14 +20851,18 @@
           "description": "Debug example for standalone Spin components nested inside a wrapping Spin. The inner\nones should not pick up the outer overlay's absolute centering styles.",
           "descriptionZh": "嵌套独立 `Spin` 的调试示例：包裹型 `Spin` 的内容里再放独立 `Spin`，内层不应被外层的居中定位样式影响。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst loading = ref(true)\nconst dataSource = ['Apple', 'Banana']\n</script>\n\n<template>\n  <a-flex gap=\"middle\" vertical>\n    <a-spin :spinning=\"loading\">\n      <a-flex vertical gap=\"small\" :style=\"{ padding: '16px', border: '1px solid #d9d9d9' }\">\n        <a-flex v-for=\"item in dataSource\" :key=\"item\" align=\"center\" justify=\"space-between\">\n          <span>{{ item }}</span>\n          <a-spin size=\"small\" />\n        </a-flex>\n      </a-flex>\n    </a-spin>\n    <a-flex align=\"center\" gap=\"small\">\n      <span>Outer loading state:</span>\n      <a-switch v-model:checked=\"loading\" />\n    </a-flex>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with absolute positioning, display control, color, font size, text alignment, vertical alignment, opacity and transition animation (effective when fullscreen is false)",
+          "descriptionZh": "根元素，设置绝对定位、显示控制、颜色、字体大小、文本对齐、垂直对齐、透明度和过渡动画(fullscreen 为 false 时才有效)"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Spin\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div\n        :style=\"{\n          position: 'relative',\n          width: '500px',\n          height: '100px',\n          display: 'flex',\n          alignItems: 'center',\n          justifyContent: 'center',\n        }\"\n      >\n        <a-spin :percent=\"0\" :classes=\"classes\" />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "indicator",
+          "description": "Indicator element with width, height, font size, inline-block display, transition animation, transform origin, line height and color",
+          "descriptionZh": "指示器元素，设置宽度、高度、字体大小、行内块显示、过渡动画、变换原点、行高和颜色"
         }
       ]
     },
@@ -20117,14 +21145,23 @@
           "description": "Customize semantic structure styles and class names. Supports both object and function forms.",
           "descriptionZh": "自定义语义化结构的样式和类名。支持对象和函数两种形式。",
           "code": "<script setup lang=\"ts\">\nimport type { SplitterProps } from 'antdv-next'\n\nconst stylesObject: SplitterProps['styles'] = {\n  root: { backgroundColor: '#fffbe6' },\n  dragger: { backgroundColor: 'rgba(194,223,252,0.4)' },\n}\n\nconst stylesFn: SplitterProps['styles'] = ({ props }) => {\n  if (props.orientation === 'horizontal') {\n    return {\n      root: {\n        borderWidth: '2px',\n        borderStyle: 'dashed',\n        marginBottom: '10px',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-splitter\n      style=\"height: 200px\"\n      root-class=\"shadow-secondary\"\n      :styles=\"stylesObject\"\n    >\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\" style=\"color: #000\">\n            First\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\" style=\"color: #000\">\n            Second\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n    </a-splitter>\n    <a-splitter\n      style=\"height: 200px\"\n      root-class=\"shadow-secondary\"\n      :styles=\"stylesFn\"\n    >\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\">\n            First\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\">\n            Second\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n    </a-splitter>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, width and height, alignment and stretch styles",
+          "descriptionZh": "根元素，设置flex布局、宽度高度、对齐方式和拉伸样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'panel', desc: t('panel'), version: '1.0.0' },\n  { name: 'dragger', desc: t('dragger'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Splitter\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-splitter\n        :style=\"{ height: '200px', boxShadow: '0 0 10px rgba(0, 0, 0, 0.1)' }\"\n        :classes=\"classes\"\n      >\n        <a-splitter-panel>\n          <div :style=\"{ display: 'flex', height: '100%', alignItems: 'center', justifyContent: 'center' }\">\n            First\n          </div>\n        </a-splitter-panel>\n        <a-splitter-panel>\n          <div :style=\"{ display: 'flex', height: '100%', alignItems: 'center', justifyContent: 'center' }\">\n            Second\n          </div>\n        </a-splitter-panel>\n      </a-splitter>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "panel",
+          "description": "Panel element with flex basis, grow ratio and panel container styles",
+          "descriptionZh": "面板元素，设置flex基础值、增长比例和面板容器样式"
+        },
+        {
+          "key": "dragger",
+          "description": "Drag control element with absolute positioning, user selection, z-index, center alignment, background color, hover and active states styles",
+          "descriptionZh": "拖拽控制元素，设置绝对定位、用户选择、层级、居中对齐、背景色、悬停态和激活态样式"
         }
       ]
     },
@@ -20325,14 +21362,43 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of the Statistic by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Statistic 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { StatisticProps } from 'antdv-next'\nimport { ArrowDownOutlined, ArrowUpOutlined } from '@antdv-next/icons'\n\nconst classes = {\n  root: 'custom-statistic-root',\n}\nconst styleFn: StatisticProps['styles'] = ({ props }) => {\n  const numValue = Number(props.value ?? 0)\n  const isNegative = Number.isFinite(numValue) && numValue < 0\n  if (isNegative) {\n    return {\n      title: {\n        color: '#ff4d4f',\n      },\n      content: {\n        color: '#ff7875',\n      },\n    } satisfies StatisticProps['styles']\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-statistic\n      :value=\"93241\"\n      title=\"Monthly Active Users\"\n      :classes=\"classes\"\n      :styles=\"{ title: { color: '#1890ff', fontWeight: '600px' }, content: { fontSize: '24px' } }\"\n      suffix=\"users\"\n    >\n      <template #prefix>\n        <ArrowUpOutlined />\n      </template>\n    </a-statistic>\n\n    <a-statistic\n      :value=\"-18.7\"\n      title=\"Yearly Loss\"\n      :precision=\"1\"\n      :classes=\"classes\"\n      :styles=\"styleFn\"\n      suffix=\"%\"\n    >\n      <template #prefix>\n        <ArrowDownOutlined />\n      </template>\n    </a-statistic>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with reset styles and overall container styles for statistic component",
+          "descriptionZh": "根元素，包含统计数值组件的重置样式和整体容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { ArrowUpOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'prefix', desc: t('prefix'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'value', desc: t('value'), version: '1.3.0' },\n  { name: 'suffix', desc: t('suffix'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Statistic\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ position: 'absolute' }\">\n        <a-statistic\n          title=\"Active\"\n          :value=\"11.28\"\n          :precision=\"2\"\n          :styles=\"{ content: { color: '#3f8600' } }\"\n          suffix=\"%\"\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <ArrowUpOutlined />\n          </template>\n        </a-statistic>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with bottom padding and title area layout styles",
+          "descriptionZh": "头部元素，包含下内边距和标题区域的布局样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text color, font size and other title text display styles",
+          "descriptionZh": "标题元素，包含文字颜色、字体大小等标题文字的显示样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with text color, font size, font family and other numeric content display styles",
+          "descriptionZh": "内容元素，包含文字颜色、字体大小、字体族等数值内容的展示样式"
+        },
+        {
+          "key": "value",
+          "description": "Value element with text color, font size, font family and other statistic number display styles",
+          "descriptionZh": "数值元素，包含文字颜色、字体大小、字体族等统计数值的展示样式"
+        },
+        {
+          "key": "prefix",
+          "description": "Prefix element with inline-block display, right margin and other prefix content layout styles",
+          "descriptionZh": "前缀元素，包含行内块显示、右外边距等前缀内容的布局样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with inline-block display, left margin and other suffix content layout styles",
+          "descriptionZh": "后缀元素，包含行内块显示、左外边距等后缀内容的布局样式"
         }
       ]
     },
@@ -20645,14 +21711,58 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Steps by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Steps 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { StepsProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: StepsProps['classes'] = {\n  root: 'steps-demo-root',\n}\n\nconst stylesObject: StepsProps['styles'] = {\n  itemIcon: {\n    borderRadius: '30%',\n  },\n  itemContent: {\n    fontStyle: 'italic',\n  },\n}\n\nconst stylesFn: StepsProps['styles'] = (info) => {\n  if (info?.props?.type === 'navigation') {\n    return {\n      root: {\n        borderColor: '#1890ff',\n      },\n    }\n  }\n  return {}\n}\n\nconst items: StepsProps['items'] = [\n  { title: 'Finished', content: 'This is a content.' },\n  { title: 'In Progress', content: 'This is a content.' },\n  { title: 'Waiting', content: 'This is a content.' },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-steps :items=\"items\" :current=\"1\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-steps\n      :items=\"items\"\n      :current=\"1\"\n      type=\"navigation\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, nowrap, alignment, CSS variables and other basic step container styles",
+          "descriptionZh": "根元素，包含 flex 布局、禁止换行、对齐方式、CSS 变量等步骤条容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemWrapper', desc: t('itemWrapper') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n  { name: 'itemHeader', desc: t('itemHeader') },\n  { name: 'itemTitle', desc: t('itemTitle') },\n  { name: 'itemSubtitle', desc: t('itemSubtitle') },\n  { name: 'itemSection', desc: t('itemSection') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'itemRail', desc: t('itemRail') },\n])\n\nconst items = [\n  { title: 'Step 1', subTitle: '00:01', content: 'This is a content.' },\n  { title: 'Step 2', subTitle: '00:02', content: 'This is a content.' },\n  { title: 'Step 3', subTitle: '00:03', content: 'This is a content.' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Steps\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical gap=\"large\" :style=\"{ width: '100%' }\">\n        <a-steps\n          :current=\"1\"\n          :style=\"{ width: '100%' }\"\n          title-placement=\"vertical\"\n          :items=\"items\"\n          :classes=\"classes\"\n        />\n        <a-steps\n          :current=\"1\"\n          :style=\"{ width: '100%' }\"\n          type=\"panel\"\n          size=\"small\"\n          title-placement=\"horizontal\"\n          :items=\"items\"\n          :classes=\"classes\"\n        />\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Step item element with flex layout, relative positioning and other basic step item container styles",
+          "descriptionZh": "步骤项元素，包含 flex 布局、相对定位等单个步骤项的基础容器样式"
+        },
+        {
+          "key": "itemWrapper",
+          "description": "Step item wrapper element with flex layout, nowrap, top padding and other step content wrapping styles",
+          "descriptionZh": "步骤项内裹元素，包含 flex 布局、禁止换行、顶部内边距等步骤项内容的包装样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Step item icon element with icon size, positioning, font-size and other icon display related styles",
+          "descriptionZh": "步骤项图标元素，包含图标的尺寸、定位、字体大小等图标显示相关样式"
+        },
+        {
+          "key": "itemHeader",
+          "description": "Step item header element with flex layout, nowrap, alignment and other header area layout styles",
+          "descriptionZh": "步骤项头部元素，包含 flex 布局、禁止换行、对齐方式等头部区域的布局样式"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Step item title element with color, font-size, line-height, word-break, transitions and other title text styles",
+          "descriptionZh": "步骤项标题元素，包含颜色、字体大小、行高、文字换行、过渡动画等标题文字样式"
+        },
+        {
+          "key": "itemSubtitle",
+          "description": "Step item subtitle element with color, font-weight, font-size, line-height, margin, word-break and other subtitle styles",
+          "descriptionZh": "步骤项副标题元素，包含颜色、字体权重、字体大小、行高、外边距、文字换行等副标题样式"
+        },
+        {
+          "key": "itemSection",
+          "description": "Step item section element with step content area layout and styling",
+          "descriptionZh": "步骤项区域元素，包含步骤项内容区域的布局和样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Step item content element with color, font-size, line-height, word-break, transitions and other content text styles",
+          "descriptionZh": "步骤项内容元素，包含颜色、字体大小、行高、文字换行、过渡动画等内容文字样式"
+        },
+        {
+          "key": "itemRail",
+          "description": "Step item rail element with border-style, border-width, transitions and other connecting line styles",
+          "descriptionZh": "步骤项连接线元素，包含边框样式、边框宽度、过渡动画等连接线的样式"
         }
       ]
     },
@@ -20951,14 +22061,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Switch by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Switch 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes = {\n  root: 'custom-switch-root',\n}\n\nconst stylesObject = {\n  root: {\n    backgroundColor: '#F5D2D2',\n  },\n}\n\nfunction stylesFn(info: any) {\n  if (info.props.size === 'medium') {\n    return {\n      root: {\n        backgroundColor: '#BDE3C3',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical align=\"flex-start\" justify=\"flex-start\" gap=\"medium\">\n    <a-switch\n      size=\"small\"\n      checked-children=\"on\"\n      un-checked-children=\"off\"\n      :styles=\"stylesObject\"\n      :classes=\"{ root: 'custom-switch-root' }\"\n    />\n    <a-switch\n      size=\"medium\"\n      checked-children=\"on\"\n      un-checked-children=\"off\"\n      :styles=\"stylesFn\"\n      :classes=\"classes\"\n    />\n    <a-switch\n      default-checked\n      :classes=\"{ root: 'mui-root', indicator: 'mui-indicator' }\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with min-width, height, line-height, vertical alignment, background color, border, border radius, cursor style, transition animations, user selection and other basic switch container styles",
+          "descriptionZh": "根元素，包含最小宽度、高度、行高、垂直对齐、背景色、边框、圆角、光标样式、过渡动画、用户选择等开关容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.3' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Switch\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-switch\n        checked-children=\"on\"\n        un-checked-children=\"off\"\n        default-checked\n        disabled\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "content",
+          "description": "Content element with block display, overflow hidden, border radius, height, padding, transition animations and other switch content area layout and styles",
+          "descriptionZh": "内容元素，包含块级显示、溢出隐藏、圆角、高度、内边距、过渡动画等开关内容区域的布局和样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element with absolute positioning, width, height, background color, border radius, shadow, transition animations and other switch handle styles and interactive effects",
+          "descriptionZh": "指示器元素,包含绝对定位、宽度、高度、背景色、圆角、阴影、过渡动画等开关把手的样式和交互效果"
         }
       ]
     },
@@ -21818,14 +22937,73 @@
           "description": "Customize header and body cells via the headerCell and bodyCell slots.",
           "descriptionZh": "通过 headerCell 与 bodyCell 插槽自定义表头和单元格内容。",
           "code": "<script setup lang=\"ts\">\nimport type { TableProps } from 'antdv-next'\n\ninterface DataItem {\n  key: string\n  name: string\n  age: number\n  address: string\n}\n\nconst columns: TableProps['columns'] = [\n  {\n    title: 'Name',\n    dataIndex: 'name',\n    key: 'name',\n  },\n  {\n    title: 'Age',\n    dataIndex: 'age',\n    key: 'age',\n  },\n  {\n    title: 'Address',\n    dataIndex: 'address',\n    key: 'address',\n  },\n  {\n    title: 'Action',\n    key: 'action',\n  },\n]\n\nconst dataSource: DataItem[] = [\n  {\n    key: '1',\n    name: 'John Brown',\n    age: 32,\n    address: 'New York No. 1 Lake Park',\n  },\n  {\n    key: '2',\n    name: 'Jim Green',\n    age: 42,\n    address: 'London No. 1 Lake Park',\n  },\n  {\n    key: '3',\n    name: 'Joe Black',\n    age: 32,\n    address: 'Sydney No. 1 Lake Park',\n  },\n]\n\nfunction handleAction(record: Record<string, any>) {\n  console.log('Action:', record.name)\n}\n</script>\n\n<template>\n  <a-table :columns=\"columns\" :data-source=\"dataSource\">\n    <template #headerCell=\"{ column }\">\n      <template v-if=\"column.key === 'name'\">\n        <span class=\"table-header-strong\">{{ column.title }}</span>\n      </template>\n    </template>\n    <template #bodyCell=\"{ column, text, record }\">\n      <template v-if=\"column.key === 'name'\">\n        <a class=\"table-name\" @click.prevent=\"handleAction(record)\">{{ text }}</a>\n      </template>\n      <template v-else-if=\"column.key === 'action'\">\n        <a @click.prevent=\"handleAction(record)\">Action</a>\n      </template>\n    </template>\n  </a-table>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with font-size, background, border-radius, scrollbar-color and other basic table container styles",
+          "descriptionZh": "根元素，包含字体大小、背景色、圆角、滚动条颜色等表格容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'title', desc: t('title') },\n  { name: 'content', desc: t('content') },\n  { name: 'header.wrapper', desc: t('header.wrapper') },\n  { name: 'header.row', desc: t('header.row') },\n  { name: 'header.cell', desc: t('header.cell') },\n  { name: 'section', desc: t('section') },\n  { name: 'body.wrapper', desc: t('body.wrapper') },\n  { name: 'body.row', desc: t('body.row') },\n  { name: 'body.cell', desc: t('body.cell') },\n  { name: 'footer', desc: t('footer') },\n  { name: 'pagination.root', desc: t('pagination.root') },\n  { name: 'pagination.item', desc: t('pagination.item') },\n])\n\nconst columns = [\n  {\n    title: 'Personal Info',\n    children: [\n      { title: 'Name', dataIndex: 'name', key: 'name' },\n      { title: 'Age', dataIndex: 'age', key: 'age' },\n    ],\n  },\n  { title: 'Address', dataIndex: 'address' },\n]\n\nconst data = [\n  { key: '1', name: 'thinkasany', age: 24, address: 'New York No. 1 Lake Park' },\n  { key: '2', name: 'Jim Green', age: 42, address: 'London No. 1 Lake Park' },\n  { key: '3', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n  { key: '4', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n  { key: '5', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n  { key: '6', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Table\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-table\n        bordered\n        :style=\"{ width: '100%' }\"\n        :columns=\"columns\"\n        :data-source=\"data\"\n        size=\"middle\"\n        :pagination=\"{ pageSize: 3 }\"\n        :classes=\"classes\"\n      >\n        <template #title>\n          table title\n        </template>\n        <template #footer>\n          table footer\n        </template>\n      </a-table>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Container element with clear-fix, max-width, scrollbar background and other table wrapper styles",
+          "descriptionZh": "容器元素，包含清除浮动、最大宽度、滚动条背景等表格包装容器样式"
+        },
+        {
+          "key": "header.wrapper",
+          "description": "Header wrapper element with table header layout and container styles",
+          "descriptionZh": "头部容器元素，包含表头的布局和容器样式"
+        },
+        {
+          "key": "header.row",
+          "description": "Header row element with table header row layout and styling",
+          "descriptionZh": "头部行元素，包含表头行的布局和样式"
+        },
+        {
+          "key": "header.cell",
+          "description": "Header cell element with relative positioning, padding, word-wrap, background, text color, font-weight and other header cell styles",
+          "descriptionZh": "头部单元格元素，包含相对定位、内边距、文字换行、背景色、文字颜色、字体权重等表头单元格样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with table title styling and layout",
+          "descriptionZh": "标题元素，包含表格标题的样式和布局"
+        },
+        {
+          "key": "body.wrapper",
+          "description": "Body wrapper element with table body layout and container styles",
+          "descriptionZh": "主体容器元素，包含表格主体的布局和容器样式"
+        },
+        {
+          "key": "body.row",
+          "description": "Body row element with hover effects, selected states, expanded states and other interactive row styles",
+          "descriptionZh": "主体行元素，包含数据行的悬浮效果、选中状态、展开状态等交互样式"
+        },
+        {
+          "key": "body.cell",
+          "description": "Body cell element with relative positioning, padding, word-wrap and other basic data cell styles",
+          "descriptionZh": "主体单元格元素，包含相对定位、内边距、文字换行等数据单元格的基础样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with table footer background color, text color and other footer styles",
+          "descriptionZh": "底部元素，包含表格底部的背景色、文字颜色等样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with table content area styling and layout",
+          "descriptionZh": "内容元素，包含表格内容区域的样式和布局"
+        },
+        {
+          "key": "pagination.root",
+          "description": "Pagination root element with pagination component basic styles and layout",
+          "descriptionZh": "分页根元素，包含分页组件的基础样式和布局"
+        },
+        {
+          "key": "pagination.item",
+          "description": "Pagination item element with pagination item styling and interactive effects",
+          "descriptionZh": "分页单项元素，包含分页项的样式和交互效果"
         }
       ]
     },
@@ -22338,14 +23516,43 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tabs by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tabs 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TabsProps } from 'antdv-next'\n\nconst items: TabsProps['items'] = [\n  { key: '1', label: 'Tab 1', content: 'Content of Tab Pane 1' },\n  { key: '2', label: 'Tab 2', content: 'Content of Tab Pane 2' },\n  { key: '3', label: 'Tab 3', content: 'Content of Tab Pane 3' },\n]\n\nconst classes: TabsProps['classes'] = {\n  root: 'custom-tabs-root',\n}\n\nconst stylesObject: TabsProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed', padding: '16px', marginBottom: '10px' },\n  header: { backgroundColor: 'rgba(245,245,245,0.5)' },\n  item: { fontWeight: 'bold', color: '#1890ff', padding: `6px 10px` },\n  indicator: { backgroundColor: 'rgba(255,77,79, 0.3)', height: '4px' },\n  body: { backgroundColor: 'rgba(230,247,255,0.8)' },\n  content: { padding: '16px' },\n}\n\nconst stylesFn: TabsProps['styles'] = (info) => {\n  if (info.props.type === 'card') {\n    return {\n      root: { backgroundColor: 'rgba(250,250,250, 0.8)', borderColor: '#d9d9d9' },\n      header: { textAlign: 'start' },\n    } satisfies TabsProps['styles']\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-tabs :items=\"items\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-tabs type=\"card\" :items=\"items\" :classes=\"classes\" :styles=\"stylesFn\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with basic tab container styles, layout and direction control",
+          "descriptionZh": "根元素，包含标签页容器的基础样式、布局和方向控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'header', desc: t('header') },\n  { name: 'item', desc: t('item') },\n  { name: 'indicator', desc: t('indicator') },\n  { name: 'body', desc: t('body') },\n  { name: 'content', desc: t('content') },\n  { name: 'popup.root', desc: t('popup.root') },\n])\n\nconst items = computed(() =>\n  Array.from({ length: 30 }, (_, i) => {\n    const id = String(i)\n    return {\n      label: `Tab-${id}`,\n      key: id,\n      disabled: i === 28,\n      content: `Content of tab ${id}`,\n    }\n  }),\n)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tabs\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-tabs\n        default-active-key=\"1\"\n        :style=\"{ height: '220px', width: '100%' }\"\n        :styles=\"{\n          popup: {\n            root: { background: '#fff' },\n          },\n        }\"\n        :items=\"items\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with relative positioning, padding, colors, text ellipsis, border-radius, transitions and other tab item styles and interactive effects",
+          "descriptionZh": "Item 元素，包含相对定位、内边距、颜色、文本省略、圆角、过渡动画等标签项的样式和交互效果"
+        },
+        {
+          "key": "header",
+          "description": "Header element with tab navigation header layout, background, borders and other styles",
+          "descriptionZh": "头部元素，包含标签页头部导航的布局、背景、边框等样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element with indicator bar color, position, dimensions, transitions and other active state indication styles",
+          "descriptionZh": "指示器元素，包含指示条的颜色、位置、尺寸、过渡动画等活跃状态指示样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with tab panel container layout, animation and size control styles",
+          "descriptionZh": "内容区域元素，包含标签页面板容器的布局、动画和尺寸控制"
+        },
+        {
+          "key": "content",
+          "description": "Content element with single tab panel layout, padding and other content display styles",
+          "descriptionZh": "内容元素，包含单个标签页面板的布局、内边距等内容展示样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup menu element with dropdown absolute positioning, z-index, display control, max-height, scrolling and other styles",
+          "descriptionZh": "弹出菜单元素，包含下拉菜单的绝对定位、层级、显示控制、最大高度、滚动等样式"
         }
       ]
     },
@@ -22657,14 +23864,28 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tag by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tag 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { CheckCircleOutlined, CloseCircleOutlined } from '@antdv-next/icons'\n\nconst tagStyles = {\n  root: {\n    backgroundColor: '#e6f7ff',\n  },\n  icon: {\n    color: '#52c41a',\n  },\n  content: {\n    color: '#262626',\n  },\n}\n\nconst filledTagStyles = {\n  root: {\n    backgroundColor: '#F5EFFF',\n  },\n  icon: {\n    color: '#8F87F1',\n  },\n  content: {\n    color: '#8F87F1',\n  },\n}\n\nconst groupStyles = {\n  root: {\n    gap: '12px',\n    padding: '8px 12px',\n    backgroundColor: 'rgba(82, 196, 26, 0.08)',\n    borderRadius: '8px',\n  },\n  item: {\n    backgroundColor: 'rgba(82, 196, 26, 0.1)',\n    borderColor: 'rgba(82, 196, 26, 0.3)',\n    color: '#52c41a',\n  },\n}\n\nconst multipleGroupStyles = {\n  root: {\n    gap: '16px',\n    padding: '8px 12px',\n    backgroundColor: 'rgba(143, 135, 241, 0.08)',\n    borderRadius: '8px',\n  },\n  item: {\n    backgroundColor: 'rgba(143, 135, 241, 0.1)',\n    borderColor: 'rgba(143, 135, 241, 0.3)',\n    color: '#8F87F1',\n    fontWeight: 500,\n  },\n}\n\nconst options1 = ['React', 'Vue', 'Angular']\nconst options2 = ['meet-student', 'thinkasany']\n</script>\n\n<template>\n  <a-space size=\"large\" vertical>\n    <a-flex gap=\"middle\">\n      <a-tag :classes=\"{ root: 'custom-tag-root' }\" :styles=\"tagStyles\">\n        <template #icon>\n          <CheckCircleOutlined />\n        </template>\n        Object\n      </a-tag>\n      <a-tag\n        variant=\"filled\"\n        :classes=\"{ root: 'custom-tag-root' }\"\n        :styles=\"filledTagStyles\"\n      >\n        <template #icon>\n          <CloseCircleOutlined />\n        </template>\n        Function\n      </a-tag>\n    </a-flex>\n    <a-flex vertical gap=\"middle\">\n      <a-checkable-tag-group\n        :classes=\"{ root: 'custom-tag-root' }\"\n        :styles=\"groupStyles\"\n        :options=\"options1\"\n      />\n      <a-checkable-tag-group\n        :classes=\"{ root: 'custom-tag-root' }\"\n        :styles=\"multipleGroupStyles\"\n        :options=\"options2\"\n        multiple\n      />\n    </a-flex>\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with inline-block display, auto height, padding, font size, line height, nowrap, background color, border, border radius, opacity, transition animations, text alignment, relative positioning and other basic tag styles",
+          "descriptionZh": "根元素，包含行内块布局、自动高度、内边距、字体大小、行高、禁止换行、背景色、边框、圆角、透明度、过渡动画、文本对齐、相对定位等标签的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AntDesignOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.3.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tag\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-tag closable :classes=\"classes\">\n        <template #icon>\n          <AntDesignOutlined />\n        </template>\n        Ant Design\n      </a-tag>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element with font size, color, cursor style, transition animations and other icon display styles",
+          "descriptionZh": "图标元素，包含字体大小、颜色、光标样式、过渡动画等图标的显示样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with text content color, font styles and other content area styles",
+          "descriptionZh": "内容元素，包含文本内容的颜色、字体样式等内容区域的样式"
+        },
+        {
+          "key": "close",
+          "description": "Close element with close button layout, cursor styles, transition animations and other interaction styles",
+          "descriptionZh": "关闭元素，包含关闭按钮的布局、光标样式、过渡动画等交互样式"
         }
       ]
     },
@@ -22811,14 +24032,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of TimePicker by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 TimePicker 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TimePickerProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { useToken } = theme\nconst { token } = useToken()\n\nconst customClasses = {\n  root: 'custom-timepicker-root',\n}\n\nconst stylesObject: TimePickerProps['styles'] = {\n  root: {\n    borderColor: '#d9d9d9',\n  },\n}\n\nconst stylesFn: TimePickerProps['styles'] = (info) => {\n  if (info.props.size === 'large') {\n    return {\n      root: {\n        borderColor: '#722ed1',\n      },\n      suffix: {\n        color: '#722ed1',\n      },\n      popup: {\n        container: { border: '1px solid #722ed1', borderRadius: '8px' },\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-time-picker :classes=\"customClasses\" :styles=\"stylesObject\" placeholder=\"Object\" />\n    <a-time-picker :classes=\"customClasses\" :styles=\"stylesFn\" placeholder=\"Function\" size=\"large\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, padding, border-radius, transition animations and other basic styles for time picker container",
+          "descriptionZh": "根元素，包含相对定位、行内flex布局、内边距、边框圆角、过渡动画等时间选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { SmileOutlined } from '@antdv-next/icons'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'popup.root', desc: t('popup') },\n  { name: 'popup.container', desc: t('popup.container') },\n  { name: 'popup.content', desc: t('popup.content') },\n  { name: 'popup.item', desc: t('popup.item') },\n  { name: 'popup.footer', desc: t('popup.footer') },\n])\n\nconst type = ref<'Single' | 'Multiple'>('Single')\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    :component-name=\"type === 'Single' ? 'TimePicker' : 'TimePicker.RangePicker'\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" vertical :style=\"{ alignSelf: 'flex-start' }\" gap=\"middle\" align=\"center\">\n        <a-segmented\n          :options=\"['Single', 'Multiple']\"\n          :value=\"type\"\n          @change=\"(val: 'Single' | 'Multiple') => type = val\"\n        />\n        <a-time-picker\n          v-if=\"type === 'Single'\"\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-time-picker>\n        <a-time-range-picker\n          v-else\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-time-range-picker>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with flex layout and margin styles for prefix content layout",
+          "descriptionZh": "前缀元素，包含flex布局、右外边距等前缀内容的布局样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with relative positioning, width, color, font, line-height, transition animations and other core interactive styles for input field",
+          "descriptionZh": "输入框元素，包含相对定位、宽度、颜色、字体、行高、过渡动画等输入框的核心交互样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with flex layout, color, line-height, pointer events, transition animations and other styles for suffix content",
+          "descriptionZh": "后缀元素，包含flex布局、颜色、行高、指针事件、过渡动画等后缀内容的样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup element",
+          "descriptionZh": "弹出框元素"
+        },
+        {
+          "key": "popup.container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "popup.content",
+          "description": "Popup content element with width, border, cell and other content display styles for time list",
+          "descriptionZh": "弹出框内容元素，包含时间列表的宽度、边框、单元格等内容展示样式"
+        },
+        {
+          "key": "popup.item",
+          "description": "Popup item element with size, background, border-radius, hover state, selected state and other interactive styles for time cells",
+          "descriptionZh": "弹出框单项元素，包含时间单元格的尺寸、背景色、边框圆角、悬停态、选中态等交互样式"
+        },
+        {
+          "key": "popup.footer",
+          "description": "Popup footer element with layout styles for bottom operation area including confirm/cancel buttons",
+          "descriptionZh": "弹出框底部元素，包含确认取消按钮等底部操作区域的布局样式"
         }
       ]
     },
@@ -23055,14 +24315,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Timeline by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Timeline 的[语义化结构](#semantic-dom)样式。",
           "code": "<script lang=\"ts\" setup>\nconst classes = {\n  root: 'custom-timeline-root',\n}\n\nconst styles = {\n  itemIcon: {\n    borderColor: '#1890ff',\n  },\n}\n\nfunction stylesFn(info: any) {\n  if (info.props.orientation === 'vertical') {\n    return {\n      root: {\n        padding: '10px 6px',\n        border: '1px solid #A294F9',\n      },\n      itemIcon: {\n        borderColor: '#A294F9',\n      },\n    }\n  }\n  return {}\n}\n\nconst items = [\n  {\n    title: '2015-09-01',\n    content: 'Create a services site',\n  },\n  {\n    title: '2015-09-01 09:12:11',\n    content: 'Solve initial network problems',\n  },\n  {\n    content: 'Technical testing',\n  },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-timeline :items=\"items\" orientation=\"horizontal\" :styles=\"styles\" :classes=\"classes\" />\n    <a-timeline :items=\"items\" orientation=\"vertical\" :styles=\"stylesFn\" :classes=\"classes\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with timeline container list style reset, vertical layout, dot icon, outlined style, alternate layout and other basic container styles",
+          "descriptionZh": "根元素，设置时间轴容器的列表样式重置、垂直布局、点状图标、轮廓样式、交替布局等基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemWrapper', desc: t('itemWrapper') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n  { name: 'itemSection', desc: t('itemSection') },\n  { name: 'itemHeader', desc: t('itemHeader') },\n  { name: 'itemTitle', desc: t('itemTitle') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'itemRail', desc: t('itemRail') },\n])\n\nconst items = [\n  { title: '2015-09-01', content: 'Create a services' },\n  { title: '2015-09-01 09:12:11', content: 'Solve initial network problems' },\n  { content: 'Technical testing' },\n  { title: '2015-09-01 09:12:11', content: 'Network problems being solved' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Timeline\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-timeline :items=\"items\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with single timeline node relative positioning, margin, padding, font size, finish state, color theme, layout direction and other node basic styles",
+          "descriptionZh": "节点元素，设置单个时间节点的相对定位、外边距、内边距、字体大小、完成状态、颜色主题、布局方向等节点基础样式"
+        },
+        {
+          "key": "itemWrapper",
+          "description": "Item wrapper element with timeline node content wrapping container styles",
+          "descriptionZh": "节点包装元素，设置时间节点内容的包装容器样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Item icon element with node head icon absolute positioning, width/height size, background color, border, border radius, wave animation and other icon styles",
+          "descriptionZh": "节点图标元素，设置节点头部图标的绝对定位、宽高尺寸、背景色、边框、圆角、波纹动画等图标样式"
+        },
+        {
+          "key": "itemHeader",
+          "description": "Item header element with header area layout containing title and rail, alignment, text direction and other styles",
+          "descriptionZh": "节点头部元素，设置包含标题和连接线的头部区域布局、对齐方式、文本方向等样式"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Item title element with node title text font size, line height, color and other text styles",
+          "descriptionZh": "节点标题元素，设置节点标题文字的字体大小、行高、颜色等文本样式"
+        },
+        {
+          "key": "itemSection",
+          "description": "Item section element with section container containing header and content flex layout, wrap, gap and other layout styles",
+          "descriptionZh": "节点区域元素，设置包含头部和内容的区域容器的Flex布局、换行、间距等布局样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Item content element with node detail content relative positioning, top offset, left margin, text color, word break and other content styles",
+          "descriptionZh": "节点内容元素，设置节点详细内容的相对定位、顶部偏移、左侧外边距、文字颜色、词汇换行等内容样式"
+        },
+        {
+          "key": "itemRail",
+          "description": "Item rail element with timeline node connection track line absolute positioning, top offset, left offset, height, border color, width, style and other connection line styles",
+          "descriptionZh": "节点连接线元素，设置连接时间节点的轨道线条的绝对定位、顶部偏移、左侧偏移、高度、边框颜色、宽度、样式等连接线样式"
         }
       ]
     },
@@ -23431,14 +24730,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tooltip by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tooltip 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TooltipProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: TooltipProps['classes'] = {\n  container: 'demo-tooltip-container',\n}\n\nconst stylesObject: TooltipProps['styles'] = {\n  container: {\n    borderRadius: '12px',\n    boxShadow: 'inset 0 0 8px #ccc',\n  },\n}\n\nconst stylesFn: TooltipProps['styles'] = (info) => {\n  if (info?.props?.arrow === false) {\n    return {\n      container: {\n        backgroundColor: 'rgba(53, 71, 125, 0.8)',\n        padding: '12px',\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-tooltip title=\"Object text\" :classes=\"classes\" :styles=\"stylesObject\" :arrow=\"false\">\n      <a-button>Object Style</a-button>\n    </a-tooltip>\n    <a-tooltip title=\"Function text\" :classes=\"classes\" :styles=\"stylesFn\" :arrow=\"false\">\n      <a-button type=\"primary\">\n        Function Style\n      </a-button>\n    </a-tooltip>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element (including arrows, content elements) with absolute positioning, z-index, block display, max width, visibility, transform origin and arrow background color",
+          "descriptionZh": "根元素 (包含箭头、内容元素)，设置绝对定位、层级、块级显示、最大宽度、可见性、变换原点和箭头背景色"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'container', desc: t('container') },\n  { name: 'arrow', desc: t('arrow') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tooltip\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', marginTop: '60px' }\">\n        <a-tooltip\n          open\n          placement=\"top\"\n          title=\"tooltip prompt text\"\n          :auto-adjust-overflow=\"false\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "container",
+          "description": "Content element with min width and height, padding, color, text alignment, background color, border radius, shadow and border styles",
+          "descriptionZh": "内容元素，设置最小宽度高度、内边距、颜色、文本对齐、背景色、圆角、阴影和边框样式"
+        },
+        {
+          "key": "arrow",
+          "description": "Arrow element with width, height, position, color and border styles",
+          "descriptionZh": "箭头元素，设置宽高、位置、颜色和边框样式"
         }
       ]
     },
@@ -23740,14 +25048,68 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tour by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tour 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TourProps, TourStepItem } from 'antdv-next'\nimport { computed, h, shallowRef } from 'vue'\n\nconst ref1 = shallowRef()\nconst ref2 = shallowRef()\nconst ref3 = shallowRef()\nconst open = shallowRef(false)\nconst openFn = shallowRef(false)\n\nconst btnProps = {\n  nextButtonProps: {\n    style: {\n      border: '1px solid #CDC1FF',\n      color: '#CDC1FF',\n    },\n  },\n  prevButtonProps: {\n    style: {\n      backgroundColor: '#CDC1FF',\n      color: '#fff',\n    },\n  },\n}\n\nconst coverNode = h('img', {\n  alt: 'tour.png',\n  src: 'https://user-images.githubusercontent.com/5378891/197385811-55df8480-7ff4-44bd-9d43-a7dade598d70.png',\n})\n\nconst steps: TourStepItem[] = [\n  {\n    title: 'Upload File',\n    description: 'Put your files here.',\n    cover: coverNode,\n    target: ref1,\n    prevButtonProps: {},\n  },\n  {\n    title: 'Save',\n    description: 'Save your changes.',\n    target: ref2,\n  },\n  {\n    title: 'Other Actions',\n    description: 'Click to see other actions.',\n    target: ref3,\n  },\n]\n\nconst stepsWithButtonProps = computed(() => steps.map(step => ({ ...step, ...btnProps })))\n\nconst classes: TourProps['classes'] = {\n  root: 'custom-tour-root',\n  section: 'custom-tour-section',\n}\n\nconst stylesObject: TourProps['styles'] = {\n  mask: {\n    backgroundColor: 'rgba(0, 0, 0, 0.3)',\n  },\n  section: {\n    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',\n    border: '2px solid #4096ff',\n  },\n  cover: {\n    borderRadius: '12px 12px 0 0',\n  },\n}\n\nconst stylesFn: TourProps['styles'] = (info) => {\n  if (info.props.type === 'primary') {\n    return {\n      mask: {\n        backgroundColor: 'rgba(0, 0, 0, 0.3)',\n      },\n      section: {\n        backgroundColor: 'rgba(205, 193, 255, 0.8)',\n        boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',\n      },\n      cover: {\n        borderRadius: '12px 12px 0 0',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-flex gap=\"middle\">\n      <a-button type=\"primary\" @click=\"open = true\">\n        Begin Tour Object\n      </a-button>\n      <a-button type=\"primary\" @click=\"openFn = true\">\n        Begin Tour Function\n      </a-button>\n    </a-flex>\n    <a-divider />\n    <a-tour\n      v-model:open=\"open\"\n      :steps=\"steps\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    />\n    <a-tour\n      v-model:open=\"openFn\"\n      :steps=\"stepsWithButtonProps\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n      type=\"primary\"\n    />\n    <a-space>\n      <a-button ref=\"ref1\" type=\"primary\">\n        Upload\n      </a-button>\n      <a-button ref=\"ref2\">\n        Save\n      </a-button>\n      <a-button ref=\"ref3\" type=\"dashed\">\n        Other Actions\n      </a-button>\n    </a-space>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Tour root container with absolute positioning, z-index control, max width, visibility, arrow background color variable, theme styles and other container styles",
+          "descriptionZh": "引导根容器，设置绝对定位、层级控制、最大宽度、可见性、箭头背景色变量、主题样式等容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'mask', desc: t('mask'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'cover', desc: t('cover'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n  { name: 'indicators', desc: t('indicators'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.3.0' },\n])\n\nconst open = ref(true)\nconst createBtnRef = ref<HTMLButtonElement | null>(null)\n\nconst steps = [\n  {\n    title: 'Hello World!',\n    description: 'Hello World?!',\n    target: () => createBtnRef.value!,\n    mask: true,\n  },\n  {\n    title: 'Save',\n    description: 'Save your changes.',\n    target: () => createBtnRef.value!,\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tour\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div\n        :style=\"{\n          width: '100%',\n          height: '825px',\n          display: 'flex',\n          alignItems: 'center',\n          justifyContent: 'center',\n          position: 'relative',\n          overflow: 'hidden',\n        }\"\n      >\n        <a-button ref=\"createBtnRef\" @click=\"open = true\">\n          Show\n        </a-button>\n        <a-tour\n          v-model:open=\"open\"\n          :z-index=\"1\"\n          :default-current=\"0\"\n          :get-popup-container=\"false\"\n          :steps=\"steps\"\n          :classes=\"classes\"\n        >\n          <template #coverRender=\"{ index }\">\n            <template v-if=\"index === 0\">\n              <img src=\"https://user-images.githubusercontent.com/5378891/197385811-55df8480-7ff4-44bd-9d43-a7dade598d70.png\" alt=\"img\">\n            </template>\n          </template>\n        </a-tour>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "cover",
+          "description": "Card cover area with text center alignment, padding, image width and other image display styles",
+          "descriptionZh": "卡片封面区域，设置文本居中对齐、内边距、图片宽度等图片展示样式"
+        },
+        {
+          "key": "section",
+          "description": "Card main content area with text alignment, border radius, box shadow, relative positioning, background color, border, background clip and other card styles",
+          "descriptionZh": "卡片主要内容区域，设置文本对齐、边框圆角、盒阴影、相对定位、背景色、边框、背景裁剪等卡片样式"
+        },
+        {
+          "key": "footer",
+          "description": "Card bottom action area with padding, text right alignment, border radius, flex layout and other bottom container styles",
+          "descriptionZh": "卡片底部操作区域，设置内边距、文本右对齐、边框圆角、Flex布局等底部容器样式"
+        },
+        {
+          "key": "actions",
+          "description": "Action button group container with left auto margin, button spacing and other button group layout styles",
+          "descriptionZh": "操作按钮组容器，设置左侧自动外边距、按钮间距等按钮组布局样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Single indicator element with width/height size, inline-block display, border radius, background color, right margin, active state and other dot styles",
+          "descriptionZh": "单个指示器元素，设置宽高尺寸、行内块显示、圆角、背景色、右外边距、激活状态等圆点样式"
+        },
+        {
+          "key": "indicators",
+          "description": "Indicator group container with inline-block display and other indicator container styles",
+          "descriptionZh": "指示器组容器，设置行内块显示等指示器容器样式"
+        },
+        {
+          "key": "header",
+          "description": "Card header area with padding, width calculation, word break and other header container styles",
+          "descriptionZh": "卡片头部区域，设置内边距、宽度计算、词汇换行等头部容器样式"
+        },
+        {
+          "key": "title",
+          "description": "Guide title text with font weight and other title text styles",
+          "descriptionZh": "引导标题文字，设置字体粗细等标题文本样式"
+        },
+        {
+          "key": "description",
+          "description": "Guide description text with padding, word wrap and other description text styles",
+          "descriptionZh": "引导描述文字，设置内边距、词汇换行等描述文本样式"
+        },
+        {
+          "key": "mask",
+          "description": "Mask layer element with fixed positioning, full screen coverage, z-index, pointer events, transition animation and other mask styles",
+          "descriptionZh": "遮罩层元素，设置固定定位、全屏覆盖、层级、指针事件、过渡动画等遮罩样式"
+        },
+        {
+          "key": "close",
+          "description": "Close button element with absolute positioning, size, color, hover state and interaction feedback styles",
+          "descriptionZh": "关闭按钮元素，设置绝对定位、尺寸、颜色、悬浮态和交互反馈等关闭按钮样式"
         }
       ]
     },
@@ -24079,14 +25441,73 @@
           "description": "Custom the labels for select all checkboxes.",
           "descriptionZh": "自定义穿梭框全选按钮的文字。",
           "code": "<script setup lang=\"ts\">\nimport type { TransferEmits, TransferProps } from 'antdv-next'\nimport { ref } from 'vue'\n\ninterface RecordType {\n  key: string\n  title: string\n  description: string\n}\n\nconst mockData = Array.from({ length: 10 }).map<RecordType>((_, i) => ({\n  key: i.toString(),\n  title: `content${i + 1}`,\n  description: `description of content${i + 1}`,\n}))\n\nconst oriTargetKeys = mockData.filter(item => Number(item.key) % 3 > 1).map(item => item.key)\n\nconst selectAllLabels: TransferProps['selectAllLabels'] = [\n  'Select All',\n  ({ selectedCount, totalCount }) => `${selectedCount}/${totalCount}`,\n]\n\nconst targetKeys = ref(oriTargetKeys)\n\nconst handleChange: TransferEmits['change'] = (newTargetKeys) => {\n  targetKeys.value = newTargetKeys\n}\n</script>\n\n<template>\n  <a-transfer\n    v-model:target-keys=\"targetKeys\"\n    :data-source=\"mockData\"\n    :render=\"(item: RecordType) => item.title\"\n    :select-all-labels=\"selectAllLabels\"\n    @change=\"handleChange\"\n  />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, transfer container base styles and layout control",
+          "descriptionZh": "根元素，设置flex布局、穿梭框容器的基础样式和布局控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'section', desc: t('section') },\n  { name: 'header', desc: t('header') },\n  { name: 'title', desc: t('title') },\n  { name: 'body', desc: t('body') },\n  { name: 'list', desc: t('list') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'footer', desc: t('footer') },\n  { name: 'actions', desc: t('actions') },\n  { name: 'source', desc: t('source'), version: '1.3.0' },\n  { name: 'target', desc: t('target'), version: '1.3.0' },\n])\n\nconst mockData = Array.from({ length: 20 }).map((_, i) => ({\n  key: i,\n  title: `content ${i + 1}`,\n}))\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Transfer\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-transfer\n        show-search\n        :titles=\"['Source', 'Target']\"\n        :data-source=\"mockData\"\n        :selected-keys=\"[]\"\n        :target-keys=\"[3, 9]\"\n        :render=\"(item: any) => item.title\"\n        :styles=\"{\n          section: { height: '250px', width: '200px' },\n        }\"\n        :classes=\"classes\"\n      >\n        <template #footer>\n          <div :style=\"{ padding: '8px' }\">\n            Custom Footer\n          </div>\n        </template>\n      </a-transfer>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Section element with flex layout, width, height, min height, border, border radius and other single-side transfer container styles",
+          "descriptionZh": "区域元素，设置flex布局、宽度、高度、最小高度、边框、圆角等单侧穿梭框的容器样式"
+        },
+        {
+          "key": "header",
+          "description": "Header element with flex layout, alignment, height, padding, color, background color, bottom border, border radius and other header area styles",
+          "descriptionZh": "头部元素，设置flex布局、对齐方式、高度、内边距、颜色、背景色、下边框、圆角等头部区域的样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text ellipsis, flex ratio, text alignment, auto left margin and other title text layout and styles",
+          "descriptionZh": "标题元素，设置文本省略、flex占比、文本对齐、自动左边距等标题文字的布局和样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with list main area container styles and layout control",
+          "descriptionZh": "内容元素，设置列表主体区域的容器样式和布局控制"
+        },
+        {
+          "key": "list",
+          "description": "List element with list content styles, layout and scroll control",
+          "descriptionZh": "列表元素，设置列表内容的样式、布局和滚动控制"
+        },
+        {
+          "key": "item",
+          "description": "List item element with relative positioning, padding, border, hover state, selected state, disabled state and other list item interaction styles",
+          "descriptionZh": "列表项元素，设置相对定位、内边距、边框、悬停态、选中态、禁用态等列表项的交互样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "List item icon element with checkbox and other icon styles and interaction states",
+          "descriptionZh": "列表项图标元素，设置复选框等图标的样式和交互状态"
+        },
+        {
+          "key": "itemContent",
+          "description": "List item content element with text ellipsis, padding and other list item text content display styles",
+          "descriptionZh": "列表项内容元素，设置文本省略、内边距等列表项文本内容的展示样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with bottom operation area styles and layout",
+          "descriptionZh": "页脚元素，设置底部操作区域的样式和布局"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element with transfer button group styles, layout and interaction states",
+          "descriptionZh": "操作元素，设置穿梭按钮组的样式、布局和交互状态"
+        },
+        {
+          "key": "source",
+          "description": "Source-side (left) overrides nested under the same shared semantic keys (section/header/title/body/list/item/itemIcon/itemContent/footer); only the source list picks them up",
+          "descriptionZh": "源（左侧）区域专属语义，与共享 section/header/title/body/list/item/itemIcon/itemContent/footer 同级，仅覆盖源侧"
+        },
+        {
+          "key": "target",
+          "description": "Target-side (right) overrides nested under the same shared semantic keys (section/header/title/body/list/item/itemIcon/itemContent/footer); only the target list picks them up",
+          "descriptionZh": "目标（右侧）区域专属语义，与共享 section/header/title/body/list/item/itemIcon/itemContent/footer 同级，仅覆盖目标侧"
         }
       ]
     },
@@ -24789,14 +26210,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tree by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tree 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TreeDataNode, TreeProps } from 'antdv-next'\nimport { ref } from 'vue'\n\nconst treeData: TreeDataNode[] = [\n  {\n    title: 'parent 1',\n    key: '0-0',\n    children: [\n      {\n        title: 'parent 1-0',\n        key: '0-0-0',\n        children: [\n          {\n            title: 'leaf',\n            key: '0-0-0-0',\n          },\n          {\n            title: 'leaf',\n            key: '0-0-0-1',\n          },\n        ],\n      },\n      {\n        title: 'parent 1-1',\n        key: '0-0-1',\n        children: [\n          {\n            title: 'leaf',\n            key: '0-0-1-0',\n          },\n        ],\n      },\n    ],\n  },\n]\n\nconst styles: TreeProps['styles'] = {\n  root: { border: '2px solid #d9d9d9' },\n  item: { margin: '2px 0' },\n}\n\nconst stylesFn: TreeProps['styles'] = (info) => {\n  if (!info.props.checkable) {\n    return {\n      root: {\n        border: `2px solid #E5D9F2`,\n        borderRadius: '4px',\n      },\n    }\n  }\n  return {}\n}\n\nconst expandedKeys = ref(['0-0-0', '0-0-1'])\nconst selectedKeys = ref(['0-0-1'])\nconst checkedKeys = ref(['0-0-0', '0-0-1'])\nconst classes = {\n  root: 'root',\n  item: 'item',\n  itemTitle: 'itemTitle',\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-tree\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      auto-expand-parent\n      checkable\n      :styles=\"styles\"\n    />\n    <a-tree\n      v-model:expanded-keys=\"expandedKeys\"\n      v-model:selected-keys=\"selectedKeys\"\n      v-model:checked-keys=\"checkedKeys\"\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      auto-expand-parent\n      :checkable=\"false\"\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with tree control base styles, layout and container control",
+          "descriptionZh": "根元素，设置树形控件的基础样式、布局和容器控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { DownOutlined, FrownFilled, FrownOutlined, MehOutlined, SmileOutlined } from '@antdv-next/icons'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'itemIcon', desc: t('itemIcon'), version: '1.0.0' },\n  { name: 'itemTitle', desc: t('itemTitle'), version: '1.0.0' },\n  { name: 'itemSwitcher', desc: t('itemSwitcher'), version: '1.3.0' },\n])\n\nconst treeData = [\n  {\n    title: 'parent 1',\n    key: '0-0',\n    icon: h(SmileOutlined),\n    children: [\n      { title: 'leaf', key: '0-0-0', icon: h(MehOutlined) },\n      { title: 'leaf', key: '0-0-1', icon: ({ selected }: { selected: boolean }) => selected ? h(FrownFilled) : h(FrownOutlined) },\n    ],\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tree\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-tree\n        show-icon\n        default-expand-all\n        :default-selected-keys=\"['0-0-0']\"\n        :tree-data=\"treeData\"\n        :classes=\"classes\"\n      >\n        <template #switcherIcon>\n          <DownOutlined />\n        </template>\n      </a-tree>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with tree node base styles, drag state, role attributes, indentation, switcher, content wrapper and other node structure",
+          "descriptionZh": "条目元素，设置树节点的基础样式、拖拽状态、角色属性、缩进、切换器、内容包装器等节点结构"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Title element with tree node title text display styles and text content",
+          "descriptionZh": "标题元素，设置树节点标题文字的显示样式和文本内容"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Icon element with tree node icon styles, size and state display",
+          "descriptionZh": "图标元素，设置树节点图标的样式、尺寸和状态显示"
+        },
+        {
+          "key": "itemSwitcher",
+          "description": "Switcher element with tree node expand/collapse button styles and background",
+          "descriptionZh": "切换器元素，设置树节点展开/收起按钮的样式和背景"
         }
       ]
     },
@@ -25379,14 +26819,73 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of TreeSelect by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 TreeSelect 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TreeSelectProps } from 'antdv-next'\n\nconst classes: TreeSelectProps['classes'] = {\n  root: 'custom-tree-select',\n}\n\nconst stylesObject: TreeSelectProps['styles'] = {\n  input: {\n    fontSize: 16,\n  },\n  suffix: {\n    color: '#1890ff',\n  },\n  popup: {\n    root: {\n      border: '1px solid #1890ff',\n    },\n  },\n}\n\nconst stylesFn: TreeSelectProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      suffix: {\n        color: '#722ed1',\n      },\n      popup: {\n        item: {\n          color: '#722ed1',\n        },\n      },\n    }\n  }\n  return {}\n}\n\nconst treeData: TreeSelectProps['treeData'] = [\n  {\n    value: 'parent 1',\n    title: 'parent 1',\n    children: [\n      {\n        value: 'parent 1-0',\n        title: 'parent 1-0',\n        children: [\n          {\n            value: 'leaf1',\n            title: 'leaf1',\n          },\n          {\n            value: 'leaf2',\n            title: 'leaf2',\n          },\n        ],\n      },\n      {\n        value: 'parent 1-1',\n        title: 'parent 1-1',\n        children: [\n          {\n            value: 'leaf3',\n            title: 'leaf3',\n          },\n        ],\n      },\n    ],\n  },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-tree-select\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      placeholder=\"Object\"\n    />\n    <a-tree-select\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      placeholder=\"Function\"\n      size=\"middle\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with tree selector base styles, border, border radius container styles",
+          "descriptionZh": "根元素，设置树选择器的基础样式、边框、圆角容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst mode = ref<'single' | 'multiple'>('single')\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => {\n  const base = [\n    { name: 'root', desc: t('root') },\n    { name: 'prefix', desc: t('prefix') },\n    { name: 'placeholder', desc: t('placeholder') },\n  ]\n\n  if (mode.value === 'multiple') {\n    base.push(\n      ...[\n        { name: 'content', desc: t('content') },\n        { name: 'item', desc: t('item') },\n        { name: 'itemContent', desc: t('itemContent') },\n        { name: 'itemRemove', desc: t('itemRemove') },\n      ],\n    )\n  }\n\n  base.push(\n    ...[\n      { name: 'input', desc: t('input') },\n      { name: 'suffix', desc: t('suffix') },\n      { name: 'popup.root', desc: t('popup.root') },\n      { name: 'popup.item', desc: t('popup.item') },\n      { name: 'popup.itemTitle', desc: t('popup.itemTitle') },\n      { name: 'popup.itemSwitcher', desc: t('popup.itemSwitcher'), version: '1.3.0' },\n    ],\n  )\n\n  return base\n})\n\nconst treeValue = ref<string | string[] | undefined>(undefined)\nfunction handleResetValue(newMode: string | number) {\n  if (newMode === 'multiple') {\n    treeValue.value = ['aojunhao123']\n  }\n  else {\n    treeValue.value = undefined\n  }\n}\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst treeData = [\n  {\n    value: 'contributors',\n    title: 'contributors',\n    children: [\n      { value: 'aojunhao123', title: 'aojunhao123' },\n      { value: 'thinkasany', title: 'thinkasany' },\n      { value: 'meet-student', title: 'meet-student' },\n    ],\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"TreeSelect\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <div :style=\"{ display: 'flex', justifyContent: 'center', marginBottom: '12px' }\">\n          <a-segmented v-model:value=\"mode\" :options=\"['single', 'multiple']\" @change=\"handleResetValue\" />\n        </div>\n\n        <a-tree-select\n          v-model:value=\"treeValue\"\n          prefix=\"prefix\"\n          :style=\"{ width: '300px' }\"\n          :tree-data=\"treeData\"\n          tree-default-expand-all\n          :multiple=\"mode === 'multiple'\"\n          show-search\n          max-tag-count=\"responsive\"\n          placeholder=\"Please select\"\n          allow-clear\n          open\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with prefix content layout and styles",
+          "descriptionZh": "前缀元素，设置前缀内容的布局和样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "input",
+          "description": "Input element with text input, search, selected value display and other input core interaction styles",
+          "descriptionZh": "输入框元素，设置文本输入、搜索、选择值显示等输入框的核心交互样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with suffix content, clear button, dropdown arrow and other suffix area styles",
+          "descriptionZh": "后缀元素，设置后缀内容、清除按钮、下拉箭头等后缀区域的样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with dropdown tree selection panel positioning, z-index, background, border, shadow and other popup layer styles",
+          "descriptionZh": "弹出菜单元素，设置下拉树形选择面板的定位、层级、背景、边框、阴影等弹层样式"
+        },
+        {
+          "key": "popup.item",
+          "description": "Popup item element with tree node option styles, hover state, selected state and other interaction states",
+          "descriptionZh": "弹出菜单条目元素，设置树节点选项的样式、悬停态、选中态等交互状态"
+        },
+        {
+          "key": "popup.itemTitle",
+          "description": "Popup title element with tree node title text display styles",
+          "descriptionZh": "弹出菜单标题元素，设置树节点标题文字的显示样式"
+        },
+        {
+          "key": "popup.itemSwitcher",
+          "description": "Popup switcher element with tree node expand/collapse button styles and background",
+          "descriptionZh": "弹出菜单切换器元素，设置树节点展开/收起按钮的样式和背景"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "item",
+          "description": "Multiple selection item element with border, background, padding, and margin styles",
+          "descriptionZh": "多选项元素，包含边框、背景、内边距、外边距样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Multiple selection item content area with text ellipsis styles",
+          "descriptionZh": "多选项内容区域，包含文字的省略样式"
+        },
+        {
+          "key": "itemRemove",
+          "description": "Multiple selection item remove button with font-related styles",
+          "descriptionZh": "多选项移除按钮，包含字体相关样式"
         }
       ]
     },
@@ -25898,14 +27397,28 @@
           "description": "Add suffix ellipsis support.",
           "descriptionZh": "添加后缀的省略。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst rows = ref(1)\n\nconst article = `To be, or not to be, that is the question: Whether it is nobler in the mind to suffer. The slings and arrows of outrageous fortune Or to take arms against a sea of troubles, And by opposing end them? To die: to sleep; No more; and by a sleep to say we end The heart-ache and the thousand natural shocks That flesh is heir to, 'tis a consummation Devoutly to be wish'd. To die, to sleep To sleep- perchance to dream: ay, there's the rub! For in that sleep of death what dreams may come When we have shuffled off this mortal coil, Must give us pause. There 's the respect That makes calamity of so long life`\n\nfunction onEllipsis(ellipsis: boolean) {\n  console.log('Ellipsis changed:', ellipsis)\n}\n</script>\n\n<template>\n  <div>\n    <a-slider v-model:value=\"rows\" :min=\"1\" :max=\"10\" />\n    <a-typography-paragraph\n      :ellipsis=\"{\n        rows,\n        expandable: true,\n        suffix: '--William Shakespeare',\n        onEllipsis,\n      }\"\n      :title=\"`${article}--William Shakespeare`\"\n    >\n      {{ article }}\n    </a-typography-paragraph>\n  </div>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with base typography styles, layout, and positioning",
+          "descriptionZh": "根元素，包含排版基础样式、布局和定位"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst editing = ref(false)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.3.0' },\n  { name: 'actions', desc: t('actions'), version: '1.3.0' },\n  { name: 'action', desc: t('action'), version: '1.3.0' },\n  { name: 'textarea', desc: t('textarea'), version: '1.3.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Typography\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex\n        vertical\n        gap=\"middle\"\n        align=\"start\"\n        :style=\"{ width: '100%', alignSelf: 'flex-start' }\"\n      >\n        <a-switch\n          v-model:checked=\"editing\"\n          checked-children=\"Editing\"\n          un-checked-children=\"Editing\"\n        />\n        <a-typography-paragraph\n          copyable\n          :editable=\"{ editing }\"\n          :ellipsis=\"{ rows: 2, expandable: true }\"\n          :style=\"{ width: '100%' }\"\n          :classes=\"classes\"\n        >\n          Ant Design is a design language for background applications, refined by Ant UED Team.\n          It aims to uniform the user interface specs for internal background projects, lower the\n          unnecessary cost of design differences and implementation and liberate the resources of\n          design and front-end development.\n        </a-typography-paragraph>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "actions",
+          "description": "Actions element with layout and spacing styles for copy, edit, expand/collapse buttons",
+          "descriptionZh": "操作区域元素，包含复制、编辑、展开/收起等操作按钮的布局和间距样式"
+        },
+        {
+          "key": "action",
+          "description": "Individual action button element including copy, edit, expand, collapse button styles like padding, border radius, colors, etc.",
+          "descriptionZh": "单个操作按钮元素，包括复制、编辑、展开、收起按钮的样式，如内边距、圆角、颜色等"
+        },
+        {
+          "key": "textarea",
+          "description": "TextArea element in editable mode, used to customize className and inline styles for the edit input",
+          "descriptionZh": "可编辑模式下的 TextArea 元素样式，用于自定义编辑输入框的类名和内联样式"
         }
       ]
     },
@@ -26363,14 +27876,33 @@
           "description": "Component Token Debug.",
           "descriptionZh": "Component Token Debug.",
           "code": "<script setup lang=\"ts\">\nimport type { UploadEmits, UploadFile } from 'antdv-next'\nimport { UploadOutlined } from '@antdv-next/icons'\n\nconst defaultFileList: UploadFile[] = [\n  {\n    uid: '1',\n    name: 'xxx.png',\n    status: 'uploading',\n    url: 'http://www.baidu.com/xxx.png',\n    percent: 33,\n  },\n  {\n    uid: '2',\n    name: 'yyy.png',\n    status: 'done',\n    url: 'http://www.baidu.com/yyy.png',\n  },\n  {\n    uid: '3',\n    name: 'zzz.png',\n    status: 'error',\n    response: 'Server Error 500',\n    url: 'http://www.baidu.com/zzz.png',\n  },\n]\n\nconst handleChange: UploadEmits['change'] = ({ file, fileList }) => {\n  if (file.status !== 'uploading') {\n    console.log(file, fileList)\n  }\n}\n</script>\n\n<template>\n  <a-config-provider\n    :theme=\"{\n      components: {\n        Upload: {\n          actionsColor: 'yellow',\n        },\n      },\n    }\"\n  >\n    <a-upload\n      action=\"https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload\"\n      :default-file-list=\"defaultFileList\"\n      @change=\"handleChange\"\n    >\n      <a-button>\n        <template #icon>\n          <UploadOutlined />\n        </template>\n        Upload\n      </a-button>\n    </a-upload>\n  </a-config-provider>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "cropModalTitle",
+          "description": "Edit image",
+          "descriptionZh": "编辑图片"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { UploadOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'list', desc: t('list'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n])\n\nconst defaultFileList = [\n  { uid: '1', name: 'xxx.png', status: 'uploading', url: 'http://www.baidu.com/xxx.png', percent: 33 },\n  { uid: '2', name: 'yyy.png', status: 'done', url: 'http://www.baidu.com/yyy.png' },\n  { uid: '3', name: 'zzz.png', status: 'error', response: 'Server Error 500', url: 'http://www.baidu.com/zzz.png' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Upload\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-upload\n        action=\"https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload\"\n        :default-file-list=\"defaultFileList\"\n        :classes=\"classes\"\n      >\n        <a-button>\n          <template #icon>\n            <UploadOutlined />\n          </template>\n          Upload\n        </a-button>\n      </a-upload>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "cropResetText",
+          "description": "Reset",
+          "descriptionZh": "重置"
+        },
+        {
+          "key": "root",
+          "description": "Root container element with layout styles, disabled text color, user-select control, cursor styles and other basic styles",
+          "descriptionZh": "根元素容器，包含布局样式、禁用状态文字颜色、用户选择控制、鼠标样式等基础样式"
+        },
+        {
+          "key": "list",
+          "description": "File list container with layout arrangement, transition animations, spacing control and other styles",
+          "descriptionZh": "文件列表容器，包含布局排列、过渡动画、间距控制等样式"
+        },
+        {
+          "key": "item",
+          "description": "File item element with padding, background color, border styles, hover effects, status colors, transition animations and other styles",
+          "descriptionZh": "文件项元素，包含内边距、背景色、边框样式、悬停效果、状态颜色、过渡动画等样式"
         }
       ]
     },
@@ -26517,7 +28049,8 @@
           "descriptionZh": "在 Modal 与 Drawer 中使用。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst showModal = shallowRef(false)\nconst showDrawer = shallowRef(false)\nconst showDrawer2 = shallowRef(false)\n\nconst placeholderStyle = {\n  height: '300px',\n  display: 'flex',\n  justifyContent: 'center',\n  alignItems: 'center',\n  backgroundColor: 'rgba(150, 150, 150, 0.2)',\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-button type=\"primary\" @click=\"showModal = true\">\n      Show in Modal\n    </a-button>\n    <a-button type=\"primary\" @click=\"showDrawer = true\">\n      Show in Drawer\n    </a-button>\n    <a-button type=\"primary\" @click=\"showDrawer2 = true\">\n      Not Show in Drawer\n    </a-button>\n  </a-flex>\n  <a-watermark content=\"Antdv Next\">\n    <a-modal\n      v-model:open=\"showModal\"\n      destroy-on-hidden\n      title=\"Modal\"\n      @ok=\"showModal = false\"\n      @cancel=\"showModal = false\"\n    >\n      <div :style=\"placeholderStyle\">\n        A mock height\n      </div>\n    </a-modal>\n    <a-drawer\n      v-model:open=\"showDrawer\"\n      destroy-on-hidden\n      title=\"Drawer\"\n      @close=\"showDrawer = false\"\n    >\n      <div :style=\"placeholderStyle\">\n        A mock height\n      </div>\n    </a-drawer>\n  </a-watermark>\n  <a-watermark content=\"Antdv Next\" :inherit=\"false\">\n    <a-drawer\n      v-model:open=\"showDrawer2\"\n      destroy-on-hidden\n      title=\"Drawer\"\n      @close=\"showDrawer2 = false\"\n    >\n      <div :style=\"placeholderStyle\">\n        A mock height\n      </div>\n    </a-drawer>\n  </a-watermark>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     }
   ],
   "changelog": [

--- a/data/v1.json
+++ b/data/v1.json
@@ -1840,7 +1840,8 @@
           "descriptionZh": "用 `target` 设置 `Affix` 需要监听其滚动事件的元素，默认为 `window`。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst container = shallowRef()\n</script>\n\n<template>\n  <div ref=\"container\" style=\"width: 100%;height: 100px;overflow: auto;box-shadow: 0 0 0 1px #1677ff;scrollbar-width: thin;scrollbar-gutter: stable\">\n    <div style=\"width: 100%;height: 1000px\">\n      <a-affix :target=\"() => container\">\n        <a-button type=\"primary\">\n          Fixed at the top of container\n        </a-button>\n      </a-affix>\n    </div>\n  </div>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Alert",
@@ -2144,14 +2145,43 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Alert by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Alert 的 [语义化结构](#semantic-dom) 样式。",
           "code": "<script setup lang=\"ts\">\nimport type { AlertProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: AlertProps['classes'] = {\n  root: 'demo-alert-root',\n}\n\nconst stylesObject: AlertProps['styles'] = {\n  icon: {\n    fontSize: '18px',\n  },\n  section: {\n    fontWeight: 500,\n  },\n}\n\nconst stylesFn: AlertProps['styles'] = (info) => {\n  if (info?.props?.type === 'success') {\n    return {\n      root: {\n        backgroundColor: 'rgba(82, 196, 26, 0.1)',\n        borderColor: '#b7eb8f',\n      },\n      icon: {\n        color: '#52c41a',\n      },\n    }\n  }\n  if (info?.props?.type === 'warning') {\n    return {\n      root: {\n        backgroundColor: 'rgba(250, 173, 20, 0.1)',\n        borderColor: '#ffe58f',\n      },\n      icon: {\n        color: '#faad14',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"small\">\n    <a-alert\n      title=\"Object styles\"\n      type=\"info\"\n      show-icon\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n    >\n      <template #action>\n        <a-button size=\"small\">\n          Action\n        </a-button>\n      </template>\n    </a-alert>\n    <a-alert\n      title=\"Function styles\"\n      type=\"success\"\n      show-icon\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with border, background, padding, border-radius, and positioning styles for the alert container",
+          "descriptionZh": "根元素，包含边框、背景色、内边距、圆角、位置布局等警告提示框的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Alert\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-alert\n        closable\n        title=\"Info Text\"\n        show-icon\n        description=\"Info Description Info Description Info Description Info Description\"\n        type=\"info\"\n        :classes=\"classes\"\n      >\n        <template #action>\n          <a-flex vertical gap=\"small\" :style=\"{ minWidth: '80px' }\">\n            <a-button size=\"small\" type=\"primary\" block>\n              Accept\n            </a-button>\n            <a-button size=\"small\" danger ghost block>\n              Decline\n            </a-button>\n          </a-flex>\n        </template>\n      </a-alert>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Content element with flex layout controlling content area typography and minimum width",
+          "descriptionZh": "内容元素，采用 flex 布局控制内容区域的排版和最小宽度"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with color, line-height, and margin styles, supporting different status icon types",
+          "descriptionZh": "图标元素，包含图标的颜色、行高、外边距等样式，支持不同类型的状态图标"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text color and font styling for the alert title",
+          "descriptionZh": "标题元素，包含标题文字的颜色、字体等样式"
+        },
+        {
+          "key": "description",
+          "description": "Description element with font-size and line-height styles for additional content",
+          "descriptionZh": "描述元素，包含描述文字的字体大小、行高等排版样式"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element with layout and spacing styles for action buttons",
+          "descriptionZh": "操作组元素，包含操作按钮的布局和间距样式"
+        },
+        {
+          "key": "close",
+          "description": "Close button element with basic button styling",
+          "descriptionZh": "关闭按钮元素，包含按钮的基础样式"
         }
       ]
     },
@@ -2389,14 +2419,28 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Anchor by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "您可以通过 `classes` 和 `styles` 传入对象/函数可以自定义 Anchor 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { AnchorProps } from 'antdv-next'\n\nconst classesObject: AnchorProps['classes'] = {\n  root: 'demo-anchor-root',\n  item: 'demo-anchor-item',\n  itemTitle: 'demo-anchor-title',\n  indicator: 'demo-anchor-indicator',\n}\n\nconst stylesFn: AnchorProps['styles'] = (info) => {\n  if (info.props.direction === 'vertical') {\n    return {\n      root: {\n        backgroundColor: 'rgba(255,251,230,0.5)',\n        height: '100vh',\n      },\n    }\n  }\n  return {}\n}\n\nconst items: NonNullable<AnchorProps['items']> = [\n  {\n    key: 'part-1',\n    href: '#part-1',\n    title: 'Part 1',\n  },\n  {\n    key: 'part-2',\n    href: '#part-2',\n    title: 'Part 2',\n  },\n  {\n    key: 'part-3',\n    href: '#part-3',\n    title: 'Part 3',\n  },\n]\n</script>\n\n<template>\n  <a-row>\n    <a-col :span=\"16\">\n      <div id=\"part-1\" style=\"height: 100vh; background: rgba(255, 0, 0, 0.08)\" />\n      <div id=\"part-2\" style=\"height: 100vh; background: rgba(0, 255, 0, 0.08)\" />\n      <div id=\"part-3\" style=\"height: 100vh; background: rgba(0, 0, 255, 0.08)\" />\n    </a-col>\n    <a-col :span=\"8\">\n      <a-anchor replace :items=\"items\" :styles=\"stylesFn\" :classes=\"classesObject\" />\n    </a-col>\n  </a-row>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with layout positioning, padding, margin, background color and other basic styles",
+          "descriptionZh": "根元素，包含布局定位、内边距、边距、背景色等基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'itemTitle', desc: t('itemTitle'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n])\n\nconst items = [\n  {\n    key: 'api',\n    href: '#api',\n    title: 'API',\n    children: [\n      { key: '4', href: '#anchor-props', title: 'Anchor Props' },\n      { key: '5', href: '#link-props', title: 'Link Props' },\n    ],\n  },\n  { key: '1', href: '#anchor-demo-basic', title: 'Basic demo' },\n  { key: '2', href: '#anchor-demo-static', title: 'Static demo' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Anchor\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-anchor :affix=\"false\" :items=\"items\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Link item element with padding, text color, hover states, transition animations and other styles",
+          "descriptionZh": "链接项元素，包含内边距、文字颜色、悬停状态、过渡动画等样式"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Title text element with font styles, color changes, text decoration, transition effects and other styles",
+          "descriptionZh": "标题文字元素，包含字体样式、颜色变化、文本装饰、过渡效果等样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element with width, height, background color, position changes, transition animations and other styles",
+          "descriptionZh": "指示器元素，包含宽度、高度、背景色、位置变化、过渡动画等样式"
         }
       ]
     },
@@ -2459,7 +2503,8 @@
           "descriptionZh": "对 `message`、`notification` 进行配置。。",
           "code": "<script setup lang=\"ts\">\nimport MyPage2 from './myPage2.vue'\n</script>\n\n<template>\n  <a-app :message=\"{ maxCount: 1 }\" :notification=\"{ placement: 'bottomLeft' }\">\n    <MyPage2 />\n  </a-app>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "AutoComplete",
@@ -2800,14 +2845,53 @@
           "description": "Disabled text colour inside a Form, debug. Checks that the input text uses the disabled\ncolour both when the Form is disabled and when the component itself is.",
           "descriptionZh": "禁用文字颜色在 Form 中 Debug。校验 `Form disabled` 与组件自身 `disabled` 两种来源下，\n输入框文字都使用禁用色。",
           "code": "<script setup lang=\"ts\">\nconst options = [{ value: 'Disabled Value' }]\n</script>\n\n<template>\n  <a-flex vertical :gap=\"12\" :style=\"{ width: '240px' }\">\n    <a-form disabled>\n      <a-form-item label=\"Form disabled\" :style=\"{ marginBottom: 0 }\">\n        <a-auto-complete value=\"Disabled Value\" :options=\"options\" />\n      </a-form-item>\n    </a-form>\n    <a-auto-complete disabled value=\"Disabled Value\" :options=\"options\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, cursor styles, transitions, border and other basic selector container styles",
+          "descriptionZh": "根元素，包含相对定位、行内 flex 布局、光标样式、过渡动画、边框等选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'placeholder', desc: t('placeholder') },\n  { name: 'content', desc: t('content') },\n  { name: 'clear', desc: t('clear') },\n  { name: 'popup.root', desc: t('popup.root') },\n  { name: 'popup.list', desc: t('popup.list') },\n  { name: 'popup.listItem', desc: t('popup.listItem') },\n])\n\nconst options = ref([\n  { value: 'aojunhao123', label: 'aojunhao123' },\n  { value: 'thinkasany', label: 'thinkasany' },\n  { value: 'meet-student', label: 'meet-student' },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"AutoComplete\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <a-auto-complete\n          prefix=\"prefix\"\n          :style=\"{ width: '200px' }\"\n          :options=\"options\"\n          placeholder=\"input here\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with layout and styling for prefix content",
+          "descriptionZh": "前缀元素，包含前缀内容的布局和样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with search input styling, cursor control, font inheritance and other search-related styles. Remove border styles",
+          "descriptionZh": "输入框元素，包含搜索输入框的样式、光标控制、字体继承等搜索相关样式，去除了边框样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "clear",
+          "description": "Clear button element with layout, styling and interactive effects for clear button",
+          "descriptionZh": "清除按钮元素，包含清除按钮的布局、样式和交互效果"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with popup layer positioning, z-index, background, border, box-shadow and other popup container styles",
+          "descriptionZh": "弹出菜单元素，包含弹出层的定位、层级、背景、边框、阴影等弹出容器样式"
+        },
+        {
+          "key": "popup.list",
+          "description": "Popup list element with option list layout, scrolling, max-height and other list container styles",
+          "descriptionZh": "弹出菜单列表元素，包含选项列表的布局、滚动、最大高度等列表容器样式"
+        },
+        {
+          "key": "popup.listItem",
+          "description": "Popup item element with option item padding, hover effects, selected states, disabled states and other option interactive styles",
+          "descriptionZh": "弹出菜单条目元素，包含选项项的内边距、悬浮效果、选中状态、禁用状态等选项交互样式"
         }
       ]
     },
@@ -3104,7 +3188,8 @@
           "descriptionZh": "头像大小可以根据屏幕大小自动调整。",
           "code": "<script setup lang=\"ts\">\nimport { AntDesignOutlined } from '@antdv-next/icons'\n</script>\n\n<template>\n  <a-avatar\n    :size=\"{ xs: 24, sm: 32, md: 40, lg: 64, xl: 80, xxl: 100 }\"\n  >\n    <template #icon>\n      <AntDesignOutlined />\n    </template>\n  </a-avatar>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Badge",
@@ -3381,22 +3466,33 @@
           "description": "The badge will display `title` when hovered over, instead of `count`.",
           "descriptionZh": "设置鼠标放在状态点上时显示的文字。",
           "code": "<script setup lang=\"ts\">\n</script>\n\n<template>\n  <a-space size=\"large\">\n    <a-badge :count=\"5\" title=\"Custom hover text\">\n      <a-avatar shape=\"square\" size=\"large\" />\n    </a-badge>\n    <a-badge :count=\"-5\" title=\"Negative\">\n      <a-avatar shape=\"square\" size=\"large\" />\n    </a-badge>\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-block display, and fit-content width for basic layout",
+          "descriptionZh": "根元素，包含相对定位、行内块布局、适应内容宽度等基础布局样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Badge\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-badge :count=\"5\" :classes=\"classes\">\n        <a-avatar shape=\"square\" size=\"large\" />\n      </a-badge>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "indicator",
+          "description": "Indicator element with positioning, z-index, dimensions, colors, fonts, text alignment, background, border-radius, box-shadow, and transition animations for complete badge styling",
+          "descriptionZh": "指示器元素，包含定位、层级、尺寸、颜色、字体、文本对齐、背景、圆角、阴影、过渡动画等完整的徽标样式"
         },
         {
-          "name": "_semantic_ribbon",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('ribbonRoot'), version: '1.0.0' },\n  { name: 'indicator', desc: t('ribbonIndicator'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <div style=\"display: flex; flex-direction: column; gap: 24px;\">\n    <SemanticPreview\n      component-name=\"Badge\"\n      :semantics=\"semantics\"\n    >\n      <template #default=\"{ classes }\">\n        <div style=\"width: 100%;\">\n          <a-badge-ribbon text=\"Hippies\" color=\"magenta\" :classes=\"classes\">\n            <a-card title=\"Pushes open the window\" size=\"small\">\n              and raises the spyglass.\n            </a-card>\n          </a-badge-ribbon>\n        </div>\n      </template>\n    </SemanticPreview>\n  </div>\n</template>"
+          "key": "ribbonRoot",
+          "description": "Root element, set relative positioning and wrapper container styles",
+          "descriptionZh": "根元素，设置相对定位和包装容器样式"
+        },
+        {
+          "key": "ribbonIndicator",
+          "description": "Indicator element, set absolute positioning, padding, background color, border radius and ribbon styles",
+          "descriptionZh": "指示器元素，设置绝对定位、内边距、背景色、圆角和缎带样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element, set text color and ribbon content display styles",
+          "descriptionZh": "文本元素，设置文本颜色和缎带内容显示样式"
         }
       ]
     },
@@ -3560,7 +3656,8 @@
           "descriptionZh": "通过 `ConfigProvider` 的 theme.components 可以覆盖 BorderBeam 的 `lineWidth` token，从而调整流光的线宽。",
           "code": "<script setup lang=\"ts\">\nconst customTheme = {\n  components: {\n    BorderBeam: { lineWidth: 3 },\n  },\n}\n</script>\n\n<template>\n  <a-flex :gap=\"24\" wrap>\n    <div :style=\"{ width: '320px' }\">\n      <a-border-beam>\n        <a-card title=\"Default line width\">\n          <a-typography-text type=\"secondary\">\n            Uses the default global lineWidth token from the current theme.\n          </a-typography-text>\n        </a-card>\n      </a-border-beam>\n    </div>\n    <a-config-provider :theme=\"customTheme\">\n      <div :style=\"{ width: '320px' }\">\n        <a-border-beam>\n          <a-card title=\"Custom line width\">\n            <a-typography-text type=\"secondary\">\n              Override lineWidth from theme.token.\n            </a-typography-text>\n          </a-card>\n        </a-border-beam>\n      </div>\n    </a-config-provider>\n  </a-flex>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Breadcrumb",
@@ -3748,14 +3845,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Breadcrumb by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Breadcrumb 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { BreadcrumbProps } from 'antdv-next'\n\nconst classesObject = {\n  root: 'demo-breadcrumb-root',\n  item: 'demo-breadcrumb-item',\n  separator: 'demo-breadcrumb-separator',\n}\n\nconst stylesObject: BreadcrumbProps['styles'] = {\n  root: { border: '1px solid #f0f0f0', padding: '8px', borderRadius: '4px' },\n  item: { color: '#1890ff' },\n  separator: { color: 'rgba(0, 0, 0, 0.45)' },\n}\n\nconst stylesFn: BreadcrumbProps['styles'] = (info) => {\n  const items = info.props.items || []\n  if (items.length > 2) {\n    return {\n      root: { border: '1px solid #F5EFFF', padding: '8px', borderRadius: '4px' },\n      item: { color: '#8F87F1' },\n    }\n  }\n  return {}\n}\n\nconst items = [\n  { title: 'Antdv Next' },\n  { title: 'Component' },\n  { title: 'Breadcrumb' },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-breadcrumb\n      :classes=\"classesObject\"\n      :items=\"items.slice(0, 2)\"\n      :styles=\"stylesObject\"\n      aria-label=\"Breadcrumb with Object\"\n    />\n    <a-breadcrumb\n      :classes=\"classesObject\"\n      :items=\"items\"\n      :styles=\"stylesFn\"\n      aria-label=\"Breadcrumb with Function\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with text color, font size, icon size and other basic styles, using flex layout with ordered list",
+          "descriptionZh": "根元素，包含文字颜色、字体大小、图标尺寸等基础样式，内部使用 flex 布局的有序列表"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { HomeOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'separator', desc: t('separator'), version: '1.0.0' },\n])\n\nconst items = [\n  { href: '', title: h(HomeOutlined) },\n  { href: '', title: [h(UserOutlined), h('span', 'Application List')] },\n  { title: 'Application' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Breadcrumb\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-breadcrumb :items=\"items\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with text color, link color transitions, hover effects, padding, border-radius, height, and margin styles",
+          "descriptionZh": "Item 元素，包含文字颜色、链接的颜色变化、悬浮效果、内边距、圆角、高度、外边距等样式"
+        },
+        {
+          "key": "separator",
+          "description": "Separator element with margin and color styles for the divider",
+          "descriptionZh": "分隔符元素，包含分隔符的外边距和颜色样式"
         }
       ]
     },
@@ -4276,20 +4382,29 @@
           "code": "<script setup lang=\"ts\">\nimport type { ButtonProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: ButtonProps['classes'] = {\n  root: 'demo-button-root',\n  content: 'demo-button-content',\n}\n\nconst stylesObject: ButtonProps['styles'] = {\n  root: {\n    boxShadow: '0 1px 2px 0 rgba(0,0,0,0.05)',\n  },\n}\n\nconst stylesFn: ButtonProps['styles'] = (info) => {\n  if (info?.props?.type === 'primary') {\n    return {\n      root: {\n        backgroundColor: '#171717',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"small\">\n    <a-button type=\"default\" :classes=\"classes\" :styles=\"stylesObject\">\n      Object\n    </a-button>\n    <a-button type=\"primary\" :classes=\"classes\" :styles=\"stylesFn\">\n      Function\n    </a-button>\n  </a-flex>\n</template>"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AntDesignOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Button\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-button type=\"primary\" :classes=\"classes\">\n        <template #icon>\n          <AntDesignOutlined />\n        </template>\n        Antdv Next\n      </a-button>\n    </template>\n  </SemanticPreview>\n</template>"
-        },
-        {
           "name": "chinese-space",
           "title": "",
           "titleZh": "移除两个汉字之间的空格",
           "description": "We add a space between two Chinese characters by default, which can be removed by setting `autoInsertSpace` to `false`.",
           "descriptionZh": "我们默认在两个汉字之间添加空格，可以通过设置 `autoInsertSpace` 为 `false` 关闭。",
           "code": "<template>\n  <a-flex gap=\"small\" wrap>\n    <a-button type=\"primary\" :auto-insert-space=\"false\">\n      确定\n    </a-button>\n    <a-button type=\"primary\" auto-insert-space>\n      确定\n    </a-button>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with comprehensive button styling including border, background, padding, border-radius, box-shadow, transitions, cursor, font-weight, alignment, and layout properties",
+          "descriptionZh": "根元素，包含边框样式、背景色、内边距、圆角、阴影效果、过渡动画、光标样式、文字权重、对齐方式等完整的按钮外观样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element that wraps button text with typography styles including nowrap, text-align center, and Chinese character spacing optimization",
+          "descriptionZh": "内容元素，包装按钮文本内容，控制文本的不换行显示、居中对齐、中文字符间距优化等文本排版样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with font-size, color inheritance, and SVG style reset for proper icon display",
+          "descriptionZh": "图标元素，包含图标的字体大小、颜色继承、SVG 样式重置等图标显示相关样式"
         }
       ]
     },
@@ -4577,14 +4692,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Calendar by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Calendar 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CalendarProps } from 'antdv-next'\nimport type { Dayjs } from 'dayjs'\n\nconst classes = {\n  root: 'custom-calendar-root',\n}\n\nconst stylesObject: CalendarProps<Dayjs>['styles'] = {\n  root: {\n    borderRadius: '8px',\n    width: '600px',\n  },\n}\n\nconst stylesFunction: CalendarProps<Dayjs>['styles'] = (info) => {\n  if (info.props.fullscreen) {\n    return {\n      root: {\n        border: '2px solid #BDE3C3',\n        borderRadius: '10px',\n        backgroundColor: 'rgba(189,227,195, 0.3)',\n      },\n    } satisfies CalendarProps<Dayjs>['styles']\n  }\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-calendar :fullscreen=\"false\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-calendar :classes=\"classes\" :styles=\"stylesFunction\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element containing background, border, border-radius and overall layout structure of the calendar component",
+          "descriptionZh": "根元素，包含日历组件的背景色、边框、圆角等基础样式和整体布局结构"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'itemContent', desc: t('itemContent'), version: '1.3.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Calendar\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-calendar :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with layout and style control for year selector, month selector and mode switcher",
+          "descriptionZh": "头部元素，包含年份选择器、月份选择器、模式切换器的布局和样式控制"
+        },
+        {
+          "key": "body",
+          "description": "Body element with padding and layout control for the calendar table that contains the calendar grid",
+          "descriptionZh": "主体元素，包含日历表格的内边距、布局控制等样式，用于容纳日历网格"
+        },
+        {
+          "key": "content",
+          "description": "Content element with width, height and table styling control for the calendar table",
+          "descriptionZh": "内容元素，包含日历表格的宽度、高度等尺寸控制和表格样式"
+        },
+        {
+          "key": "item",
+          "description": "Item element with background, border, hover state, selected state and other interactive styles for calendar cells",
+          "descriptionZh": "条目元素，包含日历单元格的背景色、边框、悬停态、选中态等交互样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Item content element with layout and styles for the calendar cell content area",
+          "descriptionZh": "条目内容元素，包含日历单元格内容区域的布局和样式"
         }
       ]
     },
@@ -5070,14 +5209,43 @@
           "description": "Debug vertical alignment of button icons inside Card extra (#57727, #57896, #58428).",
           "descriptionZh": "调试 Card extra 中按钮图标的垂直对齐（#57727、#57896、#58428）。",
           "code": "<script setup lang=\"ts\">\nimport { SmileOutlined } from '@antdv-next/icons'\nimport { Popconfirm } from 'antdv-next'\nimport { h } from 'vue'\n\nconst InternalPopconfirm = Popconfirm._InternalPanelDoNotUseOrYouWillBeFired\n\nconst btnCls = {\n  icon: 'card-btn-debug-icon',\n  content: 'card-btn-debug-content',\n}\n</script>\n\n<template>\n  <a-config-provider :button=\"{ classes: btnCls }\">\n    <a-flex vertical gap=\"middle\">\n      <a-card class=\"line-card\" title=\"#57727 Card extra\">\n        <template #extra>\n          <a-button>\n            <template #icon>\n              <SmileOutlined />\n            </template>\n            Test\n          </a-button>\n        </template>\n        Button in Card extra should be vertically centered with the title.\n      </a-card>\n\n      <a-card title=\"#57896 regression minimum case\">\n        <div class=\"simulate-57896\">\n          <div class=\"inline-buttons\">\n            <a-button>Cancel</a-button>\n            <a-button type=\"primary\" :icon=\"() => h(SmileOutlined)\">\n              Confirm\n            </a-button>\n          </div>\n        </div>\n      </a-card>\n\n      <InternalPopconfirm\n        title=\"Are you OK?\"\n        :ok-button-props=\"{ icon: () => h(SmileOutlined) }\"\n      />\n    </a-flex>\n  </a-config-provider>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Card root element with positioning, background, border, border-radius, box-shadow, padding and other container styles",
+          "descriptionZh": "卡片根元素，包含位置定位、背景色、边框、圆角、阴影、内边距等卡片容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, EllipsisOutlined, SettingOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'cover', desc: t('cover'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Card\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ position: 'absolute' }\">\n        <a-card\n          title=\"Card title\"\n          extra=\"More\"\n          :style=\"{ width: '300px' }\"\n          :classes=\"classes\"\n        >\n          <template #cover>\n            <img\n              draggable=\"false\"\n              alt=\"example\"\n              src=\"https://gw.alipayobjects.com/zos/rmsportal/JiqGstEfoWAOHiTxclqi.png\"\n            >\n          </template>\n          <template #actions>\n            <SettingOutlined key=\"setting\" />\n            <EditOutlined key=\"edit\" />\n            <EllipsisOutlined key=\"ellipsis\" />\n          </template>\n          <a-card-meta\n            title=\"Card Meta title\"\n            description=\"This is the description\"\n          >\n            <template #avatar>\n              <a-avatar src=\"https://api.dicebear.com/7.x/miniavs/svg?seed=8\" />\n            </template>\n          </a-card-meta>\n        </a-card>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Card header area with flex layout, min-height, padding, text color, font-weight, font-size, background, bottom border and top border-radius",
+          "descriptionZh": "卡片头部区域，包含 flex 布局、最小高度、内边距、文字颜色、字体权重、字体大小、背景色、下边框、顶部圆角等样式"
+        },
+        {
+          "key": "body",
+          "description": "Card content area with padding, font-size and other content display styles",
+          "descriptionZh": "卡片内容区域，包含内边距、字体大小等内容展示的基础样式"
+        },
+        {
+          "key": "extra",
+          "description": "Card extra operation area in top-right corner with text color and layout styles for additional content",
+          "descriptionZh": "卡片右上角的操作区域，包含额外内容的文字颜色和布局样式"
+        },
+        {
+          "key": "title",
+          "description": "Card title with inline-block display, flex-grow, text ellipsis and other title display styles",
+          "descriptionZh": "卡片标题，包含行内块布局、flex 占比、文本省略等标题显示样式"
+        },
+        {
+          "key": "actions",
+          "description": "Card bottom action group with flex layout, list-style reset, background, top border and bottom border-radius for action buttons container",
+          "descriptionZh": "卡片底部操作组，包含 flex 布局、列表样式重置、背景色、上边框、底部圆角等操作按钮容器样式"
+        },
+        {
+          "key": "cover",
+          "description": "Title cover with styles for cover image display and layout",
+          "descriptionZh": "标题封面，包含封面图片的显示和布局样式"
         }
       ]
     },
@@ -5343,7 +5511,8 @@
           "descriptionZh": "展示指示点的进度。",
           "code": "<template>\n  <a-carousel :autoplay=\"{ dotDuration: true }\" :autoplay-speed=\"5000\">\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        1\n      </h3>\n    </div>\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        2\n      </h3>\n    </div>\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        3\n      </h3>\n    </div>\n    <div>\n      <h3 class=\"custom-carousel-item\">\n        4\n      </h3>\n    </div>\n  </a-carousel>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Cascader",
@@ -5735,14 +5904,6 @@
           "code": "<script setup lang=\"ts\">\nimport type { CascaderEmits } from 'antdv-next'\nimport { ref } from 'vue'\n\ninterface Option {\n  value: string | number\n  label: string\n  children?: Option[]\n}\n\nconst options: Option[] = [\n  {\n    value: 'zhejiang',\n    label: 'Zhejiang',\n    children: [\n      {\n        value: 'hangzhou',\n        label: 'Hangzhou',\n        children: [\n          {\n            value: 'xihu',\n            label: 'West Lake',\n          },\n        ],\n      },\n    ],\n  },\n  {\n    value: 'jiangsu',\n    label: 'Jiangsu',\n    children: [\n      {\n        value: 'nanjing',\n        label: 'Nanjing',\n        children: [\n          {\n            value: 'zhonghuamen',\n            label: 'Zhong Hua Men',\n          },\n        ],\n      },\n    ],\n  },\n]\n\nconst disabled = ref(false)\n\nconst onChange: CascaderEmits['change'] = (value) => {\n  console.log(value)\n}\n\nconst onMultipleChange: CascaderEmits['change'] = (value) => {\n  console.log(value)\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"small\" align=\"flex-start\">\n    <a-switch\n      v-model:checked=\"disabled\"\n      checked-children=\"Enabled\"\n      un-checked-children=\"Disabled\"\n      aria-label=\"disabled switch\"\n    />\n    <a-cascader-panel :options=\"options\" :disabled=\"disabled\" @change=\"onChange\" />\n    <a-cascader-panel multiple :options=\"options\" :disabled=\"disabled\" @change=\"onMultipleChange\" />\n    <a-cascader-panel />\n  </a-flex>\n</template>"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst mode = ref<'single' | 'multiple'>('single')\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => {\n  const base = [\n    { name: 'root', desc: t('root') },\n    { name: 'prefix', desc: t('prefix') },\n    { name: 'content', desc: t('content') },\n    { name: 'placeholder', desc: t('placeholder') },\n    { name: 'clear', desc: t('clear') },\n    { name: 'input', desc: t('input') },\n    { name: 'suffix', desc: t('suffix') },\n    { name: 'popup.root', desc: t('popup.root') },\n    { name: 'popup.list', desc: t('popup.list') },\n    { name: 'popup.listItem', desc: t('popup.listItem') },\n  ]\n\n  if (mode.value === 'multiple') {\n    return [\n      ...base,\n      { name: 'item', desc: t('item') },\n      { name: 'itemContent', desc: t('itemContent') },\n      { name: 'itemRemove', desc: t('itemRemove') },\n    ]\n  }\n\n  return base\n})\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst options = [\n  {\n    value: 'contributors',\n    label: 'contributors',\n    children: [\n      { value: 'aojunhao123', label: 'aojunhao123' },\n      { value: 'thinkasany', label: 'thinkasany' },\n      { value: 'meet-student', label: 'meet-student' },\n    ],\n  },\n]\n\nconst value = computed(() => {\n  if (mode.value !== 'multiple')\n    return ['contributors', 'thinkasany']\n\n  return [['contributors', 'aojunhao123']]\n})\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Cascader\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <div :style=\"{ display: 'flex', justifyContent: 'center', marginBottom: '12px' }\">\n          <a-segmented v-model:value=\"mode\" :options=\"['single', 'multiple']\" />\n        </div>\n        <div :style=\"{ display: 'flex', flexDirection: 'column', gap: '12px' }\">\n          <a-cascader\n            prefix=\"prefix\"\n            :style=\"{ width: '300px' }\"\n            :options=\"options\"\n            :value=\"value\"\n            :multiple=\"mode === 'multiple'\"\n            open\n            :get-popup-container=\"() => divRef!\"\n            :classes=\"classes\"\n          />\n        </div>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
-        },
-        {
           "name": "basic",
           "title": "",
           "titleZh": "基本",
@@ -5789,6 +5950,73 @@
           "description": "Allows the selection of only parent options.",
           "descriptionZh": "这种交互允许只选中父级选项。",
           "code": "<script setup lang=\"ts\">\nimport type { CascaderEmits } from 'antdv-next'\nimport { shallowRef } from 'vue'\n\ninterface Option {\n  value: string\n  label: string\n  children?: Option[]\n}\n\nconst options: Option[] = [\n  {\n    value: 'zhejiang',\n    label: 'Zhejiang',\n    children: [\n      {\n        value: 'hangzhou',\n        label: 'Hanzhou',\n        children: [\n          {\n            value: 'xihu',\n            label: 'West Lake',\n          },\n        ],\n      },\n    ],\n  },\n  {\n    value: 'jiangsu',\n    label: 'Jiangsu',\n    children: [\n      {\n        value: 'nanjing',\n        label: 'Nanjing',\n        children: [\n          {\n            value: 'zhonghuamen',\n            label: 'Zhong Hua Men',\n          },\n        ],\n      },\n    ],\n  },\n]\n\nconst onChange: CascaderEmits['change'] = (value) => {\n  console.log(value)\n}\nconst value = shallowRef()\n</script>\n\n<template>\n  <a-cascader v-model:value=\"value\" :options=\"options\" change-on-select @change=\"onChange\" />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, cursor styles, transitions, border and other basic selector container styles",
+          "descriptionZh": "根元素，包含相对定位、行内 flex 布局、光标样式、过渡动画、边框等选择器容器的基础样式"
+        },
+        {
+          "key": "prefix",
+          "description": "Prefix element with layout and styling for prefix content",
+          "descriptionZh": "前缀元素，包含前缀内容的布局和样式"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "clear",
+          "description": "Clear button element with layout, styling and interactive effects for clear button式",
+          "descriptionZh": "清除按钮元素，包含清除按钮的布局、样式和交互效果"
+        },
+        {
+          "key": "item",
+          "description": "Multiple selection item element with border, background, padding, and margin styles",
+          "descriptionZh": "多选项元素，包含边框、背景、内边距、外边距样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Multiple selection item content area with text ellipsis styles",
+          "descriptionZh": "多选项内容区域，包含文字的省略样式"
+        },
+        {
+          "key": "itemRemove",
+          "description": "Multiple selection item remove button with font-related styles式",
+          "descriptionZh": "多选项移除按钮，包含字体相关样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with search input styling, cursor control, font inheritance and other search-related styles. Remove border styles",
+          "descriptionZh": "输入框元素，包含搜索输入框的样式、光标控制、字体继承等搜索相关样式，去除了边框样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with layout and styling for suffix content like clear button, arrow icon, etc.",
+          "descriptionZh": "后缀元素，包含后缀内容的布局和样式，如清除按钮、箭头图标等"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with popup layer positioning, z-index, background, border, box-shadow and other popup container styles",
+          "descriptionZh": "弹出菜单元素，包含弹出层的定位、层级、背景、边框、阴影等弹出容器样式"
+        },
+        {
+          "key": "popup.list",
+          "description": "Popup list element with option list layout, scrolling, max-height and other list container styles",
+          "descriptionZh": "弹出菜单列表元素，包含选项列表的布局、滚动、最大高度等列表容器样式"
+        },
+        {
+          "key": "popup.listItem",
+          "description": "Popup item element with option item padding, hover effects, selected states, disabled states and other option interactive styles",
+          "descriptionZh": "弹出菜单条目元素，包含选项项的内边距、悬浮效果、选中状态、禁用状态等选项交互样式式"
         }
       ]
     },
@@ -6017,14 +6245,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Checkbox by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Checkbox 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CheckboxProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\nimport { ref } from 'vue'\n\nconst checked = ref(true)\nconst { token } = theme.useToken()\n\n// Object styles — 静态样式对象\nconst stylesObject: CheckboxProps['styles'] = {\n  icon: {\n    borderRadius: '6px',\n  },\n  label: {\n    color: 'blue',\n  },\n}\n\n// Function classes — 根据 checked 状态动态返回类名\nconst classesFn: CheckboxProps['classes'] = (info) => {\n  const base: Record<string, string> = {\n    root: 'checkbox-demo-root',\n    icon: 'checkbox-demo-icon',\n    label: 'checkbox-demo-label',\n  }\n  if (info.props.checked) {\n    return {\n      root: base.root,\n      icon: `${base.icon} checkbox-demo-icon-checked`,\n      label: `${base.label} checkbox-demo-label-checked`,\n    }\n  }\n  return base\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-checkbox :styles=\"stylesObject\">\n      Object styles\n    </a-checkbox>\n    <a-checkbox\n      v-model:checked=\"checked\"\n      :classes=\"classesFn\"\n    >\n      Function classes\n    </a-checkbox>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with inline-flex layout, baseline alignment, cursor style, reset styles and other basic checkbox container styles",
+          "descriptionZh": "根元素，包含行内 flex 布局、基线对齐、光标样式、重置样式等复选框容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Checkbox\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-checkbox :classes=\"classes\">\n        Checkbox\n      </a-checkbox>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Checkbox icon element with size, direction, background, border, border-radius, transitions, and checked state checkmark styles",
+          "descriptionZh": "选中框元素，包含尺寸、方向、背景色、边框、圆角、过渡动画，以及选中状态的勾选标记样式"
+        },
+        {
+          "key": "label",
+          "description": "Label text element with padding and spacing styles relative to the checkbox",
+          "descriptionZh": "文本元素，包含文本的内边距和与复选框的间距样式"
         }
       ]
     },
@@ -6408,14 +6645,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Collapse by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Collapse 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CollapseProps } from 'antdv-next'\nimport { h } from 'vue'\n\nconst text\n  = 'A dog is a type of domesticated animal. Known for its loyalty and faithfulness, it can be found as a welcome guest in many households across the world.'\n\nconst element = h('p', text)\n\nconst items = [\n  {\n    key: '1',\n    label: 'This is panel header 1',\n    content: element,\n  },\n  {\n    key: '2',\n    label: 'This is panel header 2',\n    content: element,\n  },\n  {\n    key: '3',\n    label: 'This is panel header 3',\n    content: element,\n  },\n]\n\nconst classes: CollapseProps['classes'] = {\n  root: 'demo-collapse-root',\n}\n\nconst stylesObject: CollapseProps['styles'] = {\n  root: {\n    backgroundColor: '#fafafa',\n    border: '1px solid #e0e0e0',\n    borderRadius: '8px',\n  },\n  header: {\n    backgroundColor: '#f0f0f0',\n    padding: '12px 16px',\n    color: '#141414',\n  },\n}\n\nconst stylesFn: CollapseProps['styles'] = (info) => {\n  if (info?.props?.size === 'large') {\n    return {\n      root: {\n        backgroundColor: '#fff',\n        border: '1px solid #696FC7',\n        borderRadius: '8px',\n      },\n      header: {\n        backgroundColor: '#F5EFFF',\n        padding: '12px 16px',\n        color: '#141414',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-collapse :items=\"items\" :classes=\"classes\" :styles=\"stylesObject\" :default-active-key=\"['1']\" />\n    <a-collapse :items=\"items\" :classes=\"classes\" :styles=\"stylesFn\" size=\"large\" :default-active-key=\"['2']\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with border, border-radius, background color and container styles that control the overall layout and appearance of collapse panels",
+          "descriptionZh": "根元素，包含折叠面板的边框、圆角、背景色等容器样式，控制面板的整体布局和外观"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { theme } from 'antdv-next'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n])\n\nconst { token } = theme.useToken()\n\nconst items = computed(() => [\n  {\n    key: '1',\n    label: 'This is panel header',\n    children: 'This is panel body',\n  },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Collapse\"\n    items-a-p-i=\"items\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ position: 'absolute', inset: 0, margin: `${token.marginXL}px` }\">\n        <a-collapse\n          :items=\"items\"\n          :default-active-key=\"['1']\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with flex layout, padding, color, line-height, cursor style, transition animations and other interactive styles for panel headers",
+          "descriptionZh": "头部元素，包含flex布局、内边距、颜色、行高、光标样式、过渡动画等面板头部的交互和样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with flex auto layout and margin styles for title text layout and typography",
+          "descriptionZh": "标题元素，包含flex自适应布局、右边距等标题文字的布局和排版样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with padding, color, background color and other styles for panel content area display",
+          "descriptionZh": "内容元素，包含内边距、颜色、背景色等面板内容区域的展示样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with font size, transition animations, rotation transforms and other styles and animations for expand/collapse arrows",
+          "descriptionZh": "图标元素，包含字体大小、过渡动画、旋转变换等展开收起箭头的样式和动效"
         }
       ]
     },
@@ -6763,14 +7019,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of ColorPicker by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或函数可以自定义 ColorPicker 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst classes = { root: 'custom-color-picker' }\n\nconst color = shallowRef('#1677ff')\nconst colorLarge = shallowRef('#722ed1')\n\nconst stylesObject = {\n  popup: {\n    root: {\n      border: '1px solid #fff',\n    },\n  },\n}\n\nfunction stylesFn(info: any) {\n  if (info?.props?.size === 'large') {\n    return {\n      popup: {\n        root: {\n          border: '1px solid #722ed1',\n        },\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-space size=\"middle\" wrap>\n    <a-color-picker\n      v-model:value=\"color\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    />\n    <a-color-picker\n      v-model:value=\"colorLarge\"\n      size=\"large\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n    />\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Trigger container with border styles, transition animations, size controls, displaying color block and text content",
+          "descriptionZh": "触发器容器，包含边框样式、过渡动画、尺寸控制等样式，显示颜色块和文本内容"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'body', desc: t('body') },\n  { name: 'content', desc: t('content') },\n  { name: 'description', desc: t('description') },\n  { name: 'popup.root', desc: t('popup.root') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\nconst body = document?.body\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"ColorPicker\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" :style=\"{ height: '300px' }\" align=\"flex-start\" gap=\"small\">\n        <a-color-picker\n          default-value=\"#1677ff\"\n          open\n          show-text\n          :get-popup-container=\"() => divRef || body\"\n          :styles=\"{ popup: { root: { zIndex: 1 } } }\"\n          :classes=\"classes\"\n        />\n        <a-color-picker :open=\"false\" allow-clear :classes=\"classes\" />\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "popup.root",
+          "description": "Popup panel root container with background color, shadow effects, color selection panel, slider controls and preset colors",
+          "descriptionZh": "弹出面板根容器，包含背景色、阴影效果、色彩选择面板、滑块控制和预设颜色等样式"
+        },
+        {
+          "key": "body",
+          "description": "Color block container with background color, border styles",
+          "descriptionZh": "色块容器，包含底色、边框等样式"
+        },
+        {
+          "key": "content",
+          "description": "Color block element with actual selected color styles",
+          "descriptionZh": "色块颜色元素，包含实际选择的颜色样式"
+        },
+        {
+          "key": "description",
+          "description": "Description text content with font styles and color",
+          "descriptionZh": "描述文本内容，包含字体样式、颜色等样式"
         }
       ]
     },
@@ -6992,7 +7267,8 @@
           "descriptionZh": "通过 `theme.token.focusOutline` 全局关闭组件聚焦时的可见描边。用 Tab 键在下面的控件间移动即可对比效果。",
           "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\n\nconst focusOutline = ref(true)\n\nconst themeConfig = computed(() => ({\n  token: {\n    focusOutline: focusOutline.value,\n  },\n}))\n\nconst options = [\n  { value: 'apple', label: 'Apple' },\n  { value: 'orange', label: 'Orange' },\n  { value: 'banana', label: 'Banana' },\n]\n\nconst current = ref(0)\n\nfunction onStepChange(value: number) {\n  current.value = value\n}\n</script>\n\n<template>\n  <a-space direction=\"vertical\" style=\"width: 100%\">\n    <a-space>\n      focusOutline\n      <a-switch v-model:checked=\"focusOutline\" />\n    </a-space>\n\n    <a-config-provider :theme=\"themeConfig\">\n      <a-space direction=\"vertical\" style=\"width: 100%\">\n        <a-input placeholder=\"Outlined\" style=\"max-width: 240px\" />\n        <a-input variant=\"borderless\" placeholder=\"Borderless\" style=\"max-width: 240px\" />\n        <a-select :options=\"options\" variant=\"borderless\" placeholder=\"Borderless select\" style=\"width: 240px\" />\n        <a-rate :default-value=\"3\" />\n        <a-steps\n          :current=\"current\"\n          :items=\"[{ title: 'First' }, { title: 'Second' }, { title: 'Third' }]\"\n          @change=\"onStepChange\"\n        />\n        <a-splitter style=\"height: 100px; border: 1px solid var(--ant-color-border)\">\n          <a-splitter-panel collapsible>\n            First\n          </a-splitter-panel>\n          <a-splitter-panel>\n            Second\n          </a-splitter-panel>\n        </a-splitter>\n        <a-button>Button</a-button>\n      </a-space>\n    </a-config-provider>\n  </a-space>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "DatePicker",
@@ -7626,14 +7902,63 @@
           "description": "Custom `prefix` and `suffixIcon`.",
           "descriptionZh": "自定义前缀 `prefix` 和后缀图标 `suffixIcon`。",
           "code": "<script setup lang=\"ts\">\nimport type { Dayjs } from 'dayjs'\nimport { SmileOutlined } from '@antdv-next/icons'\nimport { h } from 'vue'\n\nconst smileIcon = h(SmileOutlined)\n\nfunction handleChange(date: Dayjs | (Dayjs | null)[] | null, dateString: string | string[] | null) {\n  console.log(date, dateString)\n}\n</script>\n\n<template>\n  <a-space vertical :size=\"12\">\n    <a-date-picker :suffix-icon=\"smileIcon\" @change=\"handleChange\" />\n    <a-date-picker :suffix-icon=\"smileIcon\" picker=\"month\" @change=\"handleChange\" />\n    <a-range-picker :suffix-icon=\"smileIcon\" @change=\"handleChange\" />\n    <a-date-picker :suffix-icon=\"smileIcon\" picker=\"week\" @change=\"handleChange\" />\n    <a-date-picker suffix-icon=\"ab\" @change=\"handleChange\" />\n    <a-date-picker suffix-icon=\"ab\" picker=\"month\" @change=\"handleChange\" />\n    <a-range-picker suffix-icon=\"ab\" @change=\"handleChange\" />\n    <a-date-picker suffix-icon=\"ab\" picker=\"week\" @change=\"handleChange\" />\n    <a-date-picker :prefix=\"smileIcon\" picker=\"week\" @change=\"handleChange\" />\n    <a-date-picker prefix=\"Event Period\" picker=\"week\" @change=\"handleChange\" />\n    <a-range-picker :prefix=\"smileIcon\" picker=\"week\" @change=\"handleChange\" />\n    <a-range-picker prefix=\"Event Period\" picker=\"week\" @change=\"handleChange\" />\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, padding, border-radius, transition animations and other basic styles for date picker container",
+          "descriptionZh": "根元素，包含相对定位、行内flex布局、内边距、边框圆角、过渡动画等日期选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { SmileOutlined } from '@antdv-next/icons'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'popup.root', desc: t('popup') },\n  { name: 'popup.container', desc: t('popup.container') },\n  { name: 'popup.header', desc: t('popup.header') },\n  { name: 'popup.body', desc: t('popup.body') },\n  { name: 'popup.content', desc: t('popup.content') },\n  { name: 'popup.item', desc: t('popup.item') },\n  { name: 'popup.footer', desc: t('popup.footer') },\n])\n\nconst type = ref<'Single' | 'Multiple'>('Single')\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    :component-name=\"type === 'Single' ? 'DatePicker' : 'DatePicker.RangePicker'\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" vertical :style=\"{ alignSelf: 'flex-start' }\" gap=\"middle\" align=\"center\">\n        <a-segmented\n          :options=\"['Single', 'Multiple']\"\n          :value=\"type\"\n          @change=\"(val: 'Single' | 'Multiple') => type = val\"\n        />\n        <a-date-picker\n          v-if=\"type === 'Single'\"\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-date-picker>\n        <a-range-picker\n          v-else\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-range-picker>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with flex layout and margin styles for prefix content layout",
+          "descriptionZh": "前缀元素，包含flex布局、右外边距等前缀内容的布局样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with relative positioning, width, color, font, line-height, transition animations and other core interactive styles for input field",
+          "descriptionZh": "输入框元素，包含相对定位、宽度、颜色、字体、行高、过渡动画等输入框的核心交互样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with flex layout, color, line-height, pointer events, transition animations and other styles for suffix content",
+          "descriptionZh": "后缀元素，包含flex布局、颜色、行高、指针事件、过渡动画等后缀内容的样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup element",
+          "descriptionZh": "弹出框元素"
+        },
+        {
+          "key": "popup.container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "popup.header",
+          "description": "Popup header element with navigation buttons, month/year selectors and other header control area layout and styles",
+          "descriptionZh": "弹出框头部元素，包含导航按钮、月份年份选择器等头部控制区域的布局和样式"
+        },
+        {
+          "key": "popup.body",
+          "description": "Popup body element with container layout and styles for date panel table",
+          "descriptionZh": "弹出框主体元素，包含日期面板表格的容器布局和样式"
+        },
+        {
+          "key": "popup.content",
+          "description": "Popup content element with width, border, cell and other content display styles for date table",
+          "descriptionZh": "弹出框内容元素，包含日期表格的宽度、边框、单元格等内容展示样式"
+        },
+        {
+          "key": "popup.item",
+          "description": "Popup item element with size, background, border-radius, hover state, selected state and other interactive styles for date cells",
+          "descriptionZh": "弹出框单项元素，包含日期单元格的尺寸、背景色、边框圆角、悬停态、选中态等交互样式"
+        },
+        {
+          "key": "popup.footer",
+          "description": "Popup footer element with layout styles for bottom operation area including confirm/cancel buttons and shortcuts",
+          "descriptionZh": "弹出框底部元素，包含确认取消按钮、快捷选择等底部操作区域的布局样式"
         }
       ]
     },
@@ -7887,14 +8212,38 @@
           "description": "Display of the entire line.",
           "descriptionZh": "整行的展示。",
           "code": "<script setup lang=\"ts\">\nimport type { DescriptionsItemType } from 'antdv-next'\n\nconst items: DescriptionsItemType[] = [\n  {\n    label: 'UserName',\n    content: 'Zhou Maomao',\n  },\n  {\n    label: 'Live',\n    span: 'filled', // span = 2\n    content: 'Hangzhou, Zhejiang',\n  },\n  {\n    label: 'Remark',\n    span: 'filled', // span = 3\n    content: 'empty',\n  },\n  {\n    label: 'Address',\n    span: 1, // span will be 3 and warning for span is not align to the end\n    content: 'No. 18, Wantang Road, Xihu District, Hangzhou, Zhejiang, China',\n  },\n]\n</script>\n\n<template>\n  <a-descriptions title=\"User Info\" :items=\"items\" bordered />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with basic styles, reset styles, border styles, layout direction and other overall styles for description list container",
+          "descriptionZh": "根元素，包含描述列表容器的基础样式、重置样式、边框样式、布局方向等整体样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n])\n\nconst bordered = ref(false)\n\nconst items = [\n  { key: '1', label: 'Telephone', content: '1810000000' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Descriptions\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ width: '100%', height: '100%' }\">\n        <a-switch v-model:checked=\"bordered\" />\n        Toggle Border\n        <a-divider />\n        <a-descriptions\n          title=\"User Info\"\n          :items=\"items\"\n          :bordered=\"bordered\"\n          :classes=\"classes\"\n        >\n          <template #extra>\n            <a-button type=\"primary\">\n              Edit\n            </a-button>\n          </template>\n        </a-descriptions>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with flex layout, alignment, bottom margin and other layout and style controls for header area",
+          "descriptionZh": "头部元素，包含flex布局、对齐方式、下边距等头部区域的布局和样式控制"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text ellipsis, flex ratio, color, font weight, font size, line height and other title text styles",
+          "descriptionZh": "标题元素，包含文本省略、flex占比、颜色、字体权重、字体大小、行高等标题文字样式"
+        },
+        {
+          "key": "extra",
+          "description": "Extra content element with left margin, color, font size and other styles for additional operation area",
+          "descriptionZh": "额外内容元素，包含左边距、颜色、字体大小等额外操作区域的样式"
+        },
+        {
+          "key": "label",
+          "description": "Label element with color, font weight, font size, line height, text align, colon styles and other label text styles",
+          "descriptionZh": "标签元素，包含颜色、字体权重、字体大小、行高、文本对齐、冒号样式等标签文字的样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with table cell layout, color, font size, line height, word break and other content display styles",
+          "descriptionZh": "内容元素，包含表格单元格布局、颜色、字体大小、行高、文字换行等内容展示样式"
         }
       ]
     },
@@ -8063,14 +8412,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of divider by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义分割线的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { DividerProps } from 'antdv-next'\n\nconst classesObject: DividerProps['classes'] = {\n  root: 'demo-divider-root',\n  content: 'demo-divider-content',\n  rail: 'demo-divider-rail',\n}\n\nconst classesFn: DividerProps['classes'] = (info) => {\n  if (info?.props?.titlePlacement === 'start') {\n    return {\n      root: 'demo-divider-root--start',\n    }\n  }\n  return {\n    root: 'demo-divider-root--default',\n  }\n}\n\nconst stylesObject: DividerProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed' },\n  content: { fontStyle: 'italic' },\n  rail: { opacity: 0.85 },\n}\n\nconst stylesFn: DividerProps['styles'] = (info) => {\n  if (info?.props?.size === 'small') {\n    return {\n      root: { opacity: 0.6, cursor: 'default' },\n    }\n  }\n  return {\n    root: { backgroundColor: '#fafafa', borderColor: '#d9d9d9' },\n  }\n}\n</script>\n\n<template>\n  <div>\n    <a-divider :classes=\"classesObject\">\n      classes Object\n    </a-divider>\n    <a-divider title-placement=\"start\" :classes=\"classesFn\">\n      classes Function\n    </a-divider>\n    <a-divider :styles=\"stylesObject\">\n      styles Object\n    </a-divider>\n    <a-divider size=\"small\" :styles=\"stylesFn\">\n      styles Function\n    </a-divider>\n  </div>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with border-top style, divider styling and other basic divider container styles",
+          "descriptionZh": "根元素，包含边框顶部样式、分隔线样式等分割线容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'rail', desc: t('rail') },\n  { name: 'content', desc: t('content') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Divider\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div>\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider :classes=\"classes\" />\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider :classes=\"classes\">\n          Solid\n        </a-divider>\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider title-placement=\"left\" variant=\"dotted\" :classes=\"classes\">\n          Dotted\n        </a-divider>\n        <p>\n          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed nonne merninisti licere mihi\n          ista probare, quae sunt a te dicta? Refert tamen, quo modo.\n        </p>\n        <a-divider title-placement=\"right\" variant=\"dashed\" :classes=\"classes\">\n          Dashed\n        </a-divider>\n        These\n        <a-divider orientation=\"vertical\" :classes=\"classes\" />\n        are\n        <a-divider orientation=\"vertical\" :classes=\"classes\" />\n        vertical\n        <a-divider orientation=\"vertical\" :classes=\"classes\" />\n        Dividers\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "content",
+          "description": "Content element with inline-block display, padding and other divider text content styles",
+          "descriptionZh": "内容元素，包含行内块显示、内边距等分割线文本内容的样式"
+        },
+        {
+          "key": "rail",
+          "description": "Background rail element with border-top style and other divider connection line styles",
+          "descriptionZh": "背景条元素，包含边框顶部样式等分割线连接条的样式"
         }
       ]
     },
@@ -8447,14 +8805,58 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Drawer by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Drawer 组件的 [语义化结构](#semantic-dom) 样式。",
           "code": "<script setup lang=\"ts\">\nimport type { DrawerProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\nimport { ref } from 'vue'\n\nconst { token } = theme.useToken()\nconst open = ref(false)\nconst openFn = ref(false)\n\nconst classes: DrawerProps['classes'] = {\n  header: 'demo-drawer-header',\n  body: 'demo-drawer-body',\n}\n\nconst stylesObject: DrawerProps['styles'] = {\n  body: {\n    backgroundColor: '#f5f5f5',\n  },\n  footer: {\n    backgroundColor: '#fafafa',\n  },\n}\n\nconst stylesFn: DrawerProps['styles'] = (info) => {\n  if (info?.props?.placement === 'right') {\n    return {\n      mask: {\n        backgroundColor: 'rgba(0, 0, 0, 0.2)',\n      },\n      wrapper: {\n        boxShadow: '0 8px 24px rgba(0, 0, 0, 0.15)',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-button @click=\"open = true\">\n      Object Style\n    </a-button>\n    <a-button type=\"primary\" @click=\"openFn = true\">\n      Function Style\n    </a-button>\n  </a-flex>\n\n  <a-drawer\n    v-model:open=\"open\"\n    title=\"Custom Style Drawer\"\n    :classes=\"classes\"\n    :styles=\"stylesObject\"\n    @close=\"open = false\"\n  >\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n  </a-drawer>\n\n  <a-drawer\n    v-model:open=\"openFn\"\n    title=\"Custom Function Drawer\"\n    :classes=\"classes\"\n    :styles=\"stylesFn\"\n    @close=\"openFn = false\"\n  >\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n    <p>Some contents...</p>\n  </a-drawer>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with fixed positioning, z-index control, pointer events, color and other basic styles and layout control for drawer container",
+          "descriptionZh": "根元素，包含固定定位、层级控制、指针事件、颜色等抽屉容器的基础样式和布局控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'mask', desc: t('mask'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n  { name: 'dragger', desc: t('dragger'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Drawer\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-drawer\n        title=\"Title\"\n        placement=\"right\"\n        open\n        :get-container=\"false\"\n        :size=\"300\"\n        :resizable=\"{}\"\n        :classes=\"classes\"\n      >\n        <template #footer>\n          <a-typography-link>Footer</a-typography-link>\n        </template>\n        <template #extra>\n          <a-button>Cancel</a-button>\n        </template>\n        <p>Some contents...</p>\n      </a-drawer>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "mask",
+          "description": "Mask element with absolute positioning, z-index, background color, pointer events and other mask layer styles and interaction controls",
+          "descriptionZh": "遮罩层元素，包含绝对定位、层级、背景色、指针事件等遮罩层的样式和交互控制"
+        },
+        {
+          "key": "section",
+          "description": "Drawer container element with flex layout, width/height, overflow control, background color, pointer events and other drawer body styles",
+          "descriptionZh": "Drawer 容器元素，包含flex布局、宽高、溢出控制、背景色、指针事件等抽屉主体的样式"
+        },
+        {
+          "key": "header",
+          "description": "Header element with flex layout, alignment, padding, font size, line height, bottom border and other header area styles",
+          "descriptionZh": "头部元素，包含flex布局、对齐方式、内边距、字体大小、行高、下边框等头部区域的样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with flex ratio, minimum size, padding, overflow scroll and other content area display and layout styles",
+          "descriptionZh": "内容元素，包含flex占比、最小尺寸、内边距、溢出滚动等内容区域的展示和布局样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with flex shrink, padding, top border and other bottom operation area styles",
+          "descriptionZh": "底部元素，包含flex收缩、内边距、上边框等底部操作区域的样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with flex ratio, margin, font weight, font size, line height and other title text styles",
+          "descriptionZh": "标题元素，包含flex占比、外边距、字体权重、字体大小、行高等标题文字的样式"
+        },
+        {
+          "key": "extra",
+          "description": "Extra element with flex fixed layout and other additional operation content style controls",
+          "descriptionZh": "额外元素，包含flex固定布局等额外操作内容的样式控制"
+        },
+        {
+          "key": "dragger",
+          "description": "Dragger element used to resize the drawer, with absolute positioning, transparent background, pointer events control, hover state styles, and dragging state styles",
+          "descriptionZh": "拖拽元素，用于调整抽屉大小的拖拽手柄，包含绝对定位、背景透明、指针事件控制、hover状态样式、拖拽状态样式等"
+        },
+        {
+          "key": "close",
+          "description": "Close button element with basic button styling",
+          "descriptionZh": "关闭按钮元素，包含按钮的基础样式"
         }
       ]
     },
@@ -8811,14 +9213,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of the Dropdown by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Dropdown 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { DropdownProps, MenuItemType } from 'antdv-next'\nimport { DownOutlined, LogoutOutlined, SettingOutlined } from '@antdv-next/icons'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst items: MenuItemType[] = [\n  {\n    key: '1',\n    label: 'Profile',\n  },\n  {\n    key: '2',\n    label: 'Settings',\n    icon: SettingOutlined,\n  },\n  {\n    type: 'divider',\n  },\n  {\n    key: '3',\n    label: 'Logout',\n    icon: LogoutOutlined,\n    danger: true,\n  },\n]\n\nconst classes: DropdownProps['classes'] = {\n  root: 'demo-dropdown-root',\n}\n\nconst objectStyles: DropdownProps['styles'] = {\n  root: {\n    backgroundColor: '#ffffff',\n    border: '1px solid #d9d9d9',\n    borderRadius: '4px',\n  },\n  item: {\n    padding: '8px 12px',\n    fontSize: '14px',\n  },\n  itemTitle: {\n    fontWeight: '500',\n  },\n  itemIcon: {\n    color: '#1890ff',\n    marginRight: '8px',\n  },\n  itemContent: {\n    backgroundColor: 'transparent',\n  },\n}\n\nconst functionStyles: DropdownProps['styles'] = (info) => {\n  const isClick = info.props.trigger?.includes('click')\n  if (isClick) {\n    return {\n      root: {\n        borderColor: '#1890ff',\n        borderRadius: '8px',\n      },\n    }\n  }\n  return {}\n}\n\nconst sharedProps: DropdownProps = {\n  menu: { items },\n  placement: 'bottomLeft',\n  classes,\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\" wrap=\"wrap\">\n    <a-space direction=\"vertical\" size=\"large\">\n      <a-dropdown v-bind=\"sharedProps\" :styles=\"objectStyles\">\n        <a-button>\n          <a-space>\n            Object Style\n            <DownOutlined />\n          </a-space>\n        </a-button>\n      </a-dropdown>\n\n      <a-dropdown v-bind=\"sharedProps\" :styles=\"functionStyles\" :trigger=\"['click']\">\n        <a-button type=\"primary\">\n          <a-space>\n            Function Style\n            <DownOutlined />\n          </a-space>\n        </a-button>\n      </a-dropdown>\n    </a-space>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element of dropdown, sets positioning, z-index and container styles",
+          "descriptionZh": "dropdown 的根元素，设置定位、层级和容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { DeleteOutlined, DownOutlined, EditOutlined, SaveOutlined } from '@antdv-next/icons'\nimport { computed, h, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'itemTitle', desc: t('itemTitle') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst items: any[] = [\n  {\n    key: '1',\n    type: 'group',\n    label: 'Group title',\n    children: [\n      { key: '1-1', label: '1st menu item', icon: h(SaveOutlined) },\n      { key: '1-2', label: '2nd menu item', icon: h(EditOutlined) },\n    ],\n  },\n  {\n    key: 'SubMenu',\n    label: 'SubMenu',\n    children: [\n      {\n        key: 'g1',\n        label: 'Item 1',\n        type: 'group',\n        children: [\n          { key: '1', label: 'Option 1' },\n          { key: '2', label: 'Option 2' },\n        ],\n      },\n    ],\n  },\n  { key: '3', type: 'divider' },\n  { key: '4', label: 'Delete', icon: h(DeleteOutlined), danger: true },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Dropdown\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ height: '120px', position: 'absolute', top: '50px' }\">\n        <a-dropdown\n          open\n          :menu=\"{ items }\"\n          :styles=\"{ root: { width: '200px', zIndex: 1 } }\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        >\n          <a @click.prevent>\n            <a-space>\n              Hover me\n              <DownOutlined />\n            </a-space>\n          </a>\n        </a-dropdown>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "itemTitle",
+          "description": "Title content area of dropdown option, sets layout and text styles",
+          "descriptionZh": "dropdown 选项的标题内容区域，设置布局和文字样式"
+        },
+        {
+          "key": "item",
+          "description": "Individual dropdown option element, sets interaction states and background styles",
+          "descriptionZh": "dropdown 的单个选项元素，设置选项的交互状态和背景样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Main content area of dropdown option, sets content layout and link styles",
+          "descriptionZh": "dropdown 选项的主要内容区域，设置内容布局和链接样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Icon area of dropdown option, sets icon size and spacing styles",
+          "descriptionZh": "dropdown 选项的图标区域，设置图标的尺寸和间距样式"
         }
       ]
     },
@@ -8928,14 +9349,28 @@
           "description": "Hide default description.",
           "descriptionZh": "隐藏默认描述。",
           "code": "<template>\n  <a-empty :description=\"false\" />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets text alignment, font and line height styles",
+          "descriptionZh": "根元素，设置文本对齐、字体和行高样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'image', desc: t('image'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Empty\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-empty\n        :image=\"1\"\n        :styles=\"{ image: { height: '60px' } }\"\n        :classes=\"classes\"\n      >\n        <template #description>\n          <a-typography-text>\n            Customize <a href=\"#API\">Description</a>\n          </a-typography-text>\n        </template>\n        <a-button type=\"primary\">\n          Create Now\n        </a-button>\n      </a-empty>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "image",
+          "description": "Image element, sets height, opacity, margin and image styles",
+          "descriptionZh": "图标元素，设置高度、透明度、边距和图片样式"
+        },
+        {
+          "key": "description",
+          "description": "Description element, sets text color styles",
+          "descriptionZh": "描述元素，设置文本颜色样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element, sets top margin and action button styles",
+          "descriptionZh": "底部元素，设置顶部边距和操作按钮样式"
         }
       ]
     },
@@ -9045,7 +9480,8 @@
           "descriptionZh": "嵌套使用，可以实现更复杂的布局。",
           "code": "<script setup lang=\"ts\">\nimport type { CSSProperties } from 'vue'\n\nconst cardStyle: CSSProperties = {\n  width: '620px',\n}\nconst imgStyle: CSSProperties = {\n  display: 'block',\n  width: '273px',\n}\n</script>\n\n<template>\n  <a-card :style=\"cardStyle\" :styles=\"{ body: { padding: 0, overflow: 'hidden' } }\">\n    <a-flex justify=\"space-between\">\n      <img\n        alt=\"avatar\"\n        src=\"https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png\"\n        :style=\"imgStyle\"\n      >\n      <a-flex vertical align=\"flex-end\" justify=\"space-between\" :style=\"{ padding: '32px' }\">\n        <a-typography>\n          <a-typography-title :level=\"3\">\n            “antd is an enterprise-class UI design language and Vue UI library.”\n          </a-typography-title>\n        </a-typography>\n        <a-button type=\"primary\" href=\"https://antdv.com\" target=\"_blank\">\n          Get Start\n        </a-button>\n      </a-flex>\n    </a-flex>\n  </a-card>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "FloatButton",
@@ -9471,22 +9907,63 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of FloatButton by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 FloatButton 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { FloatButtonProps } from 'antdv-next'\nimport { QuestionCircleOutlined } from '@antdv-next/icons'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: FloatButtonProps['classes'] = {\n  root: 'demo-float-button-root',\n  content: 'demo-float-button-content',\n}\n\nconst stylesObject: FloatButtonProps['styles'] = {\n  root: {\n    boxShadow: '0 1px 2px 0 rgba(0,0,0,0.05)',\n  },\n}\n\nconst stylesFn: FloatButtonProps['styles'] = (info) => {\n  if (info?.props?.type === 'primary') {\n    return {\n      root: {\n        backgroundColor: '#171717',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-float-button-group shape=\"circle\" style=\"inset-inline-end: 94px;\">\n    <a-float-button\n      type=\"primary\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n    >\n      <template #tooltip>\n        <div>custom style class</div>\n      </template>\n    </a-float-button>\n    <a-float-button\n      type=\"default\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n    >\n      <template #icon>\n        <QuestionCircleOutlined />\n      </template>\n    </a-float-button>\n  </a-float-button-group>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with float button base styles, shape size, type theme, fixed positioning, z-index, shadow, spacing and other container styles",
+          "descriptionZh": "根元素，设置悬浮按钮的基础样式、形状尺寸、类型主题、固定定位、层级、阴影、间距等容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { QuestionCircleOutlined } from '@antdv-next/icons'\nimport { FloatButton } from 'antdv-next'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst PurePanel = (FloatButton as any)._InternalPanelDoNotUseOrYouWillBeFired\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'icon', desc: t('icon') },\n  { name: 'content', desc: t('content') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"FloatButton\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <PurePanel\n        type=\"primary\"\n        shape=\"square\"\n        content=\"HELP\"\n        :classes=\"classes\"\n      >\n        <template #icon>\n          <QuestionCircleOutlined />\n        </template>\n      </PurePanel>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "content",
+          "description": "Content element with button text content font size, color, alignment, line wrap and other text display styles",
+          "descriptionZh": "内容元素，设置按钮内文字内容的字体大小、颜色、对齐、换行等文本显示样式"
         },
         {
-          "name": "_semantic_group",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AlertOutlined, BugOutlined, BulbOutlined } from '@antdv-next/icons'\nimport { FloatButton } from 'antdv-next'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst PurePanel = (FloatButton as any)._InternalPanelDoNotUseOrYouWillBeFired\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('group.root') },\n  { name: 'list', desc: t('group.list') },\n  { name: 'item', desc: t('group.item') },\n  { name: 'itemIcon', desc: t('group.itemIcon') },\n  { name: 'itemContent', desc: t('group.itemContent') },\n  { name: 'trigger', desc: t('group.trigger') },\n  { name: 'triggerIcon', desc: t('group.triggerIcon') },\n  { name: 'triggerContent', desc: t('group.triggerContent') },\n])\n\nconst items = [\n  {\n    icon: h(AlertOutlined),\n    content: 'warn',\n  },\n  {\n    icon: h(BugOutlined),\n    content: 'bug',\n  },\n  {\n    icon: h(BulbOutlined),\n    content: 'idea',\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"FloatButton\"\n    :semantics=\"semantics\"\n    :style=\"{ paddingTop: '100px' }\"\n  >\n    <template #default=\"{ classes }\">\n      <PurePanel\n        type=\"primary\"\n        shape=\"square\"\n        :items=\"items\"\n        trigger=\"hover\"\n        :open=\"true\"\n        content=\"back\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element with button icon size, color, line height, alignment and other icon display styles",
+          "descriptionZh": "图标元素，设置按钮内图标的尺寸、颜色、行高、对齐等图标显示样式"
+        },
+        {
+          "key": "group.root",
+          "description": "Root element with float button group container styles, fixed positioning, z-index, padding, gap, direction mode and other combined layout styles",
+          "descriptionZh": "根元素，设置悬浮按钮组的容器样式、固定定位、层级、内边距、间距、方向模式等组合布局样式"
+        },
+        {
+          "key": "group.list",
+          "description": "List element with button group list flex layout, border radius, shadow, animation transition, vertical alignment and other list container styles",
+          "descriptionZh": "列表元素，设置按钮组列表的Flex布局、圆角、阴影、动画过渡、垂直对齐等列表容器样式"
+        },
+        {
+          "key": "group.item",
+          "description": "Item element with individual float button styles, size, shape, type, state, icon content and other button base styles",
+          "descriptionZh": "列表项元素，设置单个悬浮按钮的样式、尺寸、形状、类型、状态、图标内容等按钮基础样式"
+        },
+        {
+          "key": "group.itemIcon",
+          "description": "Item icon element with float button icon size, color, alignment and other icon display styles",
+          "descriptionZh": "列表项图标元素，设置悬浮按钮内图标的尺寸、颜色、对齐等图标显示样式"
+        },
+        {
+          "key": "group.itemContent",
+          "description": "Item content element with float button text content, badge, description and other content area styles",
+          "descriptionZh": "列表项内容元素，设置悬浮按钮内文字内容、徽标、描述等内容区域样式"
+        },
+        {
+          "key": "group.trigger",
+          "description": "Trigger element with menu mode trigger button styles, shape, icon, hover state, expand/collapse state and other interaction styles",
+          "descriptionZh": "触发元素，设置菜单模式下触发按钮的样式、形状、图标、悬停态、展开收起状态等交互样式"
+        },
+        {
+          "key": "group.triggerIcon",
+          "description": "Trigger icon element with trigger button icon styles, rotation animation, toggle state and other icon interaction styles",
+          "descriptionZh": "触发图标元素，设置触发按钮内图标的样式、旋转动画、切换状态等图标交互样式"
+        },
+        {
+          "key": "group.triggerContent",
+          "description": "Trigger content element with trigger button content area text, identifier, state indicator and other content styles",
+          "descriptionZh": "触发内容元素，设置触发按钮内容区域的文字、标识、状态指示等内容样式"
         }
       ]
     },
@@ -10508,14 +10985,38 @@
           "description": "Label ellipsis debug.",
           "descriptionZh": "label 省略展示调试。",
           "code": "<script setup lang=\"ts\">\nimport { reactive } from 'vue'\n\nconst model = reactive({\n  username: '',\n  password: '',\n})\n</script>\n\n<template>\n  <a-form\n    name=\"label-ellipsis\"\n    :model=\"model\"\n    :label-col=\"{ span: 8 }\"\n    :wrapper-col=\"{ span: 16 }\"\n    style=\"max-width: 600px\"\n  >\n    <a-form-item name=\"username\">\n      <template #label>\n        <a-typography-text ellipsis>\n          longtextlongtextlongtextlongtextlongtextlongtextlongtext\n        </a-typography-text>\n      </template>\n      <a-input v-model:value=\"model.username\" />\n    </a-form-item>\n\n    <a-form-item name=\"password\">\n      <template #label>\n        <a-typography-text ellipsis>\n          longtext longtext longtext longtext longtext longtext longtext\n        </a-typography-text>\n      </template>\n      <a-input-password v-model:value=\"model.password\" />\n    </a-form-item>\n  </a-form>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with form item margin-bottom, vertical-align, transitions, hidden states, error/warning states and other basic form item container styles",
+          "descriptionZh": "根元素，包含表单项的底边距、垂直对齐、过渡动画、隐藏状态、错误警告状态等表单项容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport type { FormInstance } from 'antdv-next'\nimport { computed, onMounted, shallowRef } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst formRef = shallowRef<FormInstance>()\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'help', desc: t('help'), version: '1.3.0' },\n  { name: 'helpItem', desc: t('helpItem'), version: '1.3.0' },\n  { name: 'extra', desc: t('extra'), version: '1.3.0' },\n])\n\nonMounted(() => {\n  formRef.value?.setFields?.([\n    {\n      name: 'password',\n      errors: ['Please input your password!', 'Use at least 8 characters.'],\n    },\n  ])\n})\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Form\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-form\n        ref=\"formRef\"\n        name=\"basic\"\n        :label-col=\"{ span: 8 }\"\n        :wrapper-col=\"{ span: 16 }\"\n        :style=\"{ maxWidth: '600px' }\"\n        :initial-values=\"{ remember: true }\"\n        autocomplete=\"off\"\n        :classes=\"classes\"\n      >\n        <a-form-item\n          label=\"Username\"\n          name=\"username\"\n          help=\"Use 4 to 16 characters.\"\n          :rules=\"[{ required: true, message: 'Please input your username!' }]\"\n        >\n          <a-input />\n        </a-form-item>\n        <a-form-item\n          label=\"Password\"\n          name=\"password\"\n          extra=\"Password must contain letters and numbers.\"\n          :rules=\"[\n            { required: true, message: 'Please input your password!' },\n            { min: 8, message: 'Use at least 8 characters.' },\n          ]\"\n        >\n          <a-input-password />\n        </a-form-item>\n      </a-form>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "label",
+          "description": "Label element with flex layout, overflow hidden, whitespace nowrap, text alignment, vertical alignment, plus label color, font size, height, required marks and other label display styles",
+          "descriptionZh": "标签元素，包含 flex 布局、溢出隐藏、文本不换行、文本对齐、垂直对齐，以及标签的颜色、字体大小、高度、必填标记等标签显示样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with form content area layout, styling and control container related styles",
+          "descriptionZh": "内容元素，包含表单内容区域的布局、样式和控件容器的相关样式"
+        },
+        {
+          "key": "help",
+          "description": "Help container element with spacing, motion, and presentation styles for help and validation areas",
+          "descriptionZh": "帮助信息容器元素，包含帮助文案与校验信息区域的间距、过渡与展示样式"
+        },
+        {
+          "key": "helpItem",
+          "description": "Single help message item with typography styles for prompt, error, and warning text",
+          "descriptionZh": "帮助信息单项元素，包含错误、警告与提示文案的排版样式"
+        },
+        {
+          "key": "extra",
+          "description": "Extra prompt container element with spacing, color, and typography styles for supplementary text",
+          "descriptionZh": "额外提示容器元素，包含补充说明文案的间距、颜色与排版样式"
         }
       ]
     },
@@ -10793,7 +11294,8 @@
           "descriptionZh": "使用 `useBreakpoint` Hook 实现个性化布局，其中 `xs` 仅当满足最小宽度时生效。",
           "code": "<script setup lang=\"ts\">\nimport { useBreakpoint } from 'antdv-next'\nimport { computed } from 'vue'\n\nconst screens = useBreakpoint()\nconst screenKeys = computed(() => Object.entries(screens.value ?? {}).filter(screen => !!screen[1]))\n</script>\n\n<template>\n  Current break point:\n  <div class=\"gap-2 inline-flex\">\n    <template v-for=\"item in screenKeys\" :key=\"item[0]\">\n      <a-tag color=\"blue\">\n        {{ item[0] }}\n      </a-tag>\n    </template>\n  </div>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Icon",
@@ -10856,7 +11358,8 @@
           "descriptionZh": "`scriptUrl` 可引用多个资源，用户可灵活的管理 [iconfont.cn](http://iconfont.cn/) 图标。如果资源的图标出现重名，会按照数组顺序进行覆盖。",
           "code": "<script setup lang=\"ts\">\nimport { createFromIconfontCN } from '@antdv-next/icons'\n\nconst IconFont = createFromIconfontCN({\n  scriptUrl: [\n    '//at.alicdn.com/t/font_1788044_0dwu4guekcwr.js', // icon-javascript, icon-java, icon-shoppingcart (overridden)\n    '//at.alicdn.com/t/font_1788592_a5xf2bdic3u.js', // icon-shoppingcart, icon-python\n  ],\n})\n</script>\n\n<template>\n  <a-space>\n    <IconFont type=\"icon-javascript\" />\n    <IconFont type=\"icon-java\" />\n    <IconFont type=\"icon-shoppingcart\" />\n    <IconFont type=\"icon-python\" />\n  </a-space>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Image",
@@ -11083,14 +11586,53 @@
           "description": "Nested in the modal.",
           "descriptionZh": "嵌套在弹框当中使用。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst show1 = ref(false)\nconst show2 = ref(false)\nconst show3 = ref(false)\n\nfunction handlePreviewGroupChange(current: number, prev: number) {\n  console.log(`current index: ${current}, prev index: ${prev}`)\n}\n</script>\n\n<template>\n  <a-button @click=\"show1 = true\">\n    showModal\n  </a-button>\n  <a-modal\n    v-model:open=\"show1\"\n    @cancel=\"show1 = false\"\n    @ok=\"show1 = false\"\n  >\n    <a-button @click=\"show2 = true\">\n      test2\n    </a-button>\n    <a-modal\n      v-model:open=\"show2\"\n      @cancel=\"show2 = false\"\n      @ok=\"show2 = false\"\n    >\n      <a-button @click=\"show3 = true\">\n        test3\n      </a-button>\n      <a-modal\n        v-model:open=\"show3\"\n        @cancel=\"show3 = false\"\n        @ok=\"show3 = false\"\n      >\n        <a-image\n          :width=\"200\"\n          alt=\"svg image\"\n          src=\"https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg\"\n        />\n        <a-divider />\n        <a-image-preview-group\n          :preview=\"{\n            onChange: handlePreviewGroupChange,\n          }\"\n        >\n          <a-image\n            :width=\"200\"\n            alt=\"svg image\"\n            src=\"https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg\"\n          />\n          <a-image\n            :width=\"200\"\n            src=\"https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg\"\n          />\n        </a-image-preview-group>\n      </a-modal>\n    </a-modal>\n  </a-modal>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets relative positioning and inline-block layout styles",
+          "descriptionZh": "根元素，设置相对定位和行内块布局样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { theme } from 'antdv-next'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'image', desc: t('image') },\n  { name: 'cover', desc: t('cover') },\n  { name: 'popup.root', desc: t('popup.root') },\n  { name: 'popup.mask', desc: t('popup.mask') },\n  { name: 'popup.body', desc: t('popup.body') },\n  { name: 'popup.footer', desc: t('popup.footer') },\n  { name: 'popup.actions', desc: t('popup.actions') },\n  { name: 'popup.close', desc: t('popup.close'), version: '1.3.0' },\n])\n\nconst { token } = theme.useToken()\nconst holderRef = ref<HTMLDivElement | null>(null)\n\nconst previewItems = [\n  'https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg',\n  'https://gw.alipayobjects.com/zos/antfincdn/aPkFc8Sj7n/method-draw-image.svg',\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Image\"\n    :padding=\"false\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical align=\"center\" :style=\"{ minHeight: '100%', width: '100%' }\">\n        <a-flex :style=\"{ padding: `${token.padding}px`, flex: 'none' }\" justify=\"center\">\n          <a-image\n            :width=\"200\"\n            src=\"https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png\"\n            :classes=\"classes\"\n          />\n        </a-flex>\n        <div ref=\"holderRef\" :style=\"{ flex: 1, position: 'relative', minHeight: '500px', width: '100%' }\">\n          <a-image-preview-group\n            :items=\"previewItems\"\n            :classes=\"classes\"\n            :styles=\"{ popup: { root: { position: 'absolute' } } }\"\n            :preview=\"{ getContainer: () => holderRef!, open: true, focusTrap: false }\"\n          />\n        </div>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "image",
+          "description": "Image element, sets width, height and vertical alignment styles",
+          "descriptionZh": "图片元素，设置宽度、高度和垂直对齐样式"
+        },
+        {
+          "key": "cover",
+          "description": "Image hover display prompt element, sets absolute positioning, background color, opacity and transition animation styles",
+          "descriptionZh": "悬浮图片显示的提示元素，设置绝对定位、背景色、透明度和过渡动画样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Preview root element, sets fixed positioning, z-index and background mask styles",
+          "descriptionZh": "预览根元素，设置固定定位、层级和背景遮罩样式"
+        },
+        {
+          "key": "popup.mask",
+          "description": "Preview mask element, sets absolute positioning and semi-transparent background styles",
+          "descriptionZh": "预览遮罩元素，设置绝对定位和半透明背景样式"
+        },
+        {
+          "key": "popup.body",
+          "description": "Preview body element, sets flex layout, center alignment and pointer event styles",
+          "descriptionZh": "预览内容元素，设置flex布局、居中对齐和指针事件样式"
+        },
+        {
+          "key": "popup.footer",
+          "description": "Preview footer element, sets absolute positioning, center layout and bottom operation area styles",
+          "descriptionZh": "预览页脚元素，设置绝对定位、居中布局和底部操作区域样式"
+        },
+        {
+          "key": "popup.actions",
+          "description": "Preview actions group element, sets flex layout, background color, border radius and action button styles",
+          "descriptionZh": "预览操作组元素，设置flex布局、背景色、圆角和操作按钮样式"
+        },
+        {
+          "key": "popup.close",
+          "description": "Preview close button element, sets basic button styles",
+          "descriptionZh": "预览关闭按钮元素，设置按钮的基础样式"
         }
       ]
     },
@@ -11839,46 +12381,73 @@
           "description": "You can customize the [semantic dom](#semantic-input) style of Input by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Input 的[语义化结构](#semantic-input)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { InputOTPProps, InputPasswordProps, InputProps, InputSearchProps, TextAreaProps } from 'antdv-next'\n\nconst classes: InputProps['classes'] = {\n  root: 'effect',\n}\n\nconst stylesFn: InputProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      root: {\n        borderColor: '#696FC7',\n      },\n    } satisfies InputProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnTextArea: TextAreaProps['styles'] = (info) => {\n  if (info.props.showCount) {\n    return {\n      root: { borderColor: '#BDE3C3' },\n      textarea: { resize: 'none' },\n      count: { color: '#BDE3C3' },\n    } satisfies TextAreaProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnPassword: InputPasswordProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      root: {\n        borderColor: '#F5D3C4',\n      },\n    } satisfies InputPasswordProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnOTP: InputOTPProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      root: {\n        borderWidth: 0,\n      },\n      input: {\n        borderColor: '#6E8CFB',\n        width: '32px',\n      },\n    } satisfies InputOTPProps['styles']\n  }\n  return {}\n}\n\nconst stylesFnSearch: InputSearchProps['styles'] = (info) => {\n  if (info.props.size === 'large') {\n    return {\n      root: { color: '#4DA8DA', borderWidth: 0 },\n      input: { color: '#4DA8DA', borderColor: '#4DA8DA' },\n      prefix: { color: '#4DA8DA' },\n      suffix: { color: '#4DA8DA' },\n      count: { color: '#4DA8DA' },\n      button: {\n        root: { color: '#4DA8DA', borderColor: '#4DA8DA' },\n        icon: { color: '#4DA8DA' },\n      },\n    } satisfies InputSearchProps['styles']\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-input :classes=\"classes\" placeholder=\"Object\" name=\"input-object\" />\n    <a-input :classes=\"classes\" :styles=\"stylesFn\" placeholder=\"Function\" size=\"middle\" name=\"input-fn\" />\n    <a-textarea :classes=\"classes\" :styles=\"stylesFnTextArea\" placeholder=\"Textarea\" show-count name=\"textarea-fn\" />\n    <a-input-password :classes=\"classes\" :styles=\"stylesFnPassword\" placeholder=\"Password\" size=\"middle\" name=\"password-fn\" />\n    <a-input-otp :classes=\"classes\" :styles=\"stylesFnOTP\" size=\"middle\" :length=\"6\" separator=\"*\" name=\"otp-fn\" />\n    <a-input-search :classes=\"classes\" :styles=\"stylesFnSearch\" placeholder=\"Search\" size=\"large\" name=\"search-fn\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-block display, width, min-width, padding, colors, fonts, line-height, border-radius, transitions and other input container basic styles",
+          "descriptionZh": "根元素，包含相对定位、行内块布局、宽度、最小宽度、内边距、颜色、字体、行高、圆角、过渡动画等输入框容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'count', desc: t('count') },\n  { name: 'clear', desc: t('clear'), version: '1.3.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Input\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-input\n          default-value=\"Hello, Antdv-Next\"\n          show-count\n          allow-clear\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <UserOutlined />\n          </template>\n          <template #suffix>\n            <EditOutlined />\n          </template>\n        </a-input>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "input",
+          "description": "Input element with core interactive styles and text input related styling",
+          "descriptionZh": "输入框元素，包含输入框的核心交互样式和文本输入相关的样式"
         },
         {
-          "name": "_semantic-textarea",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('TextAreaRoot') },\n  { name: 'textarea', desc: t('textarea') },\n  { name: 'count', desc: t('TextAreaCount') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"TextArea\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-textarea\n          default-value=\"Hello, Antdv-Next\"\n          :maxlength=\"100\"\n          show-count\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix wrapper element with layout and styling for prefix content",
+          "descriptionZh": "前缀的包裹元素，包含前缀内容的布局和样式"
         },
         {
-          "name": "_semantic-search",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'count', desc: t('count') },\n  { name: 'button.root', desc: t('button.root') },\n  { name: 'button.icon', desc: t('button.icon') },\n  { name: 'button.content', desc: t('button.content') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputSearch\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-input-search\n          default-value=\"Hello, Antdv-Next\"\n          enter-button=\"Searching...\"\n          loading\n          show-count\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <UserOutlined />\n          </template>\n          <template #suffix>\n            <EditOutlined />\n          </template>\n        </a-input-search>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "suffix",
+          "description": "Suffix wrapper element with layout and styling for suffix content",
+          "descriptionZh": "后缀的包裹元素，包含后缀内容的布局和样式"
         },
         {
-          "name": "_semantic-password",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { EditOutlined, UserOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'count', desc: t('count') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputPassword\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div style=\"width: 100%\">\n        <a-input-password\n          default-value=\"Hello, Antdv-Next\"\n          show-count\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <UserOutlined />\n          </template>\n          <template #suffix>\n            <EditOutlined />\n          </template>\n        </a-input-password>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "count",
+          "description": "Character count element with font and color styles for count display",
+          "descriptionZh": "文字计数元素，包含字符计数显示的字体和颜色样式"
         },
         {
-          "name": "_semantic-otp",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'input', desc: t('input') },\n  { name: 'separator', desc: t('OTPSeparator') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputOTP\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-input-otp\n        :length=\"6\"\n        separator=\"-\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "clear",
+          "description": "Clear button element with color, size, hover state and transition animation styles",
+          "descriptionZh": "清除按钮元素，包含清除按钮的颜色、尺寸、悬浮态和过渡动画等样式"
+        },
+        {
+          "key": "TextAreaRoot",
+          "description": "Root element with textarea wrapper styles, border, border radius, transition animation and state control",
+          "descriptionZh": "根元素，设置文本域包装器的样式、边框、圆角、过渡动画和状态控制"
+        },
+        {
+          "key": "textarea",
+          "description": "Textarea element with font, line height, padding, color, background, border, text input and multi-line text display styles",
+          "descriptionZh": "文本域元素，设置字体、行高、内边距、颜色、背景、边框、文本输入和多行文本展示样式"
+        },
+        {
+          "key": "TextAreaCount",
+          "description": "Count element with character count display position, font, color and numeric statistics styles",
+          "descriptionZh": "文字计数元素，设置字符计数显示的位置、字体、颜色和数值统计样式"
+        },
+        {
+          "key": "button.root",
+          "description": "Search button root element with button styles, hover effects and click interactions",
+          "descriptionZh": "搜索按钮的根元素，设置按钮的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "button.icon",
+          "description": "Search button icon element with icon styles, hover effects and click interactions",
+          "descriptionZh": "搜索按钮的图标元素，设置图标的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "button.content",
+          "description": "Search button content element with text styles, hover effects and click interactions",
+          "descriptionZh": "搜索按钮的内容元素，设置文本的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "OTPSeparator",
+          "description": "Separator element, set separator display styles between OTP input boxes",
+          "descriptionZh": "分隔符元素，设置OTP输入框之间的分隔符显示样式"
         }
       ]
     },
@@ -12460,14 +13029,38 @@
           "description": "Suffix with form feedback debug.",
           "descriptionZh": "带反馈图标时展示后缀 Debug。",
           "code": "<script setup lang=\"ts\">\n</script>\n\n<template>\n  <a-form layout=\"vertical\" :style=\"{ maxWidth: '320px' }\">\n    <a-form-item label=\"Suffix with feedback\" validate-status=\"success\" has-feedback>\n      <a-input-number :default-value=\"100\" suffix=\"RMB\" :style=\"{ width: '100%' }\" />\n    </a-form-item>\n  </a-form>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets inline-block layout, width, border radius and reset styles",
+          "descriptionZh": "根元素，设置行内块布局、宽度、边框圆角和重置样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'actions', desc: t('actions') },\n  { name: 'action', desc: t('action') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"InputNumber\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ display: 'flex', flexDirection: 'column', gap: '16px' }\">\n        <a-input-number\n          prefix=\"￥\"\n          suffix=\"RMB\"\n          :default-value=\"100\"\n          :style=\"{ width: '200px' }\"\n          :styles=\"{ actions: { opacity: 1, width: '24px' }, suffix: { marginRight: '28px' } }\"\n          :classes=\"classes\"\n        />\n        <a-input-number\n          :default-value=\"100\"\n          :style=\"{ width: '200px' }\"\n          :styles=\"{ actions: { opacity: 1, width: '24px' }, suffix: { marginRight: '28px' } }\"\n          mode=\"spinner\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "input",
+          "description": "Input element, sets font, line height, text input and interaction styles",
+          "descriptionZh": "输入框元素，设置字体、行高、文本输入和交互样式"
+        },
+        {
+          "key": "prefix",
+          "description": "Prefix wrapper element, sets flex layout, alignment and right margin styles",
+          "descriptionZh": "前缀的包裹元素，设置flex布局、对齐方式和右边距样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix wrapper element, sets flex layout, margin and transition animation styles",
+          "descriptionZh": "后缀的包裹元素，设置flex布局、边距和过渡动画样式"
+        },
+        {
+          "key": "action",
+          "description": "Single action button element, sets button styling, hover effects and click interactions",
+          "descriptionZh": "单个操作按钮元素，设置按钮的样式、悬浮效果和点击交互"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element, sets absolute positioning, width, flex layout and number adjustment button styles",
+          "descriptionZh": "操作元素，设置绝对定位、宽度、flex布局和数值调节按钮样式"
         }
       ]
     },
@@ -12805,7 +13398,8 @@
           "descriptionZh": "当内容较长时，使用固定侧边栏可以提供更好的体验。",
           "code": "<script setup lang=\"ts\">\nimport type { MenuItemType } from 'antdv-next'\nimport type { CSSProperties } from 'vue'\nimport {\n  AppstoreOutlined,\n  BarChartOutlined,\n  CloudOutlined,\n  ShopOutlined,\n  TeamOutlined,\n  UploadOutlined,\n  UserOutlined,\n  VideoCameraOutlined,\n} from '@antdv-next/icons'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\nconst year = new Date().getFullYear()\n\nconst siderStyle: CSSProperties = {\n  overflow: 'auto',\n  height: '100vh',\n  position: 'sticky',\n  insetInlineStart: 0,\n  top: 0,\n  scrollbarWidth: 'thin',\n  scrollbarGutter: 'stable',\n}\n\nconst items: MenuItemType[] = [\n  UserOutlined,\n  VideoCameraOutlined,\n  UploadOutlined,\n  BarChartOutlined,\n  CloudOutlined,\n  AppstoreOutlined,\n  TeamOutlined,\n  ShopOutlined,\n].map((icon, index) => ({\n  key: String(index + 1),\n  icon,\n  label: `nav ${index + 1}`,\n}))\n</script>\n\n<template>\n  <a-layout :has-sider=\"true\">\n    <a-layout-sider :style=\"siderStyle\">\n      <div class=\"demo-logo-vertical\" />\n      <a-menu\n        theme=\"dark\"\n        mode=\"inline\"\n        :default-selected-keys=\"['4']\"\n        :items=\"items\"\n      />\n    </a-layout-sider>\n    <a-layout>\n      <a-layout-header class=\"fixed-header\" :style=\"{ background: token.colorBgContainer }\" />\n      <a-layout-content class=\"fixed-content\">\n        <div\n          class=\"fixed-content-box\"\n          :style=\"{\n            background: token.colorBgContainer,\n            borderRadius: `${token.borderRadiusLG}px`,\n          }\"\n        >\n          <p>long content</p>\n          <template v-for=\"index in 100\" :key=\"index\">\n            {{ index % 20 === 0 && index !== 0 ? 'more' : '...' }}\n            <br>\n          </template>\n        </div>\n      </a-layout-content>\n      <a-layout-footer class=\"fixed-footer\">\n        Antdv Next ©{{ year }} Created by Ant UED\n      </a-layout-footer>\n    </a-layout>\n  </a-layout>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Listy",
@@ -12901,14 +13495,23 @@
           "description": "Customize the [semantic DOM](#semantic-dom) styles of Listy with `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 自定义 Listy 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { ListyProps } from 'antdv-next'\n\ninterface User {\n  id: number\n  name: string\n  team: string\n}\n\nconst users: User[] = [\n  { id: 0, name: 'Olivia', team: 'Design' },\n  { id: 1, name: 'Liam', team: 'Design' },\n  { id: 2, name: 'Emma', team: 'Design' },\n  { id: 3, name: 'Noah', team: 'Engineering' },\n  { id: 4, name: 'Ava', team: 'Engineering' },\n  { id: 5, name: 'Ethan', team: 'Engineering' },\n  { id: 6, name: 'Sophia', team: 'Marketing' },\n  { id: 7, name: 'Lucas', team: 'Marketing' },\n]\n\nconst classNames: ListyProps['classes'] = {\n  root: 'listy-custom-root',\n  groupHeader: 'listy-custom-group-header',\n}\n\nconst styles: ListyProps['styles'] = {\n  item: { fontStyle: 'italic' },\n}\n</script>\n\n<template>\n  <a-listy\n    :items=\"users\"\n    :row-key=\"(item: User) => item.id\"\n    :height=\"260\"\n    sticky\n    :group=\"{ key: (user: User) => user.team, title: (team: unknown) => team }\"\n    :item-render=\"(user: User) => user.name\"\n    :classes=\"classNames\"\n    :styles=\"styles\"\n  />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, the scroll container, with font and relative positioning",
+          "descriptionZh": "根元素，即滚动容器，设置字体与相对定位"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\ninterface User {\n  id: number\n  name: string\n  team: string\n}\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n  { name: 'groupHeader', desc: t('groupHeader') },\n])\n\nconst users: User[] = [\n  { id: 0, name: 'Olivia', team: 'Design' },\n  { id: 1, name: 'Liam', team: 'Design' },\n  { id: 2, name: 'Emma', team: 'Design' },\n  { id: 3, name: 'Noah', team: 'Engineering' },\n  { id: 4, name: 'Ava', team: 'Engineering' },\n  { id: 5, name: 'Ethan', team: 'Engineering' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Listy\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-listy\n        :items=\"users\"\n        :row-key=\"(item: User) => item.id\"\n        :height=\"260\"\n        sticky\n        :group=\"{ key: (user: User) => user.team, title: (team: unknown) => team }\"\n        :item-render=\"(user: User) => user.name\"\n        :classes=\"classes\"\n        style=\"width: 100%\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element, with padding, split line and hover background",
+          "descriptionZh": "条目元素，设置内间距、分割线与悬浮背景"
+        },
+        {
+          "key": "groupHeader",
+          "description": "Group header element, with sticky positioning and background color",
+          "descriptionZh": "分组标题元素，设置吸顶定位与背景色"
         }
       ]
     },
@@ -13032,14 +13635,18 @@
           "description": "When `fresh` is enabled, the masonry will continuously monitor size changes of child items and automatically re-layout. Click on cards to change their height.",
           "descriptionZh": "开启 `fresh` 属性后，瀑布流会持续监听子项的尺寸变化并自动重新布局。点击卡片可以改变其高度。",
           "code": "<script setup lang=\"ts\">\nimport { Card } from 'antdv-next'\nimport { defineComponent, h, ref } from 'vue'\n\nconst RandomHeightCard = defineComponent({\n  props: {\n    index: {\n      type: Number,\n      required: true,\n    },\n    defaultHeight: {\n      type: Number,\n      required: true,\n    },\n  },\n  setup(props) {\n    const height = ref(props.defaultHeight)\n\n    const handleClick = () => {\n      height.value = Math.floor(Math.random() * 100) + 50\n    }\n\n    return () =>\n      h(\n        Card,\n        {\n          size: 'small',\n          style: { height: `${height.value}px`, transition: 'height 0.3s' },\n          onClick: handleClick,\n        },\n        () => `${props.index + 1} - Click`,\n      )\n  },\n})\n\nconst heights = [150, 50, 90, 70, 110, 150, 130, 80, 50, 90, 100, 150, 60, 50, 80].map(\n  (height, index) => {\n    const item: {\n      key: string\n      data: number\n      column?: number\n    } = {\n      key: `item-${index}`,\n      data: height,\n    }\n\n    if (index === 4) {\n      item.column = 0\n    }\n\n    return item\n  },\n)\n</script>\n\n<template>\n  <a-masonry\n    fresh\n    :columns=\"4\"\n    :gutter=\"16\"\n    :items=\"heights\"\n  >\n    <template #itemRender=\"{ data, index }\">\n      <RandomHeightCard :index=\"index\" :default-height=\"data\" />\n    </template>\n  </a-masonry>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, sets relative positioning, flex layout and masonry container styles",
+          "descriptionZh": "根元素，设置相对定位、flex布局和瀑布流容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n])\n\nconst heights = [75, 50, 70, 60, 85, 75, 50].map((height, index) => ({\n  key: `item-${index}`,\n  data: height,\n}))\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Masonry\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-masonry\n        :columns=\"3\"\n        :gutter=\"16\"\n        :items=\"heights\"\n        style=\"width: 100%\"\n        :classes=\"classes\"\n      >\n        <template #itemRender=\"{ data, index }\">\n          <a-card size=\"small\" :style=\"{ height: data }\">\n            {{ index + 1 }}\n          </a-card>\n        </template>\n      </a-masonry>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element, sets absolute positioning, width calculation, transition animation and masonry item styles",
+          "descriptionZh": "条目元素，设置绝对定位、宽度计算、过渡动画和瀑布流项目样式"
         }
       ]
     },
@@ -13445,14 +14052,28 @@
           "description": "autoSize debug",
           "descriptionZh": "autoSize debug",
           "code": "<script setup lang=\"ts\">\nimport type { MentionsEmits, MentionsProps } from 'antdv-next'\n\nconst options: MentionsProps['options'] = [\n  {\n    value: 'afc163',\n    label: 'afc163',\n  },\n  {\n    value: 'zombieJ',\n    label: 'zombieJ',\n  },\n  {\n    value: 'yesmeck',\n    label: 'yesmeck',\n  },\n]\n\nconst handleChange: MentionsEmits['change'] = (value) => {\n  console.log('Change:', value)\n}\n\nconst handleSelect: MentionsEmits['select'] = (option) => {\n  console.log('select', option)\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-mentions\n      placeholder=\"can resize\"\n      :options=\"options\"\n      @change=\"handleChange\"\n      @select=\"handleSelect\"\n    />\n    <a-mentions\n      placeholder=\"disable resize\"\n      :options=\"options\"\n      :style=\"{ resize: 'none' }\"\n      @change=\"handleChange\"\n      @select=\"handleSelect\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set inline flex layout, relative positioning, padding and border styles",
+          "descriptionZh": "根元素，设置行内flex布局、相对定位、内边距和边框样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'textarea', desc: t('textarea'), version: '1.0.0' },\n  { name: 'suffix', desc: t('suffix'), version: '1.0.0' },\n  { name: 'popup', desc: t('popup'), version: '1.0.0' },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst options = [\n  { value: 'afc163', label: 'afc163' },\n  { value: 'zombieJ', label: 'zombieJ' },\n  { value: 'thinkasany', label: 'thinkasany' },\n  { value: 'meet-student', label: 'meet-student' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Mentions\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <a-mentions\n          placement=\"bottom\"\n          :style=\"{ width: '100%' }\"\n          value=\"Hi, @\"\n          allow-clear\n          open\n          :get-popup-container=\"() => divRef!\"\n          :options=\"options\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "textarea",
+          "description": "Textarea element, set font, line height, text input and background styles",
+          "descriptionZh": "文本域元素，设置字体、行高、文本输入和背景样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup element, set absolute positioning, z-index, background color, border radius, shadow and dropdown options styles",
+          "descriptionZh": "弹出框元素，设置绝对定位、层级、背景色、圆角、阴影和下拉选项样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with layout and styling for suffix content like clear button, etc.",
+          "descriptionZh": "后缀元素，包含后缀内容的布局和样式，如清除按钮等"
         }
       ]
     },
@@ -14194,14 +14815,68 @@
           "description": "Use the `popupRender` prop to customize submenu popup rendering.",
           "descriptionZh": "使用 `popupRender` 属性自定义弹出菜单的渲染。",
           "code": "<script setup lang=\"ts\">\nimport type { MenuItemType, MenuProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\nimport { computed, h } from 'vue'\n\nconst { token } = theme.useToken()\n\nconst popupStyle = computed(() => ({\n  padding: `${token.value.padding}px`,\n  minWidth: '480px',\n  background: token.value.colorBgElevated,\n  borderRadius: `${token.value.borderRadiusLG}px`,\n  boxShadow: token.value.boxShadowSecondary,\n}))\n\nconst headerStyle = computed(() => ({\n  margin: 0,\n  paddingBottom: `${token.value.paddingXS}px`,\n  borderBottom: `1px solid ${token.value.colorSplit}`,\n}))\n\nconst cardStyle = computed(() => ({\n  padding: `${token.value.paddingSM}px`,\n}))\n\nconst cardItemStyle = computed(() => ({\n  borderRadius: `${token.value.borderRadius}px`,\n  transition: `all ${token.value.motionDurationSlow}`,\n  cursor: 'pointer',\n}))\n\nfunction renderMenuCard(title: string, description: string) {\n  return h('div', { class: 'menu-card', style: cardStyle.value }, [\n    h('div', { class: 'menu-card-title' }, title),\n    h('div', { class: 'menu-card-desc' }, description),\n  ])\n}\n\nconst menuItems = computed<MenuItemType[]>(() => [\n  {\n    key: 'home',\n    label: 'Home',\n  },\n  {\n    key: 'features',\n    label: 'Features',\n    children: [\n      {\n        key: 'getting-started',\n        label: renderMenuCard('Getting Started', 'Quick start guide and learn the basics.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n      {\n        key: 'components',\n        label: renderMenuCard('Components', 'Explore our component library.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n      {\n        key: 'templates',\n        label: renderMenuCard('Templates', 'Ready-to-use template designs.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n    ],\n  },\n  {\n    key: 'resources',\n    label: 'Resources',\n    children: [\n      {\n        key: 'blog',\n        label: renderMenuCard('Blog', 'Latest updates and articles.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n      {\n        key: 'community',\n        label: renderMenuCard('Community', 'Join our developer community.'),\n        class: 'menu-card-item',\n        style: cardItemStyle.value,\n      },\n    ],\n  },\n])\n\nconst popupRender: MenuProps['popupRender'] = (node, info) => {\n  const title = info.item.title || info.item.key\n  return h('div', { class: 'menu-popup', style: popupStyle.value }, [\n    h('div', { class: 'menu-popup-title', style: headerStyle.value }, title),\n    node,\n  ])\n}\n\nconst themeConfig = {\n  components: {\n    Menu: {\n      popupBg: '#fff',\n      horizontalItemSelectedColor: '#1677ff',\n      horizontalItemHoverColor: '#1677ff',\n    },\n  },\n}\n</script>\n\n<template>\n  <a-config-provider :theme=\"themeConfig\">\n    <a-menu mode=\"horizontal\" :items=\"menuItems\" :popup-render=\"popupRender\" />\n  </a-config-provider>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with basic menu container styles and layout",
+          "descriptionZh": "根元素，包含菜单容器的基础样式和布局"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AppstoreOutlined, MailOutlined } from '@antdv-next/icons'\nimport { computed, h, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst mode = ref<'horizontal' | 'vertical' | 'inline'>('horizontal')\nconst current = ref('mail')\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst semantics = computed(() => {\n  const baseLocale = [\n    { name: 'root', desc: t('root') },\n    { name: 'item', desc: t('item') },\n    { name: 'itemIcon', desc: t('itemIcon') },\n    { name: 'itemContent', desc: t('itemContent') },\n  ]\n  const subMenuLocale = [\n    { name: 'subMenu.itemTitle', desc: t('subMenu.itemTitle') },\n    { name: 'subMenu.list', desc: t('subMenu.list') },\n    { name: 'subMenu.item', desc: t('subMenu.item') },\n    { name: 'subMenu.itemIcon', desc: t('subMenu.itemIcon') },\n    { name: 'subMenu.itemContent', desc: t('subMenu.itemContent') },\n  ]\n  const groupLocale = [\n    { name: 'itemTitle', desc: t('itemTitle') },\n    { name: 'list', desc: t('list') },\n  ]\n\n  const additionalPopupLocale = mode.value !== 'inline' ? [{ name: 'popup', desc: t('popup') }] : []\n  const additionalGroupLocale = mode.value !== 'horizontal' ? groupLocale : []\n\n  return [...baseLocale, ...additionalGroupLocale, ...additionalPopupLocale, ...subMenuLocale]\n})\n\nconst items = [\n  { label: 'Navigation One', key: 'mail', icon: h(MailOutlined) },\n  {\n    key: 'SubMenu',\n    label: 'Navigation Two',\n    icon: h(AppstoreOutlined),\n    children: [\n      {\n        key: 'g1',\n        label: 'Item 1',\n        type: 'group',\n        children: [\n          { key: '1', label: 'Option 1', icon: h(MailOutlined) },\n          { key: '2', label: 'Option 2' },\n        ],\n      },\n    ],\n  },\n]\n\nconst groupItem = [\n  {\n    key: 'grp',\n    label: 'Navigation Three',\n    type: 'group',\n    children: [\n      { key: '3', label: 'Option 3' },\n      { key: '4', label: 'Option 4' },\n    ],\n  },\n]\n\nconst itemList = computed(() => {\n  return mode.value === 'horizontal' ? items : [...items, ...groupItem]\n})\n\nfunction onClick(e: { key: string }) {\n  current.value = e.key\n}\n\nfunction getPopupContainer() {\n  const el = ((divRef.value as any)?.$el ?? divRef.value) as HTMLElement | null\n  return el?.parentElement?.parentElement || el!\n}\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Menu\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" vertical gap=\"middle\" align=\"center\">\n        <a-segmented\n          :options=\"['horizontal', 'vertical', 'inline']\"\n          :value=\"mode\"\n          @change=\"(val: 'horizontal' | 'vertical' | 'inline') => mode = val\"\n        />\n        <div :style=\"{ height: '360px' }\">\n          <a-menu\n            :selected-keys=\"[current]\"\n            :mode=\"mode\"\n            :items=\"itemList\"\n            :styles=\"{\n              root: { width: mode === 'horizontal' ? '480px' : '230px' },\n              popup: { root: { zIndex: 1 } },\n            }\"\n            :open-keys=\"['SubMenu']\"\n            :get-popup-container=\"getPopupContainer\"\n            :classes=\"classes\"\n            @click=\"onClick\"\n          />\n        </div>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with relative positioning, block display, margins, whitespace handling, cursor styles, transitions and other basic interactive styles for menu items",
+          "descriptionZh": "条目元素，包含相对定位、块级显示、外边距、空白符处理、光标样式、过渡动画等菜单项的基础交互样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Item content element with layout and typography styles for menu item content",
+          "descriptionZh": "条目内容元素，包含菜单项内容的布局和排版样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Icon element with min-width, font-size, transitions, icon reset styles, and spacing control with text",
+          "descriptionZh": "图标元素，包含最小宽度、字体大小、过渡动画、图标重置样式，以及与文本的间距控制"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Item title element (no effect in horizontal mode) with title text styles and layout",
+          "descriptionZh": "菜单标题元素(horizontal 模式不生效)，包含标题文字的样式和布局"
+        },
+        {
+          "key": "list",
+          "description": "Menu list element (no effect in horizontal mode) with menu list layout and container styles",
+          "descriptionZh": "菜单列表元素(horizontal 模式不生效)，包含菜单列表的布局和容器样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup menu element (no effect in inline mode) with popup layer positioning, z-index, background and other styles",
+          "descriptionZh": "弹出菜单(inline 模式不生效)，包含弹出层的定位、层级、背景等样式"
+        },
+        {
+          "key": "subMenu.itemTitle",
+          "description": "Submenu title element with submenu title styles and interactive effects",
+          "descriptionZh": "子菜单标题元素，包含子菜单标题的样式和交互效果"
+        },
+        {
+          "key": "subMenu.list",
+          "description": "Submenu list element with submenu list layout and container styles",
+          "descriptionZh": "子菜单列表元素，包含子菜单列表的布局和容器样式"
+        },
+        {
+          "key": "subMenu.item",
+          "description": "Submenu item element with submenu item styles and interactive effects",
+          "descriptionZh": "子菜单单项元素，包含子菜单项的样式和交互效果"
+        },
+        {
+          "key": "subMenu.itemIcon",
+          "description": "Submenu item icon element with submenu icon size and styles",
+          "descriptionZh": "子菜单条目图标元素，包含子菜单图标的尺寸和样式"
+        },
+        {
+          "key": "subMenu.itemContent",
+          "description": "Submenu item content element with submenu content layout and typography",
+          "descriptionZh": "子菜单条目内容元素，包含子菜单内容的布局和排版"
         }
       ]
     },
@@ -14323,14 +14998,38 @@
           "description": "Static methods cannot consume Context provided by `ConfigProvider`. When enable `layer`, they may also cause style errors. Please use hooks version or `App` provided instance first.",
           "descriptionZh": "静态方法无法消费 Context，不能动态响应 ConfigProvider 提供的各项配置，启用 `layer` 时还可能导致样式异常。请优先使用 hooks 版本或者 App 组件提供的 `message` 实例。",
           "code": "<script setup lang=\"ts\">\nimport { message } from 'antdv-next'\n\nfunction info() {\n  message.info('This is an info message')\n}\n</script>\n\n<template>\n  <a-button type=\"primary\" @click=\"info\">\n    Static Method\n  </a-button>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "list",
+          "description": "Message list root element, set positioning, z-index, width, scroll area and placement styles",
+          "descriptionZh": "消息列表根元素，设置定位、层级、宽度、滚动区域和位置样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { message } from 'antdv-next'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { _InternalListDoNotUseOrYouWillBeFired: InternalList } = message\n\nconst { t } = useComponentLocale(locales)\n\nconst previewListStyle = {\n  position: 'relative',\n  inset: 'auto',\n  width: '100%',\n  maxWidth: '100%',\n  height: 'auto',\n  padding: '24px',\n  overflow: 'visible',\n  transform: 'none',\n} as const\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'wrapper', desc: t('wrapper'), version: '1.3.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.3.0' },\n  { name: 'list', desc: t('list'), version: '1.3.0' },\n  { name: 'listContent', desc: t('listContent'), version: '1.3.0' },\n])\n\nconst items = computed(() => [\n  {\n    key: 'semantic-message-1',\n    content: 'Hello, Antdv Next!',\n    type: 'success' as const,\n    duration: false as const,\n  },\n  {\n    key: 'semantic-message-2',\n    content: 'Welcome back!',\n    type: 'info' as const,\n    duration: false as const,\n  },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Message\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <InternalList\n        :style=\"previewListStyle\"\n        :items=\"items\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "listContent",
+          "description": "Message list content element, set notice layout, gap and height transition styles",
+          "descriptionZh": "消息列表内容元素，设置消息项排列、间距和高度动画样式"
+        },
+        {
+          "key": "root",
+          "description": "Message item root element, set background color, border radius, shadow, padding and animation styles",
+          "descriptionZh": "消息项根元素，设置背景色、圆角、阴影、内边距和动画样式"
+        },
+        {
+          "key": "wrapper",
+          "description": "Wrapper element for icon and title, set content layout, gap and alignment styles",
+          "descriptionZh": "图标与标题的包裹元素，设置内容布局、间距和对齐样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element, set font size, line height and status color styles",
+          "descriptionZh": "图标元素，设置字体大小、行高和状态颜色样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element, set text color, font size, line height and content display styles",
+          "descriptionZh": "标题元素，设置文本颜色、字号、行高和内容展示样式"
         }
       ]
     },
@@ -14895,14 +15594,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Modal by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Modal 组件的 [语义化结构](#semantic-dom) 样式。",
           "code": "<script setup lang=\"ts\">\nimport type { ModalProps } from 'antdv-next'\nimport { computed, ref } from 'vue'\n\nconst modalOpen = ref(false)\nconst modalFnOpen = ref(false)\n\nconst lineStyle = {\n  lineHeight: '28px',\n}\n\nconst classNames = computed(() => ({\n  container: 'custom-modal-container',\n}))\n\nconst styles: ModalProps['styles'] = {\n  mask: {\n    backgroundImage: `linear-gradient(to top, #18181b 0, rgba(21, 21, 22, 0.2) 100%)`,\n  },\n}\n\nconst stylesFn: ModalProps['styles'] = {\n  container: {\n    borderRadius: '14px',\n    border: '1px solid #ccc',\n    padding: '0',\n    overflow: 'hidden',\n  },\n  header: {\n    padding: '16px',\n  },\n  body: {\n    padding: '16px',\n  },\n  footer: {\n    padding: '16px 10px',\n    backgroundColor: '#fafafa',\n  },\n}\n\nconst sharedProps = computed<ModalProps>(() => ({\n  centered: true,\n  classes: classNames.value,\n}))\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-button @click=\"modalOpen = true\">\n      Open Style Modal\n    </a-button>\n    <a-button type=\"primary\" @click=\"modalFnOpen = true\">\n      Open Function Modal\n    </a-button>\n\n    <a-modal\n      v-bind=\"sharedProps\"\n      v-model:open=\"modalOpen\"\n      :footer=\"null\"\n      title=\"Custom Style Modal\"\n      :styles=\"styles\"\n    >\n      <div :style=\"lineStyle\">\n        Following the Ant Design specification, we developed a React UI library antd that contains a\n        set of high quality components and demos for building rich, interactive user interfaces.\n      </div>\n      <div :style=\"lineStyle\">\n        🌈 Enterprise-class UI designed for web applications.\n      </div>\n      <div :style=\"lineStyle\">\n        📦 A set of high-quality React components out of the box.\n      </div>\n      <div :style=\"lineStyle\">\n        🛡 Written in TypeScript with predictable static types.\n      </div>\n      <div :style=\"lineStyle\">\n        ⚙️ Whole package of design resources and development tools.\n      </div>\n      <div :style=\"lineStyle\">\n        🌍 Internationalization support for dozens of languages.\n      </div>\n      <div :style=\"lineStyle\">\n        🎨 Powerful theme customization in every detail.\n      </div>\n    </a-modal>\n\n    <a-modal\n      v-bind=\"sharedProps\"\n      v-model:open=\"modalFnOpen\"\n      title=\"Custom Function Modal\"\n      :styles=\"stylesFn\"\n      :mask=\"{ enabled: true, blur: true }\"\n    >\n      <div :style=\"lineStyle\">\n        Following the Ant Design specification, we developed a React UI library antd that contains a\n        set of high quality components and demos for building rich, interactive user interfaces.\n      </div>\n      <div :style=\"lineStyle\">\n        🌈 Enterprise-class UI designed for web applications.\n      </div>\n      <div :style=\"lineStyle\">\n        📦 A set of high-quality React components out of the box.\n      </div>\n      <div :style=\"lineStyle\">\n        🛡 Written in TypeScript with predictable static types.\n      </div>\n      <div :style=\"lineStyle\">\n        ⚙️ Whole package of design resources and development tools.\n      </div>\n      <div :style=\"lineStyle\">\n        🌍 Internationalization support for dozens of languages.\n      </div>\n      <div :style=\"lineStyle\">\n        🎨 Powerful theme customization in every detail.\n      </div>\n      <template #footer>\n        <a-button\n          :style=\"{ borderColor: '#ccc', color: '#171717', backgroundColor: '#fff' }\"\n          @click=\"modalFnOpen = false\"\n        >\n          Cancel\n        </a-button>\n        <a-button\n          type=\"primary\"\n          :style=\"{ backgroundColor: '#171717' }\"\n          @click=\"modalOpen = true\"\n        >\n          Submit\n        </a-button>\n      </template>\n    </a-modal>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, top position, width, max-width, margins, bottom padding and other basic layout styles for modal container",
+          "descriptionZh": "根元素，包含相对定位、顶部位置、宽度、最大宽度、外边距、底部内边距等模态框容器的基础布局样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'mask', desc: t('mask'), version: '1.0.0' },\n  { name: 'container', desc: t('container'), version: '1.0.0' },\n  { name: 'wrapper', desc: t('wrapper'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.3.0' },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Modal\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', inset: 0 }\">\n        <a-modal\n          title=\"Title\"\n          open\n          :get-container=\"() => divRef!\"\n          :width=\"400\"\n          :styles=\"{\n            mask: { position: 'absolute', zIndex: 1 },\n            wrapper: { position: 'absolute', zIndex: 1 },\n          }\"\n          :style=\"{ top: '50%', transform: 'translateY(-50%)', marginBottom: 0, paddingBottom: 0 }\"\n          :classes=\"classes\"\n        >\n          <p>Some contents...</p>\n        </a-modal>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "mask",
+          "description": "Mask element with fixed positioning, z-index, background color, animation transitions and other mask layer styles",
+          "descriptionZh": "遮罩层元素，包含固定定位、层级、背景色、动画过渡等遮罩层的样式"
+        },
+        {
+          "key": "wrapper",
+          "description": "Wrapper element used for motion container with animation and transition effect styles",
+          "descriptionZh": "包裹层元素，一般用于动画容器，包含动画和过渡效果的样式"
+        },
+        {
+          "key": "container",
+          "description": "Modal container element with relative positioning, background, background-clip, border, border-radius, box-shadow, pointer-events, padding and other modal body styles",
+          "descriptionZh": "Modal 容器元素，包含相对定位、背景色、背景裁剪、边框、圆角、阴影、指针事件、内边距等模态框主体样式"
+        },
+        {
+          "key": "header",
+          "description": "Header element with padding, bottom border and other header area styles",
+          "descriptionZh": "头部元素，包含头部内边距、下边框等头部区域样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with margin, color, font-weight, font-size, line-height, word-wrap and other title text styles",
+          "descriptionZh": "标题元素，包含外边距、颜色、字体权重、字体大小、行高、文字换行等标题文字样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with content area background color, padding and other content display styles",
+          "descriptionZh": "内容元素，包含内容区域的背景色、内边距等内容展示样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with footer background color, padding, top border, border-radius and other footer area styles",
+          "descriptionZh": "底部元素，包含底部的背景色、内边距、上边框、圆角等底部区域样式"
+        },
+        {
+          "key": "close",
+          "description": "Close button element with base button styles, positioning and interaction effects",
+          "descriptionZh": "关闭按钮元素，包含按钮基础样式、位置和交互效果"
         }
       ]
     },
@@ -15088,14 +15826,63 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Notification by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义通知的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { CSSProperties } from 'vue'\nimport { notification } from 'antdv-next'\n\nconst [api, ContextHolder] = notification.useNotification()\n\nconst defaultStyles: Record<string, CSSProperties> = {\n  root: {\n    backgroundColor: '#f6ffed',\n    border: '2px solid #95de64',\n    borderRadius: '16px',\n    boxShadow: '4px 4px 0 #d9f7be',\n  },\n  icon: {\n    color: '#237804',\n  },\n  title: {\n    color: '#237804',\n    fontWeight: 600,\n  },\n  description: {\n    color: '#3f6600',\n  },\n}\n\nfunction styleFn(info: { props: any }): Record<string, CSSProperties> {\n  if (info.props.type === 'error') {\n    return {\n      ...defaultStyles,\n      root: {\n        ...defaultStyles.root,\n        backgroundColor: '#fff2f0',\n        borderColor: '#ffccc7',\n        boxShadow: '4px 4px 0 #ffccc7',\n      },\n      icon: {\n        color: '#cf1322',\n      },\n      title: {\n        color: '#cf1322',\n      },\n      description: {\n        color: '#5c0011',\n      },\n    }\n  }\n  return defaultStyles\n}\n\nconst sharedProps = {\n  title: 'Notification Title',\n  description: 'This is a notification description.',\n  duration: false as const,\n}\n\nfunction openDefault() {\n  api.info({\n    ...sharedProps,\n    styles: defaultStyles,\n  })\n}\n\nfunction openError() {\n  api.error({\n    ...sharedProps,\n    type: 'error',\n    styles: styleFn as any,\n  })\n}\n</script>\n\n<template>\n  <ContextHolder />\n  <a-space>\n    <a-button type=\"primary\" @click=\"openDefault\">\n      Default Notification\n    </a-button>\n    <a-button @click=\"openError\">\n      Error Notification\n    </a-button>\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "list",
+          "description": "Notification list root element, set positioning, z-index, width, scroll area and placement styles",
+          "descriptionZh": "通知列表根元素，设置定位、层级、宽度、滚动区域和位置样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { Button, notification } from 'antdv-next'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { _InternalListDoNotUseOrYouWillBeFired: InternalList } = notification\n\nconst { t } = useComponentLocale(locales)\n\nconst previewListStyle = {\n  position: 'relative',\n  inset: 'auto',\n  width: '432px',\n  maxWidth: '100%',\n  height: 'auto',\n  padding: '24px',\n  transform: 'none',\n} as const\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'wrapper', desc: t('wrapper'), version: '1.3.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.3.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.3.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n  { name: 'progress', desc: t('progress'), version: '1.3.0' },\n  { name: 'list', desc: t('list'), version: '1.3.0' },\n  { name: 'listContent', desc: t('listContent'), version: '1.3.0' },\n])\n\nconst items = computed(() => [\n  {\n    key: 'semantic-notification-1',\n    title: 'Hello World!',\n    description: 'Hello World?',\n    type: 'success' as const,\n    duration: false as const,\n    actions: h(Button, { type: 'primary', size: 'small' }, () => 'My Button'),\n  },\n  {\n    key: 'semantic-notification-2',\n    title: 'Welcome back!',\n    description: 'This is another notification.',\n    type: 'info' as const,\n    duration: 999999,\n    showProgress: true,\n  },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Notification\"\n    :height=\"320\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <InternalList\n        placement=\"topRight\"\n        :style=\"previewListStyle\"\n        :items=\"items\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "listContent",
+          "description": "Notification list content element, set notice layout, gap and height transition styles",
+          "descriptionZh": "通知列表内容元素，设置通知项排列、间距和高度动画样式"
+        },
+        {
+          "key": "root",
+          "description": "Notice root element, set background color, border radius, shadow, padding and animation styles",
+          "descriptionZh": "通知项根元素，设置背景色、圆角、阴影、内边距和动画样式"
+        },
+        {
+          "key": "wrapper",
+          "description": "Wrapper element for icon and content with content layout styles",
+          "descriptionZh": "图标与内容的包裹元素，设置内容布局样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element, set absolute positioning, font size, line height and status color styles",
+          "descriptionZh": "图标元素，设置绝对定位、字体大小、行高和状态颜色样式"
+        },
+        {
+          "key": "section",
+          "description": "Content section element that contains title and description",
+          "descriptionZh": "内容区域元素，包含标题和描述内容"
+        },
+        {
+          "key": "title",
+          "description": "Title element, set color, font size, line height and margin styles",
+          "descriptionZh": "标题元素，设置颜色、字体大小、行高和外边距样式"
+        },
+        {
+          "key": "description",
+          "description": "Description element, set font size, color and margin styles",
+          "descriptionZh": "描述元素，设置字体大小、颜色和外边距样式"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element, set float right, top margin and action button layout styles",
+          "descriptionZh": "操作组元素，设置右浮动、上边距和操作按钮布局样式"
+        },
+        {
+          "key": "close",
+          "description": "Close button element, set position, size and interaction styles",
+          "descriptionZh": "关闭按钮元素，设置位置、尺寸和交互样式"
+        },
+        {
+          "key": "progress",
+          "description": "Progress element, set progress styles for auto-closing notifications",
+          "descriptionZh": "进度条元素，设置自动关闭通知的进度样式"
         }
       ]
     },
@@ -15114,7 +15901,8 @@
       "props": [],
       "tokens": [],
       "faq": [],
-      "demos": []
+      "demos": [],
+      "semanticStructure": []
     },
     {
       "name": "Pagination",
@@ -15552,14 +16340,18 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Pagination by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Pagination 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { PaginationProps } from 'antdv-next'\nimport { useCssModule } from 'vue'\n\nconst moduleStyles = useCssModule()\n\nconst classes: PaginationProps['classes'] = {\n  root: moduleStyles.root,\n}\n\nconst stylesObject: PaginationProps['styles'] = {\n  item: {\n    borderRadius: '999px',\n  },\n}\n\nconst stylesFn: PaginationProps['styles'] = ({ props }) => {\n  if (props.size === 'small') {\n    return {\n      item: {\n        backgroundColor: 'rgba(200, 200, 200, 0.3)',\n        marginInlineEnd: '4px',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-pagination :total=\"500\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-pagination :total=\"500\" size=\"small\" :classes=\"classes\" :styles=\"stylesFn\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set flex layout, alignment, flex wrap and list styles",
+          "descriptionZh": "根元素，设置flex布局、对齐方式、换行和列表样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Pagination\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-pagination :default-current=\"1\" :total=\"50\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element, set size, padding, border, background color, hover state and active state styles",
+          "descriptionZh": "页码元素，设置尺寸、内边距、边框、背景色、悬停态和激活态样式"
         }
       ]
     },
@@ -15771,14 +16563,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Popconfirm by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Popconfirm 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { PopconfirmProps } from 'antdv-next'\n\nconst classes: PopconfirmProps['classes'] = {\n  container: 'demo-popconfirm-container',\n}\n\nconst stylesObject: PopconfirmProps['styles'] = {\n  container: {\n    backgroundColor: '#eee',\n    boxShadow: 'inset 5px 5px 3px #fff, inset -5px -5px 3px #ddd, 0 0 3px rgba(0,0,0,0.2)',\n  },\n  title: {\n    color: '#262626',\n  },\n  content: {\n    color: '#262626',\n  },\n}\n\nconst stylesFn: PopconfirmProps['styles'] = (info) => {\n  if (info?.props?.arrow === false) {\n    return {\n      container: {\n        backgroundColor: 'rgba(53, 71, 125, 0.8)',\n        padding: '12px',\n        borderRadius: '4px',\n      },\n      title: {\n        color: '#fff',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-popconfirm\n      title=\"Object text\"\n      description=\"Object description\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    >\n      <a-button>Object Style</a-button>\n    </a-popconfirm>\n    <a-popconfirm\n      title=\"Function text\"\n      description=\"Function description\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n      :ok-button-props=\"{ styles: { root: { backgroundColor: 'rgba(53, 71, 125, 0.6)', color: '#fff' } } }\"\n      :cancel-button-props=\"{ styles: { root: { borderColor: 'rgba(53, 71, 125, 0.6)', backgroundColor: '#fff', color: 'rgba(53, 71, 125, 0.8)' } } }\"\n    >\n      <a-button type=\"primary\">\n        Function Style\n      </a-button>\n    </a-popconfirm>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set absolute positioning, z-index, transform origin, arrow direction and popover container styles",
+          "descriptionZh": "根元素，设置绝对定位、层级、变换原点、箭头指向和弹层容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'container', desc: t('container') },\n  { name: 'title', desc: t('title') },\n  { name: 'content', desc: t('content') },\n  { name: 'icon', desc: t('icon'), version: '1.3.0' },\n  { name: 'arrow', desc: t('arrow') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Popconfirm\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', marginTop: '60px' }\">\n        <a-popconfirm\n          open\n          placement=\"top\"\n          title=\"Confirm\"\n          description=\"Are you sure you want to perform this action?\"\n          :auto-adjust-overflow=\"false\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "arrow",
+          "description": "Arrow element with width, height, position, color and border styles",
+          "descriptionZh": "箭头元素，设置宽高、位置、颜色和边框样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element, set title text styles and spacing",
+          "descriptionZh": "标题元素，设置标题文本样式和间距"
+        },
+        {
+          "key": "content",
+          "description": "Description element, set content text styles and layout",
+          "descriptionZh": "描述元素，设置描述文本样式和布局"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element, set icon size, color and margin styles",
+          "descriptionZh": "图标元素，设置图标尺寸、颜色和外边距样式"
         }
       ]
     },
@@ -15982,14 +16798,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Popover by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Popover 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { PopoverProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: PopoverProps['classes'] = {\n  container: 'demo-popover-container',\n}\n\nconst stylesObject: PopoverProps['styles'] = {\n  container: {\n    backgroundColor: '#eee',\n    boxShadow: 'inset 5px 5px 3px #fff, inset -5px -5px 3px #ddd, 0 0 3px rgba(0,0,0,0.2)',\n  },\n  title: {\n    color: '#262626',\n  },\n  content: {\n    color: '#262626',\n  },\n}\n\nconst stylesFn: PopoverProps['styles'] = (info) => {\n  if (info?.props?.arrow === false) {\n    return {\n      container: {\n        backgroundColor: 'rgba(53, 71, 125, 0.8)',\n        padding: '12px',\n        borderRadius: '4px',\n      },\n      title: {\n        color: '#fff',\n      },\n      content: {\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-popover\n      content=\"Object text\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    >\n      <a-button>Object Style</a-button>\n    </a-popover>\n    <a-popover\n      content=\"Function text\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n    >\n      <a-button type=\"primary\">\n        Function Style\n      </a-button>\n    </a-popover>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set absolute positioning, z-index, transform origin, arrow direction and popover container styles",
+          "descriptionZh": "根元素，设置绝对定位、层级、变换原点、箭头指向和弹层容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'container', desc: t('container') },\n  { name: 'title', desc: t('title') },\n  { name: 'content', desc: t('content') },\n  { name: 'arrow', desc: t('arrow') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Popover\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', marginTop: '60px' }\">\n        <a-popover\n          open\n          placement=\"top\"\n          title=\"Hello\"\n          content=\"Ant Design love you!\"\n          :auto-adjust-overflow=\"false\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "arrow",
+          "description": "Arrow element with width, height, position, color and border styles",
+          "descriptionZh": "箭头元素，设置宽高、位置、颜色和边框样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element, set title text styles and spacing",
+          "descriptionZh": "标题元素，设置标题文本样式和间距"
+        },
+        {
+          "key": "content",
+          "description": "Content element, set content text styles and layout",
+          "descriptionZh": "内容元素，设置内容文本样式和布局"
         }
       ]
     },
@@ -16292,14 +17127,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Progress by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Progress 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { ProgressProps } from 'antdv-next'\n\nconst classes: ProgressProps['classes'] = {\n  root: 'demo-progress-root',\n  rail: 'demo-progress-rail',\n  track: 'demo-progress-track',\n}\n\nconst stylesFn: ProgressProps['styles'] = (info) => {\n  const percent = info?.props?.percent ?? 0\n  const hue = 200 - (200 * percent) / 100\n  return {\n    track: {\n      backgroundImage: `\n        linear-gradient(\n          to right,\n          hsla(${hue}, 85%, 65%, 1),\n          hsla(${hue + 30}, 90%, 55%, 0.95)\n        )`,\n      borderRadius: 8,\n      transition: 'all 0.3s ease',\n    },\n    rail: {\n      backgroundColor: 'rgba(0, 0, 0, 0.1)',\n      borderRadius: 8,\n    },\n  } as ProgressProps['styles']\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"10\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"20\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"40\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"60\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"80\" />\n    <a-progress :classes=\"classes\" :styles=\"stylesFn\" :percent=\"99\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set relative positioning and basic container styles",
+          "descriptionZh": "根元素，设置相对定位和基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'body', desc: t('body') },\n  { name: 'rail', desc: t('rail') },\n  { name: 'track', desc: t('track') },\n  { name: 'indicator', desc: t('indicator') },\n])\n\nconst gradient = ref(false)\nconst type = ref('line')\n\nconst colorMap = {\n  '0%': '#108ee9',\n  '100%': '#87d068',\n}\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Progress\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical gap=\"middle\" :style=\"{ width: '100%' }\" align=\"center\">\n        <a-flex align=\"center\" gap=\"middle\">\n          <a-segmented\n            :options=\"['line', 'steps', 'circle', 'dashboard']\"\n            :value=\"type\"\n            @change=\"(val: string) => type = val\"\n          />\n          <a-switch\n            :checked=\"gradient\"\n            checked-children=\"Gradient\"\n            un-checked-children=\"Gradient\"\n            @change=\"(val: boolean) => gradient = val\"\n          />\n        </a-flex>\n        <a-flex vertical align=\"center\" :style=\"{ height: '200px', width: '100%' }\">\n          <a-progress\n            :percent=\"80\"\n            :type=\"type === 'steps' ? 'line' : type\"\n            :steps=\"type === 'steps' ? 5 : undefined\"\n            :stroke-color=\"gradient ? colorMap : undefined\"\n            :classes=\"classes\"\n          />\n        </a-flex>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "body",
+          "description": "Body element, set progress bar layout and size styles",
+          "descriptionZh": "主体元素，设置进度条的布局和尺寸样式"
+        },
+        {
+          "key": "rail",
+          "description": "Rail element, set background track color and border radius styles. Not exist in steps mode",
+          "descriptionZh": "导轨元素，设置背景轨道的颜色和圆角样式，steps 模式下没有该元素"
+        },
+        {
+          "key": "track",
+          "description": "Track element, set progress fill color and transition animation styles",
+          "descriptionZh": "轨迹元素，设置进度填充部分的颜色和过渡动画样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element, set percentage text or icon position and font styles",
+          "descriptionZh": "指示器元素，设置百分比文本或图标的位置和字体样式"
         }
       ]
     },
@@ -16520,14 +17374,18 @@
           "description": "With Popover.",
           "descriptionZh": "带气泡卡片的例子。",
           "code": "<script setup lang=\"ts\">\ndefineOptions({ name: 'Popover' })\n</script>\n\n<template>\n  <a-popover>\n    <template #content>\n      <a-qrcode value=\"https://ant.design\" :bordered=\"false\" />\n    </template>\n    <a-button type=\"primary\">\n      Hover me\n    </a-button>\n  </a-popover>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element, set flex layout, padding, background color, border, border radius and relative positioning styles",
+          "descriptionZh": "根元素，设置flex布局、内边距、背景色、边框、圆角和相对定位样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'cover', desc: t('cover') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"QRCode\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-qrcode value=\"https://ant.design\" status=\"loading\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "cover",
+          "description": "Cover element, set absolute positioning, z-index, background color and loading state overlay styles",
+          "descriptionZh": "遮罩层元素，设置绝对定位、层级、背景色和加载状态覆盖样式"
         }
       ]
     },
@@ -16929,14 +17787,23 @@
           "description": "Solid radio button style.",
           "descriptionZh": "实色填底的单选按钮样式。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst value = shallowRef('a')\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-radio-group v-model:value=\"value\" button-style=\"solid\">\n      <a-radio-button value=\"a\">\n        Hangzhou\n      </a-radio-button>\n      <a-radio-button value=\"b\">\n        Shanghai\n      </a-radio-button>\n      <a-radio-button value=\"c\">\n        Beijing\n      </a-radio-button>\n      <a-radio-button value=\"d\">\n        Chengdu\n      </a-radio-button>\n    </a-radio-group>\n    <a-radio-group v-model:value=\"value\" button-style=\"solid\">\n      <a-radio-button value=\"a\">\n        Hangzhou\n      </a-radio-button>\n      <a-radio-button value=\"b\" disabled>\n        Shanghai\n      </a-radio-button>\n      <a-radio-button value=\"c\">\n        Beijing\n      </a-radio-button>\n      <a-radio-button value=\"d\">\n        Chengdu\n      </a-radio-button>\n    </a-radio-group>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with layout styles, cursor styles, disabled text color and other basic container styles",
+          "descriptionZh": "根元素，包含布局样式、鼠标样式、禁用状态文字颜色等基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Radio\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-radio :classes=\"classes\">\n        Radio\n      </a-radio>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element with border radius, transition animations, border styles, hover states, focus states and other interactive styles",
+          "descriptionZh": "选中框元素，包含圆角样式、过渡动画、边框样式、悬停状态、焦点状态等交互样式"
+        },
+        {
+          "key": "label",
+          "description": "Label element with padding, text color, disabled states, alignment and other text styles",
+          "descriptionZh": "文本元素，包含内边距、文字颜色、禁用状态、对齐方式等文本样式"
         }
       ]
     },
@@ -17198,7 +18065,8 @@
           "descriptionZh": "调试使用。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst value = ref(2.5)\n</script>\n\n<template>\n  <a-config-provider\n    :theme=\"{\n      components: {\n        Rate: {\n          starColor: 'blue',\n          starSize: 40,\n          starHoverScale: 'scale(2)',\n          starBg: 'red',\n        },\n      },\n    }\"\n  >\n    <a-rate v-model:value=\"value\" allow-half />\n  </a-config-provider>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     },
     {
       "name": "Result",
@@ -17366,14 +18234,38 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Result by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Result 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { ResultProps } from 'antdv-next'\n\nconst classesObject: ResultProps['classes'] = {\n  root: 'demo-result-root',\n  title: 'demo-result-title',\n  subTitle: 'demo-result-subtitle',\n  icon: 'demo-result-icon',\n  extra: 'demo-result-extra',\n  body: 'demo-result-body',\n}\n\nconst classesFn: ResultProps['classes'] = (info) => {\n  if (info.props.status === 'success') {\n    return {\n      root: 'demo-result-root--success',\n    } satisfies ResultProps['classes']\n  }\n  return {\n    root: 'demo-result-root--default',\n  } satisfies ResultProps['classes']\n}\n\nconst stylesObject: ResultProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed', padding: '16px' },\n  title: { fontStyle: 'italic', color: '#1890ff' },\n  subTitle: { fontWeight: 'bold' },\n  icon: { opacity: 0.8 },\n  extra: { backgroundColor: '#f0f0f0', padding: 'px' },\n  body: { backgroundColor: '#fafafa', padding: '12px' },\n}\n\nconst stylesFn: ResultProps['styles'] = (info) => {\n  if (info.props.status === 'error') {\n    return {\n      root: { backgroundColor: '#fff2f0', borderColor: '#ff4d4f' },\n      title: { color: '#ff4d4f' },\n    } satisfies ResultProps['styles']\n  }\n  else {\n    return {\n      root: { backgroundColor: '#f6ffed', borderColor: '#52c41a' },\n      title: { color: '#52c41a' },\n    } satisfies ResultProps['styles']\n  }\n}\n</script>\n\n<template>\n  <a-result\n    status=\"info\"\n    title=\"classes Object\"\n    sub-title=\"This is a subtitle\"\n    :styles=\"stylesObject\"\n    :classes=\"classesObject\"\n  >\n    <template #extra>\n      <a-button type=\"primary\">\n        Action\n      </a-button>\n    </template>\n    <div>Content area</div>\n  </a-result>\n  <a-result\n    status=\"success\"\n    title=\"classes Function\"\n    sub-title=\"Dynamic class names\"\n    :styles=\"stylesFn\"\n    :classes=\"classesFn\"\n  >\n    <template #extra>\n      <a-button type=\"primary\">\n        Action\n      </a-button>\n    </template>\n  </a-result>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with text alignment, layout styles and other basic container styles",
+          "descriptionZh": "根元素，包含文本对齐、布局样式等基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'subTitle', desc: t('subTitle'), version: '1.0.0' },\n  { name: 'extra', desc: t('extra'), version: '1.0.0' },\n  { name: 'body', desc: t('body'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Result\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-result\n        title=\"title\"\n        sub-title=\"subTitle\"\n        :classes=\"classes\"\n      >\n        <template #extra>\n          <a-button type=\"primary\">\n            extra\n          </a-button>\n        </template>\n        <div :style=\"{ textAlign: 'center' }\">\n          The Content of Result\n        </div>\n      </a-result>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "title",
+          "description": "Title element with font size, text color, line height, text alignment and other text styles",
+          "descriptionZh": "标题元素，包含字体大小、文字颜色、行高、对齐方式等文字样式"
+        },
+        {
+          "key": "subTitle",
+          "description": "Subtitle element with font size, text color, line height and other text styles",
+          "descriptionZh": "副标题元素，包含字体大小、文字颜色、行高等文字样式"
+        },
+        {
+          "key": "body",
+          "description": "Content element with margin, padding, background color and other content area styles",
+          "descriptionZh": "内容元素，包含外边距、内边距、背景色等内容区域样式"
+        },
+        {
+          "key": "extra",
+          "description": "Action area element with margin, text alignment, inner element spacing and other layout styles",
+          "descriptionZh": "操作区域元素，包含外边距、文本对齐、内部元素间距等布局样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with margin, text alignment, font size, status colors and other icon styles",
+          "descriptionZh": "图标元素，包含外边距、文本对齐、字体大小、状态颜色等图标样式"
         }
       ]
     },
@@ -17637,14 +18529,28 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Segmented by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Segmented 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { SegmentedProps } from 'antdv-next'\nimport { CloudOutlined, RocketOutlined, ThunderboltOutlined } from '@antdv-next/icons'\nimport { h } from 'vue'\n\nconst classes: SegmentedProps['classes'] = {\n  root: 'custom-segmented-root',\n}\nconst styleFn: SegmentedProps['styles'] = (info) => {\n  if (info.props.vertical) {\n    return {\n      root: {\n        border: '1px solid #77BEF0',\n        padding: '4px',\n        width: '100px',\n      },\n      icon: {\n        color: '#77BEF0',\n      },\n      item: {\n        textAlign: 'start',\n      },\n    } satisfies SegmentedProps['styles']\n  }\n  return {}\n}\n\nconst styles: SegmentedProps['styles'] = {\n  root: {\n    padding: '4px',\n    width: '260px',\n  },\n}\n\nconst options: SegmentedProps['options'] = [\n  {\n    label: 'Boost',\n    value: 'boost',\n    icon: h(RocketOutlined),\n  },\n  {\n    label: 'Stream',\n    value: 'stream',\n    icon: h(ThunderboltOutlined),\n  },\n  {\n    label: 'Cloud',\n    value: 'cloud',\n    icon: h(CloudOutlined),\n  },\n]\nconst segmentedSharedProps: SegmentedProps = {\n  options,\n  classes,\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-segmented v-bind=\"segmentedSharedProps\" :styles=\"styles\" />\n    <a-segmented v-bind=\"segmentedSharedProps\" :styles=\"styleFn\" vertical />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with inline-block layout, padding, background, border radius, transition and container styles",
+          "descriptionZh": "根元素，设置行内块布局、内边距、背景色、圆角、过渡动画和容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AppstoreOutlined, BarsOutlined } from '@antdv-next/icons'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'label', desc: t('label'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n])\n\nconst options = [\n  { label: 'List', value: 'List', icon: h(BarsOutlined) },\n  { label: 'Kanban', value: 'Kanban', icon: h(AppstoreOutlined) },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Segmented\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-segmented :options=\"options\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Option element with relative positioning, text alignment, cursor style, transition, selected state background and hover styles",
+          "descriptionZh": "选项元素，设置相对定位、文本对齐、光标样式、过渡动画、选中态背景色和悬停态样式"
+        },
+        {
+          "key": "icon",
+          "description": "Icon element with icon size, color and text spacing styles",
+          "descriptionZh": "图标元素，设置图标的尺寸、颜色和与文本的间距样式"
+        },
+        {
+          "key": "label",
+          "description": "Label content element with min height, line height, padding, text ellipsis and content layout styles",
+          "descriptionZh": "标签内容元素，设置最小高度、行高、内边距、文本省略和内容布局样式"
         }
       ]
     },
@@ -18494,14 +19400,73 @@
           "description": "You can customize the semantic dom style of Select by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "您可以通过 `classes` 和 `styles` 传入对象/函数来自定义 Select 的语义化 DOM 样式。",
           "code": "<script setup lang=\"ts\">\nimport { MehOutlined } from '@antdv-next/icons'\n\nconst options = [\n  { value: 'GuangZhou', label: 'GuangZhou' },\n  { value: 'ShenZhen', label: 'ShenZhen' },\n]\n\nconst stylesObject = {\n  prefix: {\n    color: '#1890ff',\n  },\n  suffix: {\n    color: '#1890ff',\n  },\n}\n\nconst stylesFilled = {\n  prefix: {\n    color: '#722ed1',\n  },\n  suffix: {\n    color: '#722ed1',\n  },\n  popup: {\n    root: {\n      border: '1px solid #722ed1',\n    },\n  },\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-select\n      :options=\"options\"\n      :classes=\"{ root: 'custom-select' }\"\n      :styles=\"stylesObject\"\n      placeholder=\"Object\"\n    >\n      <template #prefix>\n        <MehOutlined />\n      </template>\n    </a-select>\n    <a-select\n      :options=\"options\"\n      :classes=\"{ root: 'custom-select' }\"\n      :styles=\"stylesFilled\"\n      placeholder=\"Function\"\n      variant=\"filled\"\n    >\n      <template #prefix>\n        <MehOutlined />\n      </template>\n    </a-select>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, cursor styles, transitions, border and other basic selector container styles",
+          "descriptionZh": "根元素，包含相对定位、行内 flex 布局、光标样式、过渡动画、边框等选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst mode = ref<'single' | 'multiple'>('single')\n\nconst options = [\n  { value: 'aojunhao123', label: 'aojunhao123' },\n  { value: 'thinkasany', label: 'thinkasany' },\n  { value: 'meet-student', label: 'meet-student' },\n]\n\nconst value = computed(() => {\n  if (mode.value !== 'multiple')\n    return []\n\n  return options.length > 0\n    ? [options[0]!.value]\n    : []\n})\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => {\n  const base = [\n    { name: 'root', desc: t('root') },\n    { name: 'prefix', desc: t('prefix') },\n    { name: 'content', desc: t('content') },\n    { name: 'placeholder', desc: t('placeholder') },\n    { name: 'clear', desc: t('clear') },\n    { name: 'input', desc: t('input') },\n    { name: 'suffix', desc: t('suffix') },\n    { name: 'popup.root', desc: t('popup.root') },\n    { name: 'popup.list', desc: t('popup.list') },\n    { name: 'popup.listItem', desc: t('popup.listItem') },\n  ]\n\n  if (mode.value === 'multiple') {\n    return [\n      ...base,\n      { name: 'item', desc: t('item') },\n      { name: 'itemContent', desc: t('itemContent') },\n      { name: 'itemRemove', desc: t('itemRemove') },\n    ]\n  }\n\n  return base\n})\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Select\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <div :style=\"{ display: 'flex', justifyContent: 'center', marginBottom: '12px' }\">\n          <a-segmented v-model:value=\"mode\" :options=\"['single', 'multiple']\" />\n        </div>\n        <div :style=\"{ display: 'flex', flexDirection: 'column', gap: '12px' }\">\n          <a-select\n            prefix=\"prefix\"\n            :style=\"{ width: '300px' }\"\n            :options=\"options\"\n            :value=\"value\"\n            :mode=\"mode === 'multiple' ? 'multiple' : undefined\"\n            open\n            :get-popup-container=\"() => divRef!\"\n            :classes=\"classes\"\n          />\n        </div>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with layout and styling for prefix content",
+          "descriptionZh": "前缀元素，包含前缀内容的布局和样式"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "clear",
+          "description": "Clear button element with layout, styling and interactive effects for clear button",
+          "descriptionZh": "清除按钮元素，包含清除按钮的布局、样式和交互效果"
+        },
+        {
+          "key": "input",
+          "description": "Input element with search input styling, cursor control, font inheritance and other search-related styles. Remove border styles",
+          "descriptionZh": "输入框元素，包含搜索输入框的样式、光标控制、字体继承等搜索相关样式，去除了边框样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with layout and styling for suffix content like clear button, arrow icon, etc.",
+          "descriptionZh": "后缀元素，包含后缀内容的布局和样式，如清除按钮、箭头图标等"
+        },
+        {
+          "key": "item",
+          "description": "Multiple selection item element with border, background, padding, and margin styles",
+          "descriptionZh": "多选项元素，包含边框、背景、内边距、外边距样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Multiple selection item content area with text ellipsis styles",
+          "descriptionZh": "多选项内容区域，包含文字的省略样式"
+        },
+        {
+          "key": "itemRemove",
+          "description": "Multiple selection item remove button with font-related styless",
+          "descriptionZh": "多选项移除按钮，包含字体相关样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with popup layer positioning, z-index, background, border, box-shadow and other popup container styles",
+          "descriptionZh": "弹出菜单元素，包含弹出层的定位、层级、背景、边框、阴影等弹出容器样式"
+        },
+        {
+          "key": "popup.list",
+          "description": "Popup list element with option list layout, scrolling, max-height and other list container styles",
+          "descriptionZh": "弹出菜单列表元素，包含选项列表的布局、滚动、最大高度等列表容器样式"
+        },
+        {
+          "key": "popup.listItem",
+          "description": "Popup item element with option item padding, hover effects, selected states, disabled states and other option interactive styles",
+          "descriptionZh": "弹出菜单条目元素，包含选项项的内边距、悬浮效果、选中状态、禁用状态等选项交互样式"
         }
       ]
     },
@@ -18956,22 +19921,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Skeleton by passing objects or functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象或者函数可以自定义 Skeleton 组件的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nconst classes = {\n  root: 'skeleton-root',\n  header: 'skeleton-header',\n}\n\nconst styles = {\n  avatar: {\n    border: '1px solid #aaa',\n  },\n  title: {\n    border: '1px solid #aaa',\n  },\n}\n\nfunction stylesFn(info: { props: { active?: boolean } }) {\n  if (info.props?.active) {\n    return {\n      root: {\n        border: '1px solid rgba(229, 243, 254, 0.3)',\n      },\n      title: {\n        backgroundColor: 'rgba(229, 243, 254, 0.5)',\n        height: '20px',\n        borderRadius: '20px',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-skeleton\n      :classes=\"classes\"\n      :styles=\"styles\"\n      avatar\n      :paragraph=\"false\"\n    />\n    <a-skeleton\n      :classes=\"{ ...classes, paragraph: 'skeleton-paragraph' }\"\n      :styles=\"stylesFn\"\n      active\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with table display, width, animation effects, border radius and other skeleton container basic styles",
+          "descriptionZh": "根元素，包含表格显示、宽度、动画效果、圆角等骨架屏容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'avatar', desc: t('avatar'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'paragraph', desc: t('paragraph'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Skeleton\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-skeleton avatar :paragraph=\"{ rows: 4 }\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with table cell, padding, vertical alignment and other avatar placeholder area layout styles",
+          "descriptionZh": "头部元素，包含表格单元格、内边距、垂直对齐等头像占位区域的布局样式"
         },
         {
-          "name": "_semantic_element",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport type { SegmentedOptions } from 'antdv-next'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\ntype SkeletonElement = 'Avatar' | 'Button' | 'Input' | 'Image' | 'Node'\nconst internalOptions: SegmentedOptions = ['Avatar', 'Button', 'Input', 'Image', 'Node']\n\nconst element = ref<SkeletonElement>('Avatar')\n\nconst componentMap: Record<SkeletonElement, string> = {\n  Avatar: 'a-skeleton-avatar',\n  Button: 'a-skeleton-button',\n  Input: 'a-skeleton-input',\n  Image: 'a-skeleton-image',\n  Node: 'a-skeleton-node',\n}\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('element.root'), version: '1.0.0' },\n  { name: 'content', desc: t('element.content'), version: '1.0.0' },\n])\n\nconst componentName = computed(() => `Skeleton.${element.value}`)\nconst currentComponent = computed(() => componentMap[element.value])\n</script>\n\n<template>\n  <SemanticPreview\n    :component-name=\"componentName\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical :style=\"{ width: 'fit-content', marginInlineEnd: 'auto' }\">\n        <a-segmented v-model:value=\"element\" :options=\"internalOptions\" />\n        <a-divider title-placement=\"start\" plain>\n          {{ t('element.preview') }}\n        </a-divider>\n        <component :is=\"currentComponent\" :classes=\"classes\" />\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Section element with skeleton content area layout styles",
+          "descriptionZh": "区块元素，包含骨架屏内容区域的布局样式"
+        },
+        {
+          "key": "avatar",
+          "description": "Avatar element with inline-block display, vertical alignment, background color, size, border radius and other avatar placeholder styles",
+          "descriptionZh": "头像元素，包含行内块显示、垂直对齐、背景色、尺寸、圆角等头像占位的样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with width, height, background color, border radius and other title placeholder styles",
+          "descriptionZh": "标题元素，包含宽度、高度、背景色、圆角等标题占位的样式"
+        },
+        {
+          "key": "paragraph",
+          "description": "Paragraph element with padding, list item styles, background color, border radius and other paragraph placeholder styles",
+          "descriptionZh": "段落元素，包含内边距、列表项样式、背景色、圆角等段落占位的样式"
+        },
+        {
+          "key": "element.root",
+          "description": "Root element",
+          "descriptionZh": "根元素"
+        },
+        {
+          "key": "element.content",
+          "description": "Content element",
+          "descriptionZh": "内容元素"
+        },
+        {
+          "key": "element.preview",
+          "description": "Preview",
+          "descriptionZh": "预览"
         }
       ]
     },
@@ -19377,14 +20373,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Sliders by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Sliders 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst value = ref(30)\nconst valueVertical = ref(30)\n\nconst stylesObject = {\n  track: { backgroundImage: 'linear-gradient(180deg, #91caff, #1677ff)' },\n  handle: { borderColor: '#1677ff', boxShadow: '0 2px 8px #1677ff' },\n}\n\nfunction stylesFn(info: any) {\n  if (info.props.orientation === 'vertical') {\n    return {\n      root: { height: '300px' },\n      track: { backgroundImage: 'linear-gradient(180deg, #722cc0, #722ed1)' },\n      handle: { borderColor: '#722ed1', boxShadow: '0 2px 8px #722ed1' },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-slider v-model:value=\"value\" class=\"custom-slider\" :styles=\"stylesObject\" />\n    <a-slider\n      v-model:value=\"valueVertical\"\n      class=\"custom-slider-vertical\"\n      orientation=\"vertical\"\n      reverse\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, height, margin, padding, cursor style and touch action control",
+          "descriptionZh": "根元素，设置相对定位、高度、边距、内边距、光标样式和触摸事件控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'track', desc: t('track'), version: '1.0.0' },\n  { name: 'tracks', desc: t('tracks'), version: '1.0.0' },\n  { name: 'rail', desc: t('rail'), version: '1.0.0' },\n  { name: 'handle', desc: t('handle'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Slider\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-slider\n        range\n        :default-value=\"[20, 30, 50]\"\n        :style=\"{ width: '100%' }\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "track",
+          "description": "Track selection bar element with absolute positioning, background color, border radius and transition animation styles",
+          "descriptionZh": "轨道选取条元素，设置绝对定位、背景色、圆角和过渡动画样式"
+        },
+        {
+          "key": "tracks",
+          "description": "Multi-segment track container element with absolute positioning and transition animation styles",
+          "descriptionZh": "多段轨道容器元素，设置绝对定位和过渡动画样式"
+        },
+        {
+          "key": "rail",
+          "description": "Background rail element with absolute positioning, background color, border radius and transition animation styles",
+          "descriptionZh": "背景轨道元素，设置绝对定位、背景色、圆角和过渡动画样式"
+        },
+        {
+          "key": "handle",
+          "description": "Slider handle control element with absolute positioning, size, outline, user selection, background color, border shadow, border radius, cursor style and transition animation",
+          "descriptionZh": "滑块控制点元素，设置绝对定位、尺寸、轮廓线、用户选择、背景色、边框阴影、圆角、光标样式和过渡动画"
         }
       ]
     },
@@ -19607,14 +20622,23 @@
           "description": "Customize semantic structure styles and class names. Supports both object and function forms.",
           "descriptionZh": "自定义语义化结构的样式和类名。支持对象和函数两种形式。",
           "code": "<script setup lang=\"ts\">\nimport type { SpaceProps } from 'antdv-next'\n\nconst classNamesObject: SpaceProps['classes'] = {\n  root: 'demo-space-root',\n  item: 'demo-space-item',\n  separator: 'demo-space-separator',\n}\n\nconst classNamesFn: SpaceProps['classes'] = (info) => {\n  if (info.props.orientation === 'vertical') {\n    return {\n      root: 'demo-space-root--vertical',\n    } satisfies SpaceProps['classes']\n  }\n  else {\n    return {\n      root: 'demo-space-root--horizontal',\n    } satisfies SpaceProps['classes']\n  }\n}\n\nconst stylesObject: SpaceProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed', padding: '8px', marginBottom: '10px' },\n  item: { backgroundColor: '#f0f0f0', padding: '4px' },\n  separator: { color: 'red', fontWeight: 'bold' },\n}\n\nconst stylesFn: SpaceProps['styles'] = (info) => {\n  if (info.props.size === 'large') {\n    return {\n      root: {\n        backgroundColor: '#e6f7ff',\n        borderColor: '#1890ff',\n        padding: '8px',\n      },\n    } satisfies SpaceProps['styles']\n  }\n  else {\n    return {\n      root: {\n        backgroundColor: '#fff7e6',\n        borderColor: '#fa8c16',\n      },\n    } satisfies SpaceProps['styles']\n  }\n}\n</script>\n\n<template>\n  <div>\n    <a-space :styles=\"stylesObject\" :classes=\"classNamesObject\" separator=\"•\">\n      <a-button>Styled Button 1</a-button>\n      <a-button>Styled Button 2</a-button>\n      <a-button>Styled Button 3</a-button>\n    </a-space>\n    <a-space size=\"large\" :styles=\"stylesFn\" :classes=\"classNamesFn\">\n      <a-button>Large Space Button 1</a-button>\n      <a-button>Large Space Button 2</a-button>\n      <a-button>Large Space Button 3</a-button>\n    </a-space>\n  </div>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, gap settings, alignment, wrap and other spacing container basic styles",
+          "descriptionZh": "根元素，包含 flex 布局、间隙设置、对齐方式、换行等间距容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n  { name: 'separator', desc: t('separator') },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Space\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-space :classes=\"classes\">\n        <template #separator>\n          <a-divider vertical />\n        </template>\n        <a-button type=\"primary\">\n          Primary\n        </a-button>\n        <a-button>Default</a-button>\n        <a-button type=\"dashed\">\n          Dashed\n        </a-button>\n      </a-space>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Wrapped item element with spacing item layout and styles, providing wrapper for each child element for inline alignment",
+          "descriptionZh": "包裹的子组件，包含间距项的布局和样式，为每个子元素提供包装用于内联对齐"
+        },
+        {
+          "key": "separator",
+          "description": "Separator element with divider styling",
+          "descriptionZh": "分隔符，包含分隔元素的样式"
         }
       ]
     },
@@ -19827,14 +20851,18 @@
           "description": "Debug example for standalone Spin components nested inside a wrapping Spin. The inner\nones should not pick up the outer overlay's absolute centering styles.",
           "descriptionZh": "嵌套独立 `Spin` 的调试示例：包裹型 `Spin` 的内容里再放独立 `Spin`，内层不应被外层的居中定位样式影响。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst loading = ref(true)\nconst dataSource = ['Apple', 'Banana']\n</script>\n\n<template>\n  <a-flex gap=\"middle\" vertical>\n    <a-spin :spinning=\"loading\">\n      <a-flex vertical gap=\"small\" :style=\"{ padding: '16px', border: '1px solid #d9d9d9' }\">\n        <a-flex v-for=\"item in dataSource\" :key=\"item\" align=\"center\" justify=\"space-between\">\n          <span>{{ item }}</span>\n          <a-spin size=\"small\" />\n        </a-flex>\n      </a-flex>\n    </a-spin>\n    <a-flex align=\"center\" gap=\"small\">\n      <span>Outer loading state:</span>\n      <a-switch v-model:checked=\"loading\" />\n    </a-flex>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with absolute positioning, display control, color, font size, text alignment, vertical alignment, opacity and transition animation (effective when fullscreen is false)",
+          "descriptionZh": "根元素，设置绝对定位、显示控制、颜色、字体大小、文本对齐、垂直对齐、透明度和过渡动画(fullscreen 为 false 时才有效)"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Spin\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div\n        :style=\"{\n          position: 'relative',\n          width: '500px',\n          height: '100px',\n          display: 'flex',\n          alignItems: 'center',\n          justifyContent: 'center',\n        }\"\n      >\n        <a-spin :percent=\"0\" :classes=\"classes\" />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "indicator",
+          "description": "Indicator element with width, height, font size, inline-block display, transition animation, transform origin, line height and color",
+          "descriptionZh": "指示器元素，设置宽度、高度、字体大小、行内块显示、过渡动画、变换原点、行高和颜色"
         }
       ]
     },
@@ -20117,14 +21145,23 @@
           "description": "Customize semantic structure styles and class names. Supports both object and function forms.",
           "descriptionZh": "自定义语义化结构的样式和类名。支持对象和函数两种形式。",
           "code": "<script setup lang=\"ts\">\nimport type { SplitterProps } from 'antdv-next'\n\nconst stylesObject: SplitterProps['styles'] = {\n  root: { backgroundColor: '#fffbe6' },\n  dragger: { backgroundColor: 'rgba(194,223,252,0.4)' },\n}\n\nconst stylesFn: SplitterProps['styles'] = ({ props }) => {\n  if (props.orientation === 'horizontal') {\n    return {\n      root: {\n        borderWidth: '2px',\n        borderStyle: 'dashed',\n        marginBottom: '10px',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-splitter\n      style=\"height: 200px\"\n      root-class=\"shadow-secondary\"\n      :styles=\"stylesObject\"\n    >\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\" style=\"color: #000\">\n            First\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\" style=\"color: #000\">\n            Second\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n    </a-splitter>\n    <a-splitter\n      style=\"height: 200px\"\n      root-class=\"shadow-secondary\"\n      :styles=\"stylesFn\"\n    >\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\">\n            First\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n      <a-splitter-panel>\n        <a-flex justify=\"center\" align=\"center\" style=\"height: 100%\">\n          <a-typography-title type=\"secondary\" :level=\"5\">\n            Second\n          </a-typography-title>\n        </a-flex>\n      </a-splitter-panel>\n    </a-splitter>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, width and height, alignment and stretch styles",
+          "descriptionZh": "根元素，设置flex布局、宽度高度、对齐方式和拉伸样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'panel', desc: t('panel'), version: '1.0.0' },\n  { name: 'dragger', desc: t('dragger'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Splitter\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-splitter\n        :style=\"{ height: '200px', boxShadow: '0 0 10px rgba(0, 0, 0, 0.1)' }\"\n        :classes=\"classes\"\n      >\n        <a-splitter-panel>\n          <div :style=\"{ display: 'flex', height: '100%', alignItems: 'center', justifyContent: 'center' }\">\n            First\n          </div>\n        </a-splitter-panel>\n        <a-splitter-panel>\n          <div :style=\"{ display: 'flex', height: '100%', alignItems: 'center', justifyContent: 'center' }\">\n            Second\n          </div>\n        </a-splitter-panel>\n      </a-splitter>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "panel",
+          "description": "Panel element with flex basis, grow ratio and panel container styles",
+          "descriptionZh": "面板元素，设置flex基础值、增长比例和面板容器样式"
+        },
+        {
+          "key": "dragger",
+          "description": "Drag control element with absolute positioning, user selection, z-index, center alignment, background color, hover and active states styles",
+          "descriptionZh": "拖拽控制元素，设置绝对定位、用户选择、层级、居中对齐、背景色、悬停态和激活态样式"
         }
       ]
     },
@@ -20325,14 +21362,43 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of the Statistic by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Statistic 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { StatisticProps } from 'antdv-next'\nimport { ArrowDownOutlined, ArrowUpOutlined } from '@antdv-next/icons'\n\nconst classes = {\n  root: 'custom-statistic-root',\n}\nconst styleFn: StatisticProps['styles'] = ({ props }) => {\n  const numValue = Number(props.value ?? 0)\n  const isNegative = Number.isFinite(numValue) && numValue < 0\n  if (isNegative) {\n    return {\n      title: {\n        color: '#ff4d4f',\n      },\n      content: {\n        color: '#ff7875',\n      },\n    } satisfies StatisticProps['styles']\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-statistic\n      :value=\"93241\"\n      title=\"Monthly Active Users\"\n      :classes=\"classes\"\n      :styles=\"{ title: { color: '#1890ff', fontWeight: '600px' }, content: { fontSize: '24px' } }\"\n      suffix=\"users\"\n    >\n      <template #prefix>\n        <ArrowUpOutlined />\n      </template>\n    </a-statistic>\n\n    <a-statistic\n      :value=\"-18.7\"\n      title=\"Yearly Loss\"\n      :precision=\"1\"\n      :classes=\"classes\"\n      :styles=\"styleFn\"\n      suffix=\"%\"\n    >\n      <template #prefix>\n        <ArrowDownOutlined />\n      </template>\n    </a-statistic>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with reset styles and overall container styles for statistic component",
+          "descriptionZh": "根元素，包含统计数值组件的重置样式和整体容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { ArrowUpOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'prefix', desc: t('prefix'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'value', desc: t('value'), version: '1.3.0' },\n  { name: 'suffix', desc: t('suffix'), version: '1.0.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Statistic\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div :style=\"{ position: 'absolute' }\">\n        <a-statistic\n          title=\"Active\"\n          :value=\"11.28\"\n          :precision=\"2\"\n          :styles=\"{ content: { color: '#3f8600' } }\"\n          suffix=\"%\"\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <ArrowUpOutlined />\n          </template>\n        </a-statistic>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "header",
+          "description": "Header element with bottom padding and title area layout styles",
+          "descriptionZh": "头部元素，包含下内边距和标题区域的布局样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text color, font size and other title text display styles",
+          "descriptionZh": "标题元素，包含文字颜色、字体大小等标题文字的显示样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with text color, font size, font family and other numeric content display styles",
+          "descriptionZh": "内容元素，包含文字颜色、字体大小、字体族等数值内容的展示样式"
+        },
+        {
+          "key": "value",
+          "description": "Value element with text color, font size, font family and other statistic number display styles",
+          "descriptionZh": "数值元素，包含文字颜色、字体大小、字体族等统计数值的展示样式"
+        },
+        {
+          "key": "prefix",
+          "description": "Prefix element with inline-block display, right margin and other prefix content layout styles",
+          "descriptionZh": "前缀元素，包含行内块显示、右外边距等前缀内容的布局样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with inline-block display, left margin and other suffix content layout styles",
+          "descriptionZh": "后缀元素，包含行内块显示、左外边距等后缀内容的布局样式"
         }
       ]
     },
@@ -20645,14 +21711,58 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Steps by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Steps 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { StepsProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: StepsProps['classes'] = {\n  root: 'steps-demo-root',\n}\n\nconst stylesObject: StepsProps['styles'] = {\n  itemIcon: {\n    borderRadius: '30%',\n  },\n  itemContent: {\n    fontStyle: 'italic',\n  },\n}\n\nconst stylesFn: StepsProps['styles'] = (info) => {\n  if (info?.props?.type === 'navigation') {\n    return {\n      root: {\n        borderColor: '#1890ff',\n      },\n    }\n  }\n  return {}\n}\n\nconst items: StepsProps['items'] = [\n  { title: 'Finished', content: 'This is a content.' },\n  { title: 'In Progress', content: 'This is a content.' },\n  { title: 'Waiting', content: 'This is a content.' },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-steps :items=\"items\" :current=\"1\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-steps\n      :items=\"items\"\n      :current=\"1\"\n      type=\"navigation\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, nowrap, alignment, CSS variables and other basic step container styles",
+          "descriptionZh": "根元素，包含 flex 布局、禁止换行、对齐方式、CSS 变量等步骤条容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemWrapper', desc: t('itemWrapper') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n  { name: 'itemHeader', desc: t('itemHeader') },\n  { name: 'itemTitle', desc: t('itemTitle') },\n  { name: 'itemSubtitle', desc: t('itemSubtitle') },\n  { name: 'itemSection', desc: t('itemSection') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'itemRail', desc: t('itemRail') },\n])\n\nconst items = [\n  { title: 'Step 1', subTitle: '00:01', content: 'This is a content.' },\n  { title: 'Step 2', subTitle: '00:02', content: 'This is a content.' },\n  { title: 'Step 3', subTitle: '00:03', content: 'This is a content.' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Steps\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex vertical gap=\"large\" :style=\"{ width: '100%' }\">\n        <a-steps\n          :current=\"1\"\n          :style=\"{ width: '100%' }\"\n          title-placement=\"vertical\"\n          :items=\"items\"\n          :classes=\"classes\"\n        />\n        <a-steps\n          :current=\"1\"\n          :style=\"{ width: '100%' }\"\n          type=\"panel\"\n          size=\"small\"\n          title-placement=\"horizontal\"\n          :items=\"items\"\n          :classes=\"classes\"\n        />\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Step item element with flex layout, relative positioning and other basic step item container styles",
+          "descriptionZh": "步骤项元素，包含 flex 布局、相对定位等单个步骤项的基础容器样式"
+        },
+        {
+          "key": "itemWrapper",
+          "description": "Step item wrapper element with flex layout, nowrap, top padding and other step content wrapping styles",
+          "descriptionZh": "步骤项内裹元素，包含 flex 布局、禁止换行、顶部内边距等步骤项内容的包装样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Step item icon element with icon size, positioning, font-size and other icon display related styles",
+          "descriptionZh": "步骤项图标元素，包含图标的尺寸、定位、字体大小等图标显示相关样式"
+        },
+        {
+          "key": "itemHeader",
+          "description": "Step item header element with flex layout, nowrap, alignment and other header area layout styles",
+          "descriptionZh": "步骤项头部元素，包含 flex 布局、禁止换行、对齐方式等头部区域的布局样式"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Step item title element with color, font-size, line-height, word-break, transitions and other title text styles",
+          "descriptionZh": "步骤项标题元素，包含颜色、字体大小、行高、文字换行、过渡动画等标题文字样式"
+        },
+        {
+          "key": "itemSubtitle",
+          "description": "Step item subtitle element with color, font-weight, font-size, line-height, margin, word-break and other subtitle styles",
+          "descriptionZh": "步骤项副标题元素，包含颜色、字体权重、字体大小、行高、外边距、文字换行等副标题样式"
+        },
+        {
+          "key": "itemSection",
+          "description": "Step item section element with step content area layout and styling",
+          "descriptionZh": "步骤项区域元素，包含步骤项内容区域的布局和样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Step item content element with color, font-size, line-height, word-break, transitions and other content text styles",
+          "descriptionZh": "步骤项内容元素，包含颜色、字体大小、行高、文字换行、过渡动画等内容文字样式"
+        },
+        {
+          "key": "itemRail",
+          "description": "Step item rail element with border-style, border-width, transitions and other connecting line styles",
+          "descriptionZh": "步骤项连接线元素，包含边框样式、边框宽度、过渡动画等连接线的样式"
         }
       ]
     },
@@ -20951,14 +22061,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Switch by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Switch 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes = {\n  root: 'custom-switch-root',\n}\n\nconst stylesObject = {\n  root: {\n    backgroundColor: '#F5D2D2',\n  },\n}\n\nfunction stylesFn(info: any) {\n  if (info.props.size === 'medium') {\n    return {\n      root: {\n        backgroundColor: '#BDE3C3',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical align=\"flex-start\" justify=\"flex-start\" gap=\"medium\">\n    <a-switch\n      size=\"small\"\n      checked-children=\"on\"\n      un-checked-children=\"off\"\n      :styles=\"stylesObject\"\n      :classes=\"{ root: 'custom-switch-root' }\"\n    />\n    <a-switch\n      size=\"medium\"\n      checked-children=\"on\"\n      un-checked-children=\"off\"\n      :styles=\"stylesFn\"\n      :classes=\"classes\"\n    />\n    <a-switch\n      default-checked\n      :classes=\"{ root: 'mui-root', indicator: 'mui-indicator' }\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with min-width, height, line-height, vertical alignment, background color, border, border radius, cursor style, transition animations, user selection and other basic switch container styles",
+          "descriptionZh": "根元素，包含最小宽度、高度、行高、垂直对齐、背景色、边框、圆角、光标样式、过渡动画、用户选择等开关容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.3' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Switch\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-switch\n        checked-children=\"on\"\n        un-checked-children=\"off\"\n        default-checked\n        disabled\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "content",
+          "description": "Content element with block display, overflow hidden, border radius, height, padding, transition animations and other switch content area layout and styles",
+          "descriptionZh": "内容元素，包含块级显示、溢出隐藏、圆角、高度、内边距、过渡动画等开关内容区域的布局和样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element with absolute positioning, width, height, background color, border radius, shadow, transition animations and other switch handle styles and interactive effects",
+          "descriptionZh": "指示器元素,包含绝对定位、宽度、高度、背景色、圆角、阴影、过渡动画等开关把手的样式和交互效果"
         }
       ]
     },
@@ -21818,14 +22937,73 @@
           "description": "Customize header and body cells via the headerCell and bodyCell slots.",
           "descriptionZh": "通过 headerCell 与 bodyCell 插槽自定义表头和单元格内容。",
           "code": "<script setup lang=\"ts\">\nimport type { TableProps } from 'antdv-next'\n\ninterface DataItem {\n  key: string\n  name: string\n  age: number\n  address: string\n}\n\nconst columns: TableProps['columns'] = [\n  {\n    title: 'Name',\n    dataIndex: 'name',\n    key: 'name',\n  },\n  {\n    title: 'Age',\n    dataIndex: 'age',\n    key: 'age',\n  },\n  {\n    title: 'Address',\n    dataIndex: 'address',\n    key: 'address',\n  },\n  {\n    title: 'Action',\n    key: 'action',\n  },\n]\n\nconst dataSource: DataItem[] = [\n  {\n    key: '1',\n    name: 'John Brown',\n    age: 32,\n    address: 'New York No. 1 Lake Park',\n  },\n  {\n    key: '2',\n    name: 'Jim Green',\n    age: 42,\n    address: 'London No. 1 Lake Park',\n  },\n  {\n    key: '3',\n    name: 'Joe Black',\n    age: 32,\n    address: 'Sydney No. 1 Lake Park',\n  },\n]\n\nfunction handleAction(record: Record<string, any>) {\n  console.log('Action:', record.name)\n}\n</script>\n\n<template>\n  <a-table :columns=\"columns\" :data-source=\"dataSource\">\n    <template #headerCell=\"{ column }\">\n      <template v-if=\"column.key === 'name'\">\n        <span class=\"table-header-strong\">{{ column.title }}</span>\n      </template>\n    </template>\n    <template #bodyCell=\"{ column, text, record }\">\n      <template v-if=\"column.key === 'name'\">\n        <a class=\"table-name\" @click.prevent=\"handleAction(record)\">{{ text }}</a>\n      </template>\n      <template v-else-if=\"column.key === 'action'\">\n        <a @click.prevent=\"handleAction(record)\">Action</a>\n      </template>\n    </template>\n  </a-table>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with font-size, background, border-radius, scrollbar-color and other basic table container styles",
+          "descriptionZh": "根元素，包含字体大小、背景色、圆角、滚动条颜色等表格容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'title', desc: t('title') },\n  { name: 'content', desc: t('content') },\n  { name: 'header.wrapper', desc: t('header.wrapper') },\n  { name: 'header.row', desc: t('header.row') },\n  { name: 'header.cell', desc: t('header.cell') },\n  { name: 'section', desc: t('section') },\n  { name: 'body.wrapper', desc: t('body.wrapper') },\n  { name: 'body.row', desc: t('body.row') },\n  { name: 'body.cell', desc: t('body.cell') },\n  { name: 'footer', desc: t('footer') },\n  { name: 'pagination.root', desc: t('pagination.root') },\n  { name: 'pagination.item', desc: t('pagination.item') },\n])\n\nconst columns = [\n  {\n    title: 'Personal Info',\n    children: [\n      { title: 'Name', dataIndex: 'name', key: 'name' },\n      { title: 'Age', dataIndex: 'age', key: 'age' },\n    ],\n  },\n  { title: 'Address', dataIndex: 'address' },\n]\n\nconst data = [\n  { key: '1', name: 'thinkasany', age: 24, address: 'New York No. 1 Lake Park' },\n  { key: '2', name: 'Jim Green', age: 42, address: 'London No. 1 Lake Park' },\n  { key: '3', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n  { key: '4', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n  { key: '5', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n  { key: '6', name: 'Joe Black', age: 32, address: 'Sydney No. 1 Lake Park' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Table\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-table\n        bordered\n        :style=\"{ width: '100%' }\"\n        :columns=\"columns\"\n        :data-source=\"data\"\n        size=\"middle\"\n        :pagination=\"{ pageSize: 3 }\"\n        :classes=\"classes\"\n      >\n        <template #title>\n          table title\n        </template>\n        <template #footer>\n          table footer\n        </template>\n      </a-table>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Container element with clear-fix, max-width, scrollbar background and other table wrapper styles",
+          "descriptionZh": "容器元素，包含清除浮动、最大宽度、滚动条背景等表格包装容器样式"
+        },
+        {
+          "key": "header.wrapper",
+          "description": "Header wrapper element with table header layout and container styles",
+          "descriptionZh": "头部容器元素，包含表头的布局和容器样式"
+        },
+        {
+          "key": "header.row",
+          "description": "Header row element with table header row layout and styling",
+          "descriptionZh": "头部行元素，包含表头行的布局和样式"
+        },
+        {
+          "key": "header.cell",
+          "description": "Header cell element with relative positioning, padding, word-wrap, background, text color, font-weight and other header cell styles",
+          "descriptionZh": "头部单元格元素，包含相对定位、内边距、文字换行、背景色、文字颜色、字体权重等表头单元格样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with table title styling and layout",
+          "descriptionZh": "标题元素，包含表格标题的样式和布局"
+        },
+        {
+          "key": "body.wrapper",
+          "description": "Body wrapper element with table body layout and container styles",
+          "descriptionZh": "主体容器元素，包含表格主体的布局和容器样式"
+        },
+        {
+          "key": "body.row",
+          "description": "Body row element with hover effects, selected states, expanded states and other interactive row styles",
+          "descriptionZh": "主体行元素，包含数据行的悬浮效果、选中状态、展开状态等交互样式"
+        },
+        {
+          "key": "body.cell",
+          "description": "Body cell element with relative positioning, padding, word-wrap and other basic data cell styles",
+          "descriptionZh": "主体单元格元素，包含相对定位、内边距、文字换行等数据单元格的基础样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with table footer background color, text color and other footer styles",
+          "descriptionZh": "底部元素，包含表格底部的背景色、文字颜色等样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with table content area styling and layout",
+          "descriptionZh": "内容元素，包含表格内容区域的样式和布局"
+        },
+        {
+          "key": "pagination.root",
+          "description": "Pagination root element with pagination component basic styles and layout",
+          "descriptionZh": "分页根元素，包含分页组件的基础样式和布局"
+        },
+        {
+          "key": "pagination.item",
+          "description": "Pagination item element with pagination item styling and interactive effects",
+          "descriptionZh": "分页单项元素，包含分页项的样式和交互效果"
         }
       ]
     },
@@ -22338,14 +23516,43 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tabs by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tabs 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TabsProps } from 'antdv-next'\n\nconst items: TabsProps['items'] = [\n  { key: '1', label: 'Tab 1', content: 'Content of Tab Pane 1' },\n  { key: '2', label: 'Tab 2', content: 'Content of Tab Pane 2' },\n  { key: '3', label: 'Tab 3', content: 'Content of Tab Pane 3' },\n]\n\nconst classes: TabsProps['classes'] = {\n  root: 'custom-tabs-root',\n}\n\nconst stylesObject: TabsProps['styles'] = {\n  root: { borderWidth: '2px', borderStyle: 'dashed', padding: '16px', marginBottom: '10px' },\n  header: { backgroundColor: 'rgba(245,245,245,0.5)' },\n  item: { fontWeight: 'bold', color: '#1890ff', padding: `6px 10px` },\n  indicator: { backgroundColor: 'rgba(255,77,79, 0.3)', height: '4px' },\n  body: { backgroundColor: 'rgba(230,247,255,0.8)' },\n  content: { padding: '16px' },\n}\n\nconst stylesFn: TabsProps['styles'] = (info) => {\n  if (info.props.type === 'card') {\n    return {\n      root: { backgroundColor: 'rgba(250,250,250, 0.8)', borderColor: '#d9d9d9' },\n      header: { textAlign: 'start' },\n    } satisfies TabsProps['styles']\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-tabs :items=\"items\" :classes=\"classes\" :styles=\"stylesObject\" />\n    <a-tabs type=\"card\" :items=\"items\" :classes=\"classes\" :styles=\"stylesFn\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with basic tab container styles, layout and direction control",
+          "descriptionZh": "根元素，包含标签页容器的基础样式、布局和方向控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'header', desc: t('header') },\n  { name: 'item', desc: t('item') },\n  { name: 'indicator', desc: t('indicator') },\n  { name: 'body', desc: t('body') },\n  { name: 'content', desc: t('content') },\n  { name: 'popup.root', desc: t('popup.root') },\n])\n\nconst items = computed(() =>\n  Array.from({ length: 30 }, (_, i) => {\n    const id = String(i)\n    return {\n      label: `Tab-${id}`,\n      key: id,\n      disabled: i === 28,\n      content: `Content of tab ${id}`,\n    }\n  }),\n)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tabs\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-tabs\n        default-active-key=\"1\"\n        :style=\"{ height: '220px', width: '100%' }\"\n        :styles=\"{\n          popup: {\n            root: { background: '#fff' },\n          },\n        }\"\n        :items=\"items\"\n        :classes=\"classes\"\n      />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with relative positioning, padding, colors, text ellipsis, border-radius, transitions and other tab item styles and interactive effects",
+          "descriptionZh": "Item 元素，包含相对定位、内边距、颜色、文本省略、圆角、过渡动画等标签项的样式和交互效果"
+        },
+        {
+          "key": "header",
+          "description": "Header element with tab navigation header layout, background, borders and other styles",
+          "descriptionZh": "头部元素，包含标签页头部导航的布局、背景、边框等样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Indicator element with indicator bar color, position, dimensions, transitions and other active state indication styles",
+          "descriptionZh": "指示器元素，包含指示条的颜色、位置、尺寸、过渡动画等活跃状态指示样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with tab panel container layout, animation and size control styles",
+          "descriptionZh": "内容区域元素，包含标签页面板容器的布局、动画和尺寸控制"
+        },
+        {
+          "key": "content",
+          "description": "Content element with single tab panel layout, padding and other content display styles",
+          "descriptionZh": "内容元素，包含单个标签页面板的布局、内边距等内容展示样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup menu element with dropdown absolute positioning, z-index, display control, max-height, scrolling and other styles",
+          "descriptionZh": "弹出菜单元素，包含下拉菜单的绝对定位、层级、显示控制、最大高度、滚动等样式"
         }
       ]
     },
@@ -22657,14 +23864,28 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tag by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tag 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport { CheckCircleOutlined, CloseCircleOutlined } from '@antdv-next/icons'\n\nconst tagStyles = {\n  root: {\n    backgroundColor: '#e6f7ff',\n  },\n  icon: {\n    color: '#52c41a',\n  },\n  content: {\n    color: '#262626',\n  },\n}\n\nconst filledTagStyles = {\n  root: {\n    backgroundColor: '#F5EFFF',\n  },\n  icon: {\n    color: '#8F87F1',\n  },\n  content: {\n    color: '#8F87F1',\n  },\n}\n\nconst groupStyles = {\n  root: {\n    gap: '12px',\n    padding: '8px 12px',\n    backgroundColor: 'rgba(82, 196, 26, 0.08)',\n    borderRadius: '8px',\n  },\n  item: {\n    backgroundColor: 'rgba(82, 196, 26, 0.1)',\n    borderColor: 'rgba(82, 196, 26, 0.3)',\n    color: '#52c41a',\n  },\n}\n\nconst multipleGroupStyles = {\n  root: {\n    gap: '16px',\n    padding: '8px 12px',\n    backgroundColor: 'rgba(143, 135, 241, 0.08)',\n    borderRadius: '8px',\n  },\n  item: {\n    backgroundColor: 'rgba(143, 135, 241, 0.1)',\n    borderColor: 'rgba(143, 135, 241, 0.3)',\n    color: '#8F87F1',\n    fontWeight: 500,\n  },\n}\n\nconst options1 = ['React', 'Vue', 'Angular']\nconst options2 = ['meet-student', 'thinkasany']\n</script>\n\n<template>\n  <a-space size=\"large\" vertical>\n    <a-flex gap=\"middle\">\n      <a-tag :classes=\"{ root: 'custom-tag-root' }\" :styles=\"tagStyles\">\n        <template #icon>\n          <CheckCircleOutlined />\n        </template>\n        Object\n      </a-tag>\n      <a-tag\n        variant=\"filled\"\n        :classes=\"{ root: 'custom-tag-root' }\"\n        :styles=\"filledTagStyles\"\n      >\n        <template #icon>\n          <CloseCircleOutlined />\n        </template>\n        Function\n      </a-tag>\n    </a-flex>\n    <a-flex vertical gap=\"middle\">\n      <a-checkable-tag-group\n        :classes=\"{ root: 'custom-tag-root' }\"\n        :styles=\"groupStyles\"\n        :options=\"options1\"\n      />\n      <a-checkable-tag-group\n        :classes=\"{ root: 'custom-tag-root' }\"\n        :styles=\"multipleGroupStyles\"\n        :options=\"options2\"\n        multiple\n      />\n    </a-flex>\n  </a-space>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with inline-block display, auto height, padding, font size, line height, nowrap, background color, border, border radius, opacity, transition animations, text alignment, relative positioning and other basic tag styles",
+          "descriptionZh": "根元素，包含行内块布局、自动高度、内边距、字体大小、行高、禁止换行、背景色、边框、圆角、透明度、过渡动画、文本对齐、相对定位等标签的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { AntDesignOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'icon', desc: t('icon'), version: '1.0.0' },\n  { name: 'content', desc: t('content'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.3.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tag\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-tag closable :classes=\"classes\">\n        <template #icon>\n          <AntDesignOutlined />\n        </template>\n        Ant Design\n      </a-tag>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "icon",
+          "description": "Icon element with font size, color, cursor style, transition animations and other icon display styles",
+          "descriptionZh": "图标元素，包含字体大小、颜色、光标样式、过渡动画等图标的显示样式"
+        },
+        {
+          "key": "content",
+          "description": "Content element with text content color, font styles and other content area styles",
+          "descriptionZh": "内容元素，包含文本内容的颜色、字体样式等内容区域的样式"
+        },
+        {
+          "key": "close",
+          "description": "Close element with close button layout, cursor styles, transition animations and other interaction styles",
+          "descriptionZh": "关闭元素，包含关闭按钮的布局、光标样式、过渡动画等交互样式"
         }
       ]
     },
@@ -22811,14 +24032,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of TimePicker by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 TimePicker 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TimePickerProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { useToken } = theme\nconst { token } = useToken()\n\nconst customClasses = {\n  root: 'custom-timepicker-root',\n}\n\nconst stylesObject: TimePickerProps['styles'] = {\n  root: {\n    borderColor: '#d9d9d9',\n  },\n}\n\nconst stylesFn: TimePickerProps['styles'] = (info) => {\n  if (info.props.size === 'large') {\n    return {\n      root: {\n        borderColor: '#722ed1',\n      },\n      suffix: {\n        color: '#722ed1',\n      },\n      popup: {\n        container: { border: '1px solid #722ed1', borderRadius: '8px' },\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-time-picker :classes=\"customClasses\" :styles=\"stylesObject\" placeholder=\"Object\" />\n    <a-time-picker :classes=\"customClasses\" :styles=\"stylesFn\" placeholder=\"Function\" size=\"large\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with relative positioning, inline-flex layout, padding, border-radius, transition animations and other basic styles for time picker container",
+          "descriptionZh": "根元素，包含相对定位、行内flex布局、内边距、边框圆角、过渡动画等时间选择器容器的基础样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { SmileOutlined } from '@antdv-next/icons'\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'prefix', desc: t('prefix') },\n  { name: 'input', desc: t('input') },\n  { name: 'suffix', desc: t('suffix') },\n  { name: 'popup.root', desc: t('popup') },\n  { name: 'popup.container', desc: t('popup.container') },\n  { name: 'popup.content', desc: t('popup.content') },\n  { name: 'popup.item', desc: t('popup.item') },\n  { name: 'popup.footer', desc: t('popup.footer') },\n])\n\nconst type = ref<'Single' | 'Multiple'>('Single')\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    :component-name=\"type === 'Single' ? 'TimePicker' : 'TimePicker.RangePicker'\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex ref=\"divRef\" vertical :style=\"{ alignSelf: 'flex-start' }\" gap=\"middle\" align=\"center\">\n        <a-segmented\n          :options=\"['Single', 'Multiple']\"\n          :value=\"type\"\n          @change=\"(val: 'Single' | 'Multiple') => type = val\"\n        />\n        <a-time-picker\n          v-if=\"type === 'Single'\"\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-time-picker>\n        <a-time-range-picker\n          v-else\n          :z-index=\"1\"\n          open\n          :get-popup-container=\"() => divRef!\"\n          need-confirm\n          :classes=\"classes\"\n        >\n          <template #prefix>\n            <SmileOutlined />\n          </template>\n        </a-time-range-picker>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with flex layout and margin styles for prefix content layout",
+          "descriptionZh": "前缀元素，包含flex布局、右外边距等前缀内容的布局样式"
+        },
+        {
+          "key": "input",
+          "description": "Input element with relative positioning, width, color, font, line-height, transition animations and other core interactive styles for input field",
+          "descriptionZh": "输入框元素，包含相对定位、宽度、颜色、字体、行高、过渡动画等输入框的核心交互样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with flex layout, color, line-height, pointer events, transition animations and other styles for suffix content",
+          "descriptionZh": "后缀元素，包含flex布局、颜色、行高、指针事件、过渡动画等后缀内容的样式"
+        },
+        {
+          "key": "popup",
+          "description": "Popup element",
+          "descriptionZh": "弹出框元素"
+        },
+        {
+          "key": "popup.container",
+          "description": "Container element, set background color, padding, border radius, shadow, border and content display styles",
+          "descriptionZh": "容器元素，设置背景色、内边距、圆角、阴影、边框和内容展示样式"
+        },
+        {
+          "key": "popup.content",
+          "description": "Popup content element with width, border, cell and other content display styles for time list",
+          "descriptionZh": "弹出框内容元素，包含时间列表的宽度、边框、单元格等内容展示样式"
+        },
+        {
+          "key": "popup.item",
+          "description": "Popup item element with size, background, border-radius, hover state, selected state and other interactive styles for time cells",
+          "descriptionZh": "弹出框单项元素，包含时间单元格的尺寸、背景色、边框圆角、悬停态、选中态等交互样式"
+        },
+        {
+          "key": "popup.footer",
+          "description": "Popup footer element with layout styles for bottom operation area including confirm/cancel buttons",
+          "descriptionZh": "弹出框底部元素，包含确认取消按钮等底部操作区域的布局样式"
         }
       ]
     },
@@ -23055,14 +24315,53 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Timeline by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Timeline 的[语义化结构](#semantic-dom)样式。",
           "code": "<script lang=\"ts\" setup>\nconst classes = {\n  root: 'custom-timeline-root',\n}\n\nconst styles = {\n  itemIcon: {\n    borderColor: '#1890ff',\n  },\n}\n\nfunction stylesFn(info: any) {\n  if (info.props.orientation === 'vertical') {\n    return {\n      root: {\n        padding: '10px 6px',\n        border: '1px solid #A294F9',\n      },\n      itemIcon: {\n        borderColor: '#A294F9',\n      },\n    }\n  }\n  return {}\n}\n\nconst items = [\n  {\n    title: '2015-09-01',\n    content: 'Create a services site',\n  },\n  {\n    title: '2015-09-01 09:12:11',\n    content: 'Solve initial network problems',\n  },\n  {\n    content: 'Technical testing',\n  },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-timeline :items=\"items\" orientation=\"horizontal\" :styles=\"styles\" :classes=\"classes\" />\n    <a-timeline :items=\"items\" orientation=\"vertical\" :styles=\"stylesFn\" :classes=\"classes\" />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with timeline container list style reset, vertical layout, dot icon, outlined style, alternate layout and other basic container styles",
+          "descriptionZh": "根元素，设置时间轴容器的列表样式重置、垂直布局、点状图标、轮廓样式、交替布局等基础容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemWrapper', desc: t('itemWrapper') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n  { name: 'itemSection', desc: t('itemSection') },\n  { name: 'itemHeader', desc: t('itemHeader') },\n  { name: 'itemTitle', desc: t('itemTitle') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'itemRail', desc: t('itemRail') },\n])\n\nconst items = [\n  { title: '2015-09-01', content: 'Create a services' },\n  { title: '2015-09-01 09:12:11', content: 'Solve initial network problems' },\n  { content: 'Technical testing' },\n  { title: '2015-09-01 09:12:11', content: 'Network problems being solved' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Timeline\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-timeline :items=\"items\" :classes=\"classes\" />\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with single timeline node relative positioning, margin, padding, font size, finish state, color theme, layout direction and other node basic styles",
+          "descriptionZh": "节点元素，设置单个时间节点的相对定位、外边距、内边距、字体大小、完成状态、颜色主题、布局方向等节点基础样式"
+        },
+        {
+          "key": "itemWrapper",
+          "description": "Item wrapper element with timeline node content wrapping container styles",
+          "descriptionZh": "节点包装元素，设置时间节点内容的包装容器样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Item icon element with node head icon absolute positioning, width/height size, background color, border, border radius, wave animation and other icon styles",
+          "descriptionZh": "节点图标元素，设置节点头部图标的绝对定位、宽高尺寸、背景色、边框、圆角、波纹动画等图标样式"
+        },
+        {
+          "key": "itemHeader",
+          "description": "Item header element with header area layout containing title and rail, alignment, text direction and other styles",
+          "descriptionZh": "节点头部元素，设置包含标题和连接线的头部区域布局、对齐方式、文本方向等样式"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Item title element with node title text font size, line height, color and other text styles",
+          "descriptionZh": "节点标题元素，设置节点标题文字的字体大小、行高、颜色等文本样式"
+        },
+        {
+          "key": "itemSection",
+          "description": "Item section element with section container containing header and content flex layout, wrap, gap and other layout styles",
+          "descriptionZh": "节点区域元素，设置包含头部和内容的区域容器的Flex布局、换行、间距等布局样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Item content element with node detail content relative positioning, top offset, left margin, text color, word break and other content styles",
+          "descriptionZh": "节点内容元素，设置节点详细内容的相对定位、顶部偏移、左侧外边距、文字颜色、词汇换行等内容样式"
+        },
+        {
+          "key": "itemRail",
+          "description": "Item rail element with timeline node connection track line absolute positioning, top offset, left offset, height, border color, width, style and other connection line styles",
+          "descriptionZh": "节点连接线元素，设置连接时间节点的轨道线条的绝对定位、顶部偏移、左侧偏移、高度、边框颜色、宽度、样式等连接线样式"
         }
       ]
     },
@@ -23431,14 +24730,23 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tooltip by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tooltip 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TooltipProps } from 'antdv-next'\nimport { theme } from 'antdv-next'\n\nconst { token } = theme.useToken()\n\nconst classes: TooltipProps['classes'] = {\n  container: 'demo-tooltip-container',\n}\n\nconst stylesObject: TooltipProps['styles'] = {\n  container: {\n    borderRadius: '12px',\n    boxShadow: 'inset 0 0 8px #ccc',\n  },\n}\n\nconst stylesFn: TooltipProps['styles'] = (info) => {\n  if (info?.props?.arrow === false) {\n    return {\n      container: {\n        backgroundColor: 'rgba(53, 71, 125, 0.8)',\n        padding: '12px',\n        color: '#fff',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-tooltip title=\"Object text\" :classes=\"classes\" :styles=\"stylesObject\" :arrow=\"false\">\n      <a-button>Object Style</a-button>\n    </a-tooltip>\n    <a-tooltip title=\"Function text\" :classes=\"classes\" :styles=\"stylesFn\" :arrow=\"false\">\n      <a-button type=\"primary\">\n        Function Style\n      </a-button>\n    </a-tooltip>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element (including arrows, content elements) with absolute positioning, z-index, block display, max width, visibility, transform origin and arrow background color",
+          "descriptionZh": "根元素 (包含箭头、内容元素)，设置绝对定位、层级、块级显示、最大宽度、可见性、变换原点和箭头背景色"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'container', desc: t('container') },\n  { name: 'arrow', desc: t('arrow') },\n])\n\nconst divRef = ref<HTMLDivElement | null>(null)\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tooltip\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', marginTop: '60px' }\">\n        <a-tooltip\n          open\n          placement=\"top\"\n          title=\"tooltip prompt text\"\n          :auto-adjust-overflow=\"false\"\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "container",
+          "description": "Content element with min width and height, padding, color, text alignment, background color, border radius, shadow and border styles",
+          "descriptionZh": "内容元素，设置最小宽度高度、内边距、颜色、文本对齐、背景色、圆角、阴影和边框样式"
+        },
+        {
+          "key": "arrow",
+          "description": "Arrow element with width, height, position, color and border styles",
+          "descriptionZh": "箭头元素，设置宽高、位置、颜色和边框样式"
         }
       ]
     },
@@ -23740,14 +25048,68 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tour by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tour 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TourProps, TourStepItem } from 'antdv-next'\nimport { computed, h, shallowRef } from 'vue'\n\nconst ref1 = shallowRef()\nconst ref2 = shallowRef()\nconst ref3 = shallowRef()\nconst open = shallowRef(false)\nconst openFn = shallowRef(false)\n\nconst btnProps = {\n  nextButtonProps: {\n    style: {\n      border: '1px solid #CDC1FF',\n      color: '#CDC1FF',\n    },\n  },\n  prevButtonProps: {\n    style: {\n      backgroundColor: '#CDC1FF',\n      color: '#fff',\n    },\n  },\n}\n\nconst coverNode = h('img', {\n  alt: 'tour.png',\n  src: 'https://user-images.githubusercontent.com/5378891/197385811-55df8480-7ff4-44bd-9d43-a7dade598d70.png',\n})\n\nconst steps: TourStepItem[] = [\n  {\n    title: 'Upload File',\n    description: 'Put your files here.',\n    cover: coverNode,\n    target: ref1,\n    prevButtonProps: {},\n  },\n  {\n    title: 'Save',\n    description: 'Save your changes.',\n    target: ref2,\n  },\n  {\n    title: 'Other Actions',\n    description: 'Click to see other actions.',\n    target: ref3,\n  },\n]\n\nconst stepsWithButtonProps = computed(() => steps.map(step => ({ ...step, ...btnProps })))\n\nconst classes: TourProps['classes'] = {\n  root: 'custom-tour-root',\n  section: 'custom-tour-section',\n}\n\nconst stylesObject: TourProps['styles'] = {\n  mask: {\n    backgroundColor: 'rgba(0, 0, 0, 0.3)',\n  },\n  section: {\n    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',\n    border: '2px solid #4096ff',\n  },\n  cover: {\n    borderRadius: '12px 12px 0 0',\n  },\n}\n\nconst stylesFn: TourProps['styles'] = (info) => {\n  if (info.props.type === 'primary') {\n    return {\n      mask: {\n        backgroundColor: 'rgba(0, 0, 0, 0.3)',\n      },\n      section: {\n        backgroundColor: 'rgba(205, 193, 255, 0.8)',\n        boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',\n      },\n      cover: {\n        borderRadius: '12px 12px 0 0',\n      },\n    }\n  }\n  return {}\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-flex gap=\"middle\">\n      <a-button type=\"primary\" @click=\"open = true\">\n        Begin Tour Object\n      </a-button>\n      <a-button type=\"primary\" @click=\"openFn = true\">\n        Begin Tour Function\n      </a-button>\n    </a-flex>\n    <a-divider />\n    <a-tour\n      v-model:open=\"open\"\n      :steps=\"steps\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      :arrow=\"false\"\n    />\n    <a-tour\n      v-model:open=\"openFn\"\n      :steps=\"stepsWithButtonProps\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      :arrow=\"false\"\n      type=\"primary\"\n    />\n    <a-space>\n      <a-button ref=\"ref1\" type=\"primary\">\n        Upload\n      </a-button>\n      <a-button ref=\"ref2\">\n        Save\n      </a-button>\n      <a-button ref=\"ref3\" type=\"dashed\">\n        Other Actions\n      </a-button>\n    </a-space>\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Tour root container with absolute positioning, z-index control, max width, visibility, arrow background color variable, theme styles and other container styles",
+          "descriptionZh": "引导根容器，设置绝对定位、层级控制、最大宽度、可见性、箭头背景色变量、主题样式等容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'mask', desc: t('mask'), version: '1.0.0' },\n  { name: 'section', desc: t('section'), version: '1.0.0' },\n  { name: 'cover', desc: t('cover'), version: '1.0.0' },\n  { name: 'header', desc: t('header'), version: '1.0.0' },\n  { name: 'title', desc: t('title'), version: '1.0.0' },\n  { name: 'description', desc: t('description'), version: '1.0.0' },\n  { name: 'footer', desc: t('footer'), version: '1.0.0' },\n  { name: 'actions', desc: t('actions'), version: '1.0.0' },\n  { name: 'indicators', desc: t('indicators'), version: '1.0.0' },\n  { name: 'indicator', desc: t('indicator'), version: '1.0.0' },\n  { name: 'close', desc: t('close'), version: '1.3.0' },\n])\n\nconst open = ref(true)\nconst createBtnRef = ref<HTMLButtonElement | null>(null)\n\nconst steps = [\n  {\n    title: 'Hello World!',\n    description: 'Hello World?!',\n    target: () => createBtnRef.value!,\n    mask: true,\n  },\n  {\n    title: 'Save',\n    description: 'Save your changes.',\n    target: () => createBtnRef.value!,\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tour\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div\n        :style=\"{\n          width: '100%',\n          height: '825px',\n          display: 'flex',\n          alignItems: 'center',\n          justifyContent: 'center',\n          position: 'relative',\n          overflow: 'hidden',\n        }\"\n      >\n        <a-button ref=\"createBtnRef\" @click=\"open = true\">\n          Show\n        </a-button>\n        <a-tour\n          v-model:open=\"open\"\n          :z-index=\"1\"\n          :default-current=\"0\"\n          :get-popup-container=\"false\"\n          :steps=\"steps\"\n          :classes=\"classes\"\n        >\n          <template #coverRender=\"{ index }\">\n            <template v-if=\"index === 0\">\n              <img src=\"https://user-images.githubusercontent.com/5378891/197385811-55df8480-7ff4-44bd-9d43-a7dade598d70.png\" alt=\"img\">\n            </template>\n          </template>\n        </a-tour>\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "cover",
+          "description": "Card cover area with text center alignment, padding, image width and other image display styles",
+          "descriptionZh": "卡片封面区域，设置文本居中对齐、内边距、图片宽度等图片展示样式"
+        },
+        {
+          "key": "section",
+          "description": "Card main content area with text alignment, border radius, box shadow, relative positioning, background color, border, background clip and other card styles",
+          "descriptionZh": "卡片主要内容区域，设置文本对齐、边框圆角、盒阴影、相对定位、背景色、边框、背景裁剪等卡片样式"
+        },
+        {
+          "key": "footer",
+          "description": "Card bottom action area with padding, text right alignment, border radius, flex layout and other bottom container styles",
+          "descriptionZh": "卡片底部操作区域，设置内边距、文本右对齐、边框圆角、Flex布局等底部容器样式"
+        },
+        {
+          "key": "actions",
+          "description": "Action button group container with left auto margin, button spacing and other button group layout styles",
+          "descriptionZh": "操作按钮组容器，设置左侧自动外边距、按钮间距等按钮组布局样式"
+        },
+        {
+          "key": "indicator",
+          "description": "Single indicator element with width/height size, inline-block display, border radius, background color, right margin, active state and other dot styles",
+          "descriptionZh": "单个指示器元素，设置宽高尺寸、行内块显示、圆角、背景色、右外边距、激活状态等圆点样式"
+        },
+        {
+          "key": "indicators",
+          "description": "Indicator group container with inline-block display and other indicator container styles",
+          "descriptionZh": "指示器组容器，设置行内块显示等指示器容器样式"
+        },
+        {
+          "key": "header",
+          "description": "Card header area with padding, width calculation, word break and other header container styles",
+          "descriptionZh": "卡片头部区域，设置内边距、宽度计算、词汇换行等头部容器样式"
+        },
+        {
+          "key": "title",
+          "description": "Guide title text with font weight and other title text styles",
+          "descriptionZh": "引导标题文字，设置字体粗细等标题文本样式"
+        },
+        {
+          "key": "description",
+          "description": "Guide description text with padding, word wrap and other description text styles",
+          "descriptionZh": "引导描述文字，设置内边距、词汇换行等描述文本样式"
+        },
+        {
+          "key": "mask",
+          "description": "Mask layer element with fixed positioning, full screen coverage, z-index, pointer events, transition animation and other mask styles",
+          "descriptionZh": "遮罩层元素，设置固定定位、全屏覆盖、层级、指针事件、过渡动画等遮罩样式"
+        },
+        {
+          "key": "close",
+          "description": "Close button element with absolute positioning, size, color, hover state and interaction feedback styles",
+          "descriptionZh": "关闭按钮元素，设置绝对定位、尺寸、颜色、悬浮态和交互反馈等关闭按钮样式"
         }
       ]
     },
@@ -24079,14 +25441,73 @@
           "description": "Custom the labels for select all checkboxes.",
           "descriptionZh": "自定义穿梭框全选按钮的文字。",
           "code": "<script setup lang=\"ts\">\nimport type { TransferEmits, TransferProps } from 'antdv-next'\nimport { ref } from 'vue'\n\ninterface RecordType {\n  key: string\n  title: string\n  description: string\n}\n\nconst mockData = Array.from({ length: 10 }).map<RecordType>((_, i) => ({\n  key: i.toString(),\n  title: `content${i + 1}`,\n  description: `description of content${i + 1}`,\n}))\n\nconst oriTargetKeys = mockData.filter(item => Number(item.key) % 3 > 1).map(item => item.key)\n\nconst selectAllLabels: TransferProps['selectAllLabels'] = [\n  'Select All',\n  ({ selectedCount, totalCount }) => `${selectedCount}/${totalCount}`,\n]\n\nconst targetKeys = ref(oriTargetKeys)\n\nconst handleChange: TransferEmits['change'] = (newTargetKeys) => {\n  targetKeys.value = newTargetKeys\n}\n</script>\n\n<template>\n  <a-transfer\n    v-model:target-keys=\"targetKeys\"\n    :data-source=\"mockData\"\n    :render=\"(item: RecordType) => item.title\"\n    :select-all-labels=\"selectAllLabels\"\n    @change=\"handleChange\"\n  />\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with flex layout, transfer container base styles and layout control",
+          "descriptionZh": "根元素，设置flex布局、穿梭框容器的基础样式和布局控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root') },\n  { name: 'section', desc: t('section') },\n  { name: 'header', desc: t('header') },\n  { name: 'title', desc: t('title') },\n  { name: 'body', desc: t('body') },\n  { name: 'list', desc: t('list') },\n  { name: 'item', desc: t('item') },\n  { name: 'itemIcon', desc: t('itemIcon') },\n  { name: 'itemContent', desc: t('itemContent') },\n  { name: 'footer', desc: t('footer') },\n  { name: 'actions', desc: t('actions') },\n  { name: 'source', desc: t('source'), version: '1.3.0' },\n  { name: 'target', desc: t('target'), version: '1.3.0' },\n])\n\nconst mockData = Array.from({ length: 20 }).map((_, i) => ({\n  key: i,\n  title: `content ${i + 1}`,\n}))\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Transfer\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-transfer\n        show-search\n        :titles=\"['Source', 'Target']\"\n        :data-source=\"mockData\"\n        :selected-keys=\"[]\"\n        :target-keys=\"[3, 9]\"\n        :render=\"(item: any) => item.title\"\n        :styles=\"{\n          section: { height: '250px', width: '200px' },\n        }\"\n        :classes=\"classes\"\n      >\n        <template #footer>\n          <div :style=\"{ padding: '8px' }\">\n            Custom Footer\n          </div>\n        </template>\n      </a-transfer>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "section",
+          "description": "Section element with flex layout, width, height, min height, border, border radius and other single-side transfer container styles",
+          "descriptionZh": "区域元素，设置flex布局、宽度、高度、最小高度、边框、圆角等单侧穿梭框的容器样式"
+        },
+        {
+          "key": "header",
+          "description": "Header element with flex layout, alignment, height, padding, color, background color, bottom border, border radius and other header area styles",
+          "descriptionZh": "头部元素，设置flex布局、对齐方式、高度、内边距、颜色、背景色、下边框、圆角等头部区域的样式"
+        },
+        {
+          "key": "title",
+          "description": "Title element with text ellipsis, flex ratio, text alignment, auto left margin and other title text layout and styles",
+          "descriptionZh": "标题元素，设置文本省略、flex占比、文本对齐、自动左边距等标题文字的布局和样式"
+        },
+        {
+          "key": "body",
+          "description": "Body element with list main area container styles and layout control",
+          "descriptionZh": "内容元素，设置列表主体区域的容器样式和布局控制"
+        },
+        {
+          "key": "list",
+          "description": "List element with list content styles, layout and scroll control",
+          "descriptionZh": "列表元素，设置列表内容的样式、布局和滚动控制"
+        },
+        {
+          "key": "item",
+          "description": "List item element with relative positioning, padding, border, hover state, selected state, disabled state and other list item interaction styles",
+          "descriptionZh": "列表项元素，设置相对定位、内边距、边框、悬停态、选中态、禁用态等列表项的交互样式"
+        },
+        {
+          "key": "itemIcon",
+          "description": "List item icon element with checkbox and other icon styles and interaction states",
+          "descriptionZh": "列表项图标元素，设置复选框等图标的样式和交互状态"
+        },
+        {
+          "key": "itemContent",
+          "description": "List item content element with text ellipsis, padding and other list item text content display styles",
+          "descriptionZh": "列表项内容元素，设置文本省略、内边距等列表项文本内容的展示样式"
+        },
+        {
+          "key": "footer",
+          "description": "Footer element with bottom operation area styles and layout",
+          "descriptionZh": "页脚元素，设置底部操作区域的样式和布局"
+        },
+        {
+          "key": "actions",
+          "description": "Actions element with transfer button group styles, layout and interaction states",
+          "descriptionZh": "操作元素，设置穿梭按钮组的样式、布局和交互状态"
+        },
+        {
+          "key": "source",
+          "description": "Source-side (left) overrides nested under the same shared semantic keys (section/header/title/body/list/item/itemIcon/itemContent/footer); only the source list picks them up",
+          "descriptionZh": "源（左侧）区域专属语义，与共享 section/header/title/body/list/item/itemIcon/itemContent/footer 同级，仅覆盖源侧"
+        },
+        {
+          "key": "target",
+          "description": "Target-side (right) overrides nested under the same shared semantic keys (section/header/title/body/list/item/itemIcon/itemContent/footer); only the target list picks them up",
+          "descriptionZh": "目标（右侧）区域专属语义，与共享 section/header/title/body/list/item/itemIcon/itemContent/footer 同级，仅覆盖目标侧"
         }
       ]
     },
@@ -24789,14 +26210,33 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of Tree by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 Tree 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TreeDataNode, TreeProps } from 'antdv-next'\nimport { ref } from 'vue'\n\nconst treeData: TreeDataNode[] = [\n  {\n    title: 'parent 1',\n    key: '0-0',\n    children: [\n      {\n        title: 'parent 1-0',\n        key: '0-0-0',\n        children: [\n          {\n            title: 'leaf',\n            key: '0-0-0-0',\n          },\n          {\n            title: 'leaf',\n            key: '0-0-0-1',\n          },\n        ],\n      },\n      {\n        title: 'parent 1-1',\n        key: '0-0-1',\n        children: [\n          {\n            title: 'leaf',\n            key: '0-0-1-0',\n          },\n        ],\n      },\n    ],\n  },\n]\n\nconst styles: TreeProps['styles'] = {\n  root: { border: '2px solid #d9d9d9' },\n  item: { margin: '2px 0' },\n}\n\nconst stylesFn: TreeProps['styles'] = (info) => {\n  if (!info.props.checkable) {\n    return {\n      root: {\n        border: `2px solid #E5D9F2`,\n        borderRadius: '4px',\n      },\n    }\n  }\n  return {}\n}\n\nconst expandedKeys = ref(['0-0-0', '0-0-1'])\nconst selectedKeys = ref(['0-0-1'])\nconst checkedKeys = ref(['0-0-0', '0-0-1'])\nconst classes = {\n  root: 'root',\n  item: 'item',\n  itemTitle: 'itemTitle',\n}\n</script>\n\n<template>\n  <a-flex vertical gap=\"middle\">\n    <a-tree\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      auto-expand-parent\n      checkable\n      :styles=\"styles\"\n    />\n    <a-tree\n      v-model:expanded-keys=\"expandedKeys\"\n      v-model:selected-keys=\"selectedKeys\"\n      v-model:checked-keys=\"checkedKeys\"\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      auto-expand-parent\n      :checkable=\"false\"\n      :styles=\"stylesFn\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with tree control base styles, layout and container control",
+          "descriptionZh": "根元素，设置树形控件的基础样式、布局和容器控制"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { DownOutlined, FrownFilled, FrownOutlined, MehOutlined, SmileOutlined } from '@antdv-next/icons'\nimport { computed, h } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n  { name: 'itemIcon', desc: t('itemIcon'), version: '1.0.0' },\n  { name: 'itemTitle', desc: t('itemTitle'), version: '1.0.0' },\n  { name: 'itemSwitcher', desc: t('itemSwitcher'), version: '1.3.0' },\n])\n\nconst treeData = [\n  {\n    title: 'parent 1',\n    key: '0-0',\n    icon: h(SmileOutlined),\n    children: [\n      { title: 'leaf', key: '0-0-0', icon: h(MehOutlined) },\n      { title: 'leaf', key: '0-0-1', icon: ({ selected }: { selected: boolean }) => selected ? h(FrownFilled) : h(FrownOutlined) },\n    ],\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Tree\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-tree\n        show-icon\n        default-expand-all\n        :default-selected-keys=\"['0-0-0']\"\n        :tree-data=\"treeData\"\n        :classes=\"classes\"\n      >\n        <template #switcherIcon>\n          <DownOutlined />\n        </template>\n      </a-tree>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "item",
+          "description": "Item element with tree node base styles, drag state, role attributes, indentation, switcher, content wrapper and other node structure",
+          "descriptionZh": "条目元素，设置树节点的基础样式、拖拽状态、角色属性、缩进、切换器、内容包装器等节点结构"
+        },
+        {
+          "key": "itemTitle",
+          "description": "Title element with tree node title text display styles and text content",
+          "descriptionZh": "标题元素，设置树节点标题文字的显示样式和文本内容"
+        },
+        {
+          "key": "itemIcon",
+          "description": "Icon element with tree node icon styles, size and state display",
+          "descriptionZh": "图标元素，设置树节点图标的样式、尺寸和状态显示"
+        },
+        {
+          "key": "itemSwitcher",
+          "description": "Switcher element with tree node expand/collapse button styles and background",
+          "descriptionZh": "切换器元素，设置树节点展开/收起按钮的样式和背景"
         }
       ]
     },
@@ -25379,14 +26819,73 @@
           "description": "You can customize the [semantic dom](#semantic-dom) style of TreeSelect by passing objects/functions through `classes` and `styles`.",
           "descriptionZh": "通过 `classes` 和 `styles` 传入对象/函数可以自定义 TreeSelect 的[语义化结构](#semantic-dom)样式。",
           "code": "<script setup lang=\"ts\">\nimport type { TreeSelectProps } from 'antdv-next'\n\nconst classes: TreeSelectProps['classes'] = {\n  root: 'custom-tree-select',\n}\n\nconst stylesObject: TreeSelectProps['styles'] = {\n  input: {\n    fontSize: 16,\n  },\n  suffix: {\n    color: '#1890ff',\n  },\n  popup: {\n    root: {\n      border: '1px solid #1890ff',\n    },\n  },\n}\n\nconst stylesFn: TreeSelectProps['styles'] = (info) => {\n  if (info.props.size === 'middle') {\n    return {\n      suffix: {\n        color: '#722ed1',\n      },\n      popup: {\n        item: {\n          color: '#722ed1',\n        },\n      },\n    }\n  }\n  return {}\n}\n\nconst treeData: TreeSelectProps['treeData'] = [\n  {\n    value: 'parent 1',\n    title: 'parent 1',\n    children: [\n      {\n        value: 'parent 1-0',\n        title: 'parent 1-0',\n        children: [\n          {\n            value: 'leaf1',\n            title: 'leaf1',\n          },\n          {\n            value: 'leaf2',\n            title: 'leaf2',\n          },\n        ],\n      },\n      {\n        value: 'parent 1-1',\n        title: 'parent 1-1',\n        children: [\n          {\n            value: 'leaf3',\n            title: 'leaf3',\n          },\n        ],\n      },\n    ],\n  },\n]\n</script>\n\n<template>\n  <a-flex vertical gap=\"large\">\n    <a-tree-select\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      :styles=\"stylesObject\"\n      placeholder=\"Object\"\n    />\n    <a-tree-select\n      :tree-data=\"treeData\"\n      :classes=\"classes\"\n      :styles=\"stylesFn\"\n      placeholder=\"Function\"\n      size=\"middle\"\n    />\n  </a-flex>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with tree selector base styles, border, border radius container styles",
+          "descriptionZh": "根元素，设置树选择器的基础样式、边框、圆角容器样式"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst mode = ref<'single' | 'multiple'>('single')\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => {\n  const base = [\n    { name: 'root', desc: t('root') },\n    { name: 'prefix', desc: t('prefix') },\n    { name: 'placeholder', desc: t('placeholder') },\n  ]\n\n  if (mode.value === 'multiple') {\n    base.push(\n      ...[\n        { name: 'content', desc: t('content') },\n        { name: 'item', desc: t('item') },\n        { name: 'itemContent', desc: t('itemContent') },\n        { name: 'itemRemove', desc: t('itemRemove') },\n      ],\n    )\n  }\n\n  base.push(\n    ...[\n      { name: 'input', desc: t('input') },\n      { name: 'suffix', desc: t('suffix') },\n      { name: 'popup.root', desc: t('popup.root') },\n      { name: 'popup.item', desc: t('popup.item') },\n      { name: 'popup.itemTitle', desc: t('popup.itemTitle') },\n      { name: 'popup.itemSwitcher', desc: t('popup.itemSwitcher'), version: '1.3.0' },\n    ],\n  )\n\n  return base\n})\n\nconst treeValue = ref<string | string[] | undefined>(undefined)\nfunction handleResetValue(newMode: string | number) {\n  if (newMode === 'multiple') {\n    treeValue.value = ['aojunhao123']\n  }\n  else {\n    treeValue.value = undefined\n  }\n}\n\nconst divRef = ref<HTMLDivElement | null>(null)\n\nconst treeData = [\n  {\n    value: 'contributors',\n    title: 'contributors',\n    children: [\n      { value: 'aojunhao123', title: 'aojunhao123' },\n      { value: 'thinkasany', title: 'thinkasany' },\n      { value: 'meet-student', title: 'meet-student' },\n    ],\n  },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"TreeSelect\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <div ref=\"divRef\" :style=\"{ position: 'absolute', height: '200px' }\">\n        <div :style=\"{ display: 'flex', justifyContent: 'center', marginBottom: '12px' }\">\n          <a-segmented v-model:value=\"mode\" :options=\"['single', 'multiple']\" @change=\"handleResetValue\" />\n        </div>\n\n        <a-tree-select\n          v-model:value=\"treeValue\"\n          prefix=\"prefix\"\n          :style=\"{ width: '300px' }\"\n          :tree-data=\"treeData\"\n          tree-default-expand-all\n          :multiple=\"mode === 'multiple'\"\n          show-search\n          max-tag-count=\"responsive\"\n          placeholder=\"Please select\"\n          allow-clear\n          open\n          :get-popup-container=\"() => divRef!\"\n          :classes=\"classes\"\n        />\n      </div>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "prefix",
+          "description": "Prefix element with prefix content layout and styles",
+          "descriptionZh": "前缀元素，设置前缀内容的布局和样式"
+        },
+        {
+          "key": "placeholder",
+          "description": "Placeholder element with font styles and colors for placeholder text",
+          "descriptionZh": "占位符元素，包含占位符文本的字体样式和颜色"
+        },
+        {
+          "key": "input",
+          "description": "Input element with text input, search, selected value display and other input core interaction styles",
+          "descriptionZh": "输入框元素，设置文本输入、搜索、选择值显示等输入框的核心交互样式"
+        },
+        {
+          "key": "suffix",
+          "description": "Suffix element with suffix content, clear button, dropdown arrow and other suffix area styles",
+          "descriptionZh": "后缀元素，设置后缀内容、清除按钮、下拉箭头等后缀区域的样式"
+        },
+        {
+          "key": "popup.root",
+          "description": "Popup element with dropdown tree selection panel positioning, z-index, background, border, shadow and other popup layer styles",
+          "descriptionZh": "弹出菜单元素，设置下拉树形选择面板的定位、层级、背景、边框、阴影等弹层样式"
+        },
+        {
+          "key": "popup.item",
+          "description": "Popup item element with tree node option styles, hover state, selected state and other interaction states",
+          "descriptionZh": "弹出菜单条目元素，设置树节点选项的样式、悬停态、选中态等交互状态"
+        },
+        {
+          "key": "popup.itemTitle",
+          "description": "Popup title element with tree node title text display styles",
+          "descriptionZh": "弹出菜单标题元素，设置树节点标题文字的显示样式"
+        },
+        {
+          "key": "popup.itemSwitcher",
+          "description": "Popup switcher element with tree node expand/collapse button styles and background",
+          "descriptionZh": "弹出菜单切换器元素，设置树节点展开/收起按钮的样式和背景"
+        },
+        {
+          "key": "content",
+          "description": "Multiple selection container with layout, spacing, and wrapping styles for selected items",
+          "descriptionZh": "多选容器，包含已选项的布局、间距、换行相关样式"
+        },
+        {
+          "key": "item",
+          "description": "Multiple selection item element with border, background, padding, and margin styles",
+          "descriptionZh": "多选项元素，包含边框、背景、内边距、外边距样式"
+        },
+        {
+          "key": "itemContent",
+          "description": "Multiple selection item content area with text ellipsis styles",
+          "descriptionZh": "多选项内容区域，包含文字的省略样式"
+        },
+        {
+          "key": "itemRemove",
+          "description": "Multiple selection item remove button with font-related styles",
+          "descriptionZh": "多选项移除按钮，包含字体相关样式"
         }
       ]
     },
@@ -25898,14 +27397,28 @@
           "description": "Add suffix ellipsis support.",
           "descriptionZh": "添加后缀的省略。",
           "code": "<script setup lang=\"ts\">\nimport { ref } from 'vue'\n\nconst rows = ref(1)\n\nconst article = `To be, or not to be, that is the question: Whether it is nobler in the mind to suffer. The slings and arrows of outrageous fortune Or to take arms against a sea of troubles, And by opposing end them? To die: to sleep; No more; and by a sleep to say we end The heart-ache and the thousand natural shocks That flesh is heir to, 'tis a consummation Devoutly to be wish'd. To die, to sleep To sleep- perchance to dream: ay, there's the rub! For in that sleep of death what dreams may come When we have shuffled off this mortal coil, Must give us pause. There 's the respect That makes calamity of so long life`\n\nfunction onEllipsis(ellipsis: boolean) {\n  console.log('Ellipsis changed:', ellipsis)\n}\n</script>\n\n<template>\n  <div>\n    <a-slider v-model:value=\"rows\" :min=\"1\" :max=\"10\" />\n    <a-typography-paragraph\n      :ellipsis=\"{\n        rows,\n        expandable: true,\n        suffix: '--William Shakespeare',\n        onEllipsis,\n      }\"\n      :title=\"`${article}--William Shakespeare`\"\n    >\n      {{ article }}\n    </a-typography-paragraph>\n  </div>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "root",
+          "description": "Root element with base typography styles, layout, and positioning",
+          "descriptionZh": "根元素，包含排版基础样式、布局和定位"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { computed, ref } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst editing = ref(false)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.3.0' },\n  { name: 'actions', desc: t('actions'), version: '1.3.0' },\n  { name: 'action', desc: t('action'), version: '1.3.0' },\n  { name: 'textarea', desc: t('textarea'), version: '1.3.0' },\n])\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Typography\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-flex\n        vertical\n        gap=\"middle\"\n        align=\"start\"\n        :style=\"{ width: '100%', alignSelf: 'flex-start' }\"\n      >\n        <a-switch\n          v-model:checked=\"editing\"\n          checked-children=\"Editing\"\n          un-checked-children=\"Editing\"\n        />\n        <a-typography-paragraph\n          copyable\n          :editable=\"{ editing }\"\n          :ellipsis=\"{ rows: 2, expandable: true }\"\n          :style=\"{ width: '100%' }\"\n          :classes=\"classes\"\n        >\n          Ant Design is a design language for background applications, refined by Ant UED Team.\n          It aims to uniform the user interface specs for internal background projects, lower the\n          unnecessary cost of design differences and implementation and liberate the resources of\n          design and front-end development.\n        </a-typography-paragraph>\n      </a-flex>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "actions",
+          "description": "Actions element with layout and spacing styles for copy, edit, expand/collapse buttons",
+          "descriptionZh": "操作区域元素，包含复制、编辑、展开/收起等操作按钮的布局和间距样式"
+        },
+        {
+          "key": "action",
+          "description": "Individual action button element including copy, edit, expand, collapse button styles like padding, border radius, colors, etc.",
+          "descriptionZh": "单个操作按钮元素，包括复制、编辑、展开、收起按钮的样式，如内边距、圆角、颜色等"
+        },
+        {
+          "key": "textarea",
+          "description": "TextArea element in editable mode, used to customize className and inline styles for the edit input",
+          "descriptionZh": "可编辑模式下的 TextArea 元素样式，用于自定义编辑输入框的类名和内联样式"
         }
       ]
     },
@@ -26363,14 +27876,33 @@
           "description": "Component Token Debug.",
           "descriptionZh": "Component Token Debug.",
           "code": "<script setup lang=\"ts\">\nimport type { UploadEmits, UploadFile } from 'antdv-next'\nimport { UploadOutlined } from '@antdv-next/icons'\n\nconst defaultFileList: UploadFile[] = [\n  {\n    uid: '1',\n    name: 'xxx.png',\n    status: 'uploading',\n    url: 'http://www.baidu.com/xxx.png',\n    percent: 33,\n  },\n  {\n    uid: '2',\n    name: 'yyy.png',\n    status: 'done',\n    url: 'http://www.baidu.com/yyy.png',\n  },\n  {\n    uid: '3',\n    name: 'zzz.png',\n    status: 'error',\n    response: 'Server Error 500',\n    url: 'http://www.baidu.com/zzz.png',\n  },\n]\n\nconst handleChange: UploadEmits['change'] = ({ file, fileList }) => {\n  if (file.status !== 'uploading') {\n    console.log(file, fileList)\n  }\n}\n</script>\n\n<template>\n  <a-config-provider\n    :theme=\"{\n      components: {\n        Upload: {\n          actionsColor: 'yellow',\n        },\n      },\n    }\"\n  >\n    <a-upload\n      action=\"https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload\"\n      :default-file-list=\"defaultFileList\"\n      @change=\"handleChange\"\n    >\n      <a-button>\n        <template #icon>\n          <UploadOutlined />\n        </template>\n        Upload\n      </a-button>\n    </a-upload>\n  </a-config-provider>\n</template>"
+        }
+      ],
+      "semanticStructure": [
+        {
+          "key": "cropModalTitle",
+          "description": "Edit image",
+          "descriptionZh": "编辑图片"
         },
         {
-          "name": "_semantic",
-          "title": "",
-          "titleZh": "",
-          "description": "",
-          "descriptionZh": "",
-          "code": "<script setup lang=\"ts\">\nimport { UploadOutlined } from '@antdv-next/icons'\nimport { computed } from 'vue'\nimport { SemanticPreview } from '@/components/semantic'\nimport { useComponentLocale } from '@/composables/use-locale'\nimport { locales } from '../locales'\n\nconst { t } = useComponentLocale(locales)\n\nconst semantics = computed(() => [\n  { name: 'root', desc: t('root'), version: '1.0.0' },\n  { name: 'list', desc: t('list'), version: '1.0.0' },\n  { name: 'item', desc: t('item'), version: '1.0.0' },\n])\n\nconst defaultFileList = [\n  { uid: '1', name: 'xxx.png', status: 'uploading', url: 'http://www.baidu.com/xxx.png', percent: 33 },\n  { uid: '2', name: 'yyy.png', status: 'done', url: 'http://www.baidu.com/yyy.png' },\n  { uid: '3', name: 'zzz.png', status: 'error', response: 'Server Error 500', url: 'http://www.baidu.com/zzz.png' },\n]\n</script>\n\n<template>\n  <SemanticPreview\n    component-name=\"Upload\"\n    :semantics=\"semantics\"\n  >\n    <template #default=\"{ classes }\">\n      <a-upload\n        action=\"https://660d2bd96ddfa2943b33731c.mockapi.io/api/upload\"\n        :default-file-list=\"defaultFileList\"\n        :classes=\"classes\"\n      >\n        <a-button>\n          <template #icon>\n            <UploadOutlined />\n          </template>\n          Upload\n        </a-button>\n      </a-upload>\n    </template>\n  </SemanticPreview>\n</template>"
+          "key": "cropResetText",
+          "description": "Reset",
+          "descriptionZh": "重置"
+        },
+        {
+          "key": "root",
+          "description": "Root container element with layout styles, disabled text color, user-select control, cursor styles and other basic styles",
+          "descriptionZh": "根元素容器，包含布局样式、禁用状态文字颜色、用户选择控制、鼠标样式等基础样式"
+        },
+        {
+          "key": "list",
+          "description": "File list container with layout arrangement, transition animations, spacing control and other styles",
+          "descriptionZh": "文件列表容器，包含布局排列、过渡动画、间距控制等样式"
+        },
+        {
+          "key": "item",
+          "description": "File item element with padding, background color, border styles, hover effects, status colors, transition animations and other styles",
+          "descriptionZh": "文件项元素，包含内边距、背景色、边框样式、悬停效果、状态颜色、过渡动画等样式"
         }
       ]
     },
@@ -26517,7 +28049,8 @@
           "descriptionZh": "在 Modal 与 Drawer 中使用。",
           "code": "<script setup lang=\"ts\">\nimport { shallowRef } from 'vue'\n\nconst showModal = shallowRef(false)\nconst showDrawer = shallowRef(false)\nconst showDrawer2 = shallowRef(false)\n\nconst placeholderStyle = {\n  height: '300px',\n  display: 'flex',\n  justifyContent: 'center',\n  alignItems: 'center',\n  backgroundColor: 'rgba(150, 150, 150, 0.2)',\n}\n</script>\n\n<template>\n  <a-flex gap=\"middle\">\n    <a-button type=\"primary\" @click=\"showModal = true\">\n      Show in Modal\n    </a-button>\n    <a-button type=\"primary\" @click=\"showDrawer = true\">\n      Show in Drawer\n    </a-button>\n    <a-button type=\"primary\" @click=\"showDrawer2 = true\">\n      Not Show in Drawer\n    </a-button>\n  </a-flex>\n  <a-watermark content=\"Antdv Next\">\n    <a-modal\n      v-model:open=\"showModal\"\n      destroy-on-hidden\n      title=\"Modal\"\n      @ok=\"showModal = false\"\n      @cancel=\"showModal = false\"\n    >\n      <div :style=\"placeholderStyle\">\n        A mock height\n      </div>\n    </a-modal>\n    <a-drawer\n      v-model:open=\"showDrawer\"\n      destroy-on-hidden\n      title=\"Drawer\"\n      @close=\"showDrawer = false\"\n    >\n      <div :style=\"placeholderStyle\">\n        A mock height\n      </div>\n    </a-drawer>\n  </a-watermark>\n  <a-watermark content=\"Antdv Next\" :inherit=\"false\">\n    <a-drawer\n      v-model:open=\"showDrawer2\"\n      destroy-on-hidden\n      title=\"Drawer\"\n      @close=\"showDrawer2 = false\"\n    >\n      <div :style=\"placeholderStyle\">\n        A mock height\n      </div>\n    </a-drawer>\n  </a-watermark>\n</template>"
         }
-      ]
+      ],
+      "semanticStructure": []
     }
   ],
   "changelog": [

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -2,7 +2,7 @@
 
 import fs from 'node:fs/promises'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc.js'
 import { parse } from 'semver'
@@ -61,6 +61,12 @@ interface ComponentDemoRecord {
   code: string
 }
 
+interface ComponentSemanticStructureRecord {
+  key: string
+  description: string
+  descriptionZh: string
+}
+
 interface ComponentRecord {
   name: string
   nameZh: string
@@ -77,6 +83,7 @@ interface ComponentRecord {
   tokens: ComponentPropRecord[]
   faq: ComponentFaqRecord[]
   demos: ComponentDemoRecord[]
+  semanticStructure: ComponentSemanticStructureRecord[]
 }
 
 interface ComponentTokenMeta {
@@ -1141,7 +1148,25 @@ function getElementAttribute(openingTag: string, attributeName: string): string 
 }
 
 function parseDemoReferences(markdown: string): DemoReference[] {
+  const headings = parseHeadings(markdown)
+  const semanticSections = headings
+    .map((heading, index) => ({ heading, index }))
+    .filter(({ heading }) =>
+      heading.anchor === 'semantic-dom'
+      || ['semantic dom', '语义化 dom'].includes(normalizeHeadingTitle(heading.title)),
+    )
+    .map(({ heading, index }) => ({
+      start: heading.start,
+      end: headings
+        .slice(index + 1)
+        .find(candidate => candidate.level <= heading.level)
+        ?.start ?? markdown.length,
+    }))
+
   return extractElementBlocks(markdown, 'demo')
+    .filter(block => !semanticSections.some(section =>
+      block.start >= section.start && block.start < section.end,
+    ))
     .map(block => ({
       src: getElementAttribute(block.openingTag, 'src'),
       title: block.content.trim(),
@@ -1213,6 +1238,37 @@ async function readDemos(
   return demos.filter(demo => demo !== undefined)
 }
 
+async function readSemanticStructure(
+  componentDirectory: string,
+): Promise<ComponentSemanticStructureRecord[]> {
+  const localesFile = path.join(componentDirectory, 'locales.ts')
+  let modificationTime: number
+
+  try {
+    modificationTime = (await fs.stat(localesFile)).mtimeMs
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return []
+    }
+
+    throw error
+  }
+
+  const localesModule = await import(
+    `${pathToFileURL(localesFile).href}?mtime=${modificationTime}`,
+  ) as { locales: Record<'cn' | 'en', Record<string, string>> }
+  const locales = localesModule.locales
+
+  const { en, cn } = locales
+
+  return [...new Set([...Object.keys(en), ...Object.keys(cn)])].map(key => ({
+    key,
+    description: en[key] ?? '',
+    descriptionZh: cn[key] ?? '',
+  }))
+}
+
 function getFrontmatterField(
   frontmatter: Record<string, string>,
   field: string,
@@ -1252,7 +1308,10 @@ async function readComponent(
   const en = parseComponentDocument(enMarkdown)
   const zh = parseComponentDocument(zhMarkdown)
   const name = getFrontmatterField(en.frontmatter, 'name', 'title')
-  const demos = await readDemos(directory, enMarkdown, zhMarkdown)
+  const [demos, semanticStructure] = await Promise.all([
+    readDemos(directory, enMarkdown, zhMarkdown),
+    readSemanticStructure(directory),
+  ])
   const component = {
     name,
     nameZh: getFrontmatterField(zh.frontmatter, 'subtitle'),
@@ -1269,11 +1328,12 @@ async function readComponent(
     tokens: getComponentTokens(name, tokenMeta, tokenDefaults),
     faq: parseFaq(enMarkdown),
     demos,
+    semanticStructure,
   }
 
   logStep(
     componentScope,
-    `Parsed ${component.props.length} props, ${component.tokens.length} tokens, ${component.faq.length} FAQs and ${component.demos.length} demos`,
+    `Parsed ${component.props.length} props, ${component.tokens.length} tokens, ${component.faq.length} FAQs, ${component.demos.length} demos and ${component.semanticStructure.length} semantic structures`,
   )
 
   return component


### PR DESCRIPTION
- Import pathToFileURL from node:url module
- Add ComponentSemanticStructureRecord interface definition
- Extend ComponentRecord interface with semanticStructure field
- Parse semantic DOM sections from markdown content
- Filter out demo blocks that appear within semantic sections
- Create readSemanticStructure function to load locale data
- Load semantic structure information from locales.ts files
- Include semantic structure in component parsing results
- Update log message to include semantic structure count