### PR TITLE
ci(sync): remove pnpm version specification from sync workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: Install latest pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: latest
 
       - name: Set up Node.js
         uses: actions/setup-node@v7


### PR DESCRIPTION
- Removed explicit pnpm version setting in GitHub Actions workflow
- Kept Node.js setup action unchanged
- Simplified workflow configuration by removing unnecessary version constraint