### PR TITLE
chore(lint): disable unused variable rule for imports

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -14,6 +14,7 @@ const config = antfu({
     'node/prefer-global/process': 'off',
     'antfu/top-level-function': 'off',
     'regexp/no-unused-capturing-group': 'off',
+    'unused-imports/no-unused-vars': 'off',
   },
   yaml: {
     overrides: {

--- a/scripts/tokens.ts
+++ b/scripts/tokens.ts
@@ -48,7 +48,7 @@ export async function fetchTokens(version: string): Promise<void> {
       },
     })
   }
-  // eslint-disable-next-line unused-imports/no-unused-vars
+
   catch (error) {
   }
 }
@@ -70,7 +70,7 @@ export async function loaderVersionToken(version: string) {
       descriptionZh: g.desc,
     })) as TokenData[]
   }
-  // eslint-disable-next-line unused-imports/no-unused-vars
+
   catch (error) {
     return []
   }

--- a/src/commands/demo.ts
+++ b/src/commands/demo.ts
@@ -121,7 +121,7 @@ export default defineCommand({
 
       console.log(outputDemoCode(demos[args.name]!, args))
     }
-    // eslint-disable-next-line unused-imports/no-unused-vars
+
     catch (error) {
       console.log(`Error: Component '${args.component}' not found`)
     }

--- a/src/commands/token.ts
+++ b/src/commands/token.ts
@@ -80,7 +80,7 @@ export default defineCommand({
         markdown: outputTokenMarkdown(metaData.globalTokens),
       }, args.format)
     }
-    // eslint-disable-next-line unused-imports/no-unused-vars
+
     catch (error) {
       console.log(`Error: Component '${args.component}' not found`)
       process.exit(1)

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -10,7 +10,7 @@ export const getPackageManagerVersion = async (cwd: string, manager: string): Pr
     })
     return stdout.trim()
   }
-  // eslint-disable-next-line unused-imports/no-unused-vars
+
   catch (error) {
     return '0.0.0'
   }


### PR DESCRIPTION
- Turned off 'unused-imports/no-unused-vars' rule in eslint configuration
- Maintained other linting rules including node/prefer-global/process
- Kept antfu/top-level-function and regexp/no-unused-capturing-group disabled
- Preserved yaml overrides section structure
