### PR TITLE
ci(sync): add conditional sync check to GitHub workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -14,7 +14,37 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      needs_sync: ${{ steps.check-version.outputs.needs_sync }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Install latest pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: lts/*
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check if sync needed
+        id: check-version
+        run: pnpm exec tsx scripts/check-sync-needed.ts
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   sync:
+    needs: check
+    if: needs.check.outputs.needs_sync == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 


### PR DESCRIPTION
- Add new check job to determine if sync is needed
- Implement version checking logic via check-sync-needed.ts script
- Configure job dependencies to only run sync when needed
- Set up Node.js environment with LTS version
- Add dependency installation step using pnpm
- Include cancellation protection with timeout configuration
- Pass GitHub token for authentication in check process
