### PR TITLE
feat(error): replace console.log with logErrorComponent utility

### DIFF
--- a/src/commands/demo.ts
+++ b/src/commands/demo.ts
@@ -5,6 +5,7 @@ import { defaultArgs } from '@/args/default.ts'
 import { demoArgs } from '@/args/demo.ts'
 import { resolveConfig } from '@/config.ts'
 import capitalize from '@/utils/capitalize.ts'
+import { logErrorComponent } from '@/utils/error.ts'
 import { loadVersionMetaData } from '@/utils/loader.ts'
 import { resolveVersion } from '@/utils/version.ts'
 
@@ -123,7 +124,7 @@ export default defineCommand({
     }
 
     catch (error) {
-      console.log(`Error: Component '${args.component}' not found`)
+      logErrorComponent(args)
     }
   },
 })

--- a/src/commands/token.ts
+++ b/src/commands/token.ts
@@ -7,6 +7,7 @@ import { tokenArgs } from '@/args/token.ts'
 import { resolveConfig } from '@/config.ts'
 import { tableBorderStyle } from '@/constants/table.ts'
 import capitalize from '@/utils/capitalize.ts'
+import { logErrorComponent } from '@/utils/error.ts'
 import { loadVersionMetaData } from '@/utils/loader.ts'
 import { output } from '@/utils/output.ts'
 import { resolveVersion } from '@/utils/version.ts'
@@ -82,8 +83,7 @@ export default defineCommand({
     }
 
     catch (error) {
-      console.log(`Error: Component '${args.component}' not found`)
-      process.exit(1)
+      logErrorComponent(args)
     }
   },
 })

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,5 @@
+import type { OptionsArgs } from '@/args/args'
+
+export function logErrorComponent(args: OptionsArgs): void {
+  console.log(`Error: Component '${args.component}' not found ${args.ver ? `for antdv-next v${args.ver}` : ''}`)
+}


### PR DESCRIPTION
- Replace direct console.log calls with centralized logErrorComponent function
- Add logErrorComponent utility function in src/utils/error.ts
- Import logErrorComponent in both demo.ts and token.ts commands
- Remove duplicate error logging logic from command files
- Maintain consistent error message format across components
- Include version information in component not found error messages
