### PR TITLE
fix(commands): replace console.log with error logging utility

### DIFF
--- a/src/commands/semantic.ts
+++ b/src/commands/semantic.ts
@@ -4,6 +4,7 @@ import { componentArgs } from '@/args/component.ts'
 import { defaultArgs } from '@/args/default.ts'
 import { resolveConfig } from '@/config.ts'
 import capitalize from '@/utils/capitalize.ts'
+import { logErrorComponent } from '@/utils/error.ts'
 import { loadComponent, loadVersionMetaData } from '@/utils/loader.ts'
 import { output } from '@/utils/output.ts'
 import { resolveVersion } from '@/utils/version.ts'
@@ -67,7 +68,7 @@ export default defineCommand({
       }, args.format)
     }
     catch (error) {
-      console.log(`Error: Component ${component} not found!`)
+      logErrorComponent(args)
     }
   },
 })

--- a/src/commands/token.ts
+++ b/src/commands/token.ts
@@ -1,5 +1,4 @@
 import type { ComponentPropRecord } from '#/components.ts'
-import process from 'node:process'
 import { defineCommand } from 'citty'
 import { Table } from 'console-table-printer'
 import { defaultArgs } from '@/args/default.ts'
@@ -58,8 +57,8 @@ export default defineCommand({
       if (args.component) {
         const components = metaData.components.filter(c => c.name === capitalize(args.component))
         if (!components.length) {
-          console.log(`Error: Component ${args.component} not Found`)
-          process.exit(1)
+          logErrorComponent(args)
+          return ''
         }
 
         if (args.format !== 'json') {


### PR DESCRIPTION
- Import logErrorComponent utility in semantic.ts
- Replace console.log error message with logErrorComponent call in semantic.ts
- Remove unused process import from token.ts
- Replace console.log and process.exit with logErrorComponent and return in token.ts
- Consolidate error handling using shared logging utility across commands
