### PR TITLE
ci: add PR title validation workflow

### DIFF
--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,0 +1,31 @@
+name: Validate PR title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions: {}
+
+jobs:
+  semantic-pr:
+    permissions:
+      contents: read
+      pull-requests: read # for amannn/action-semantic-pull-request to analyze PRs
+      statuses: write # for amannn/action-semantic-pull-request to mark status of analyzed PR
+    if: github.repository == 'antdv-next/cli'
+    runs-on: ubuntu-slim
+    name: 🏷️ Validate PR title
+    steps:
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        with:
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Add semantic pull request validation using amannn/action-semantic-pull-request
- Configure validation to run on pull_request_target opened, edited, and synchronize events
- Set up permissions for contents read, pull-requests read, and statuses write
- Apply validation only to antdv-next/cli repository
- Use ubuntu-slim runner for validation job
- Enforce subject pattern to prevent uppercase first letter in PR titles
- Provide custom error message for subject pattern violations
- Configure GITHUB_TOKEN environment variable for authentication
