### PR TITLE
fix(args): replace tokenArgs with componentArgs in command configuration

### DIFF
--- a/src/args/args.d.ts
+++ b/src/args/args.d.ts
@@ -1,12 +1,12 @@
 import type { ParsedArgs } from 'citty'
 import type { bugArgs } from '@/args/bug.ts'
+import type { componentArgs } from '@/args/component.ts'
 import type { defaultArgs } from '@/args/default.ts'
 import type { demoArgs } from '@/args/demo.ts'
-import type { tokenArgs } from '@/args/token.ts'
 
 export type OptionsArgs = ParsedArgs<typeof defaultArgs>
   & Partial<
     ParsedArgs<typeof bugArgs>
-    & ParsedArgs<typeof tokenArgs>
+    & ParsedArgs<typeof componentArgs>
     & ParsedArgs<typeof demoArgs>
   >

--- a/src/args/token.ts
+++ b/src/args/token.ts
@@ -1,9 +1,0 @@
-import type { ArgsDef } from 'citty'
-
-export const tokenArgs = {
-  component: {
-    type: 'positional',
-    description: 'Query Design Tokens (global or component-level)',
-    default: '',
-  },
-} satisfies ArgsDef

--- a/src/commands/token.ts
+++ b/src/commands/token.ts
@@ -1,8 +1,8 @@
 import type { ComponentPropRecord } from '#/components.ts'
 import { defineCommand } from 'citty'
 import { Table } from 'console-table-printer'
+import { componentArgs } from '@/args/component.ts'
 import { defaultArgs } from '@/args/default.ts'
-import { tokenArgs } from '@/args/token.ts'
 import { resolveConfig } from '@/config.ts'
 import { tableBorderStyle } from '@/constants/table.ts'
 import capitalize from '@/utils/capitalize.ts'
@@ -45,7 +45,7 @@ export default defineCommand({
   },
   args: {
     ...defaultArgs,
-    ...tokenArgs,
+    ...componentArgs,
   },
   async run({ args }) {
     const config = resolveConfig(args)


### PR DESCRIPTION
- Removed tokenArgs import and type reference from args.d.ts
- Added componentArgs import to replace tokenArgs in OptionsArgs type
- Replaced tokenArgs with componentArgs in token.ts command definition
- Updated command arguments to use componentArgs instead of tokenArgs
- Removed unused token.ts file containing old tokenArgs definition
- Maintained same functionality with new component-based argument structure
