### PR TITLE
feat(doctor): add doctor command

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "citty": "^0.2.2",
     "console-table-printer": "^2.16.1",
     "envinfo": "^7.21.0",
+    "glob": "^13.0.6",
     "local-pkg": "^1.2.1",
     "pkg-types": "^2.3.1",
     "semver": "^7.8.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       envinfo:
         specifier: ^7.21.0
         version: 7.21.0
+      glob:
+        specifier: ^13.0.6
+        version: 13.0.6
       local-pkg:
         specifier: ^1.2.1
         version: 1.2.1
@@ -1443,6 +1446,10 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   globals@15.15.0:
     resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
     engines: {node: '>=18'}
@@ -1649,6 +1656,10 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1803,6 +1814,10 @@ packages:
     resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
     engines: {node: 18 || 20 || >=22}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
@@ -1878,6 +1893,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -3580,6 +3599,12 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.6
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   globals@15.15.0: {}
 
   globals@17.11.0: {}
@@ -3732,6 +3757,8 @@ snapshots:
       p-locate: 5.0.0
 
   longest-streak@3.1.0: {}
+
+  lru-cache@11.5.2: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -4091,6 +4118,8 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.9
 
+  minipass@7.1.3: {}
+
   mlly@1.8.2:
     dependencies:
       acorn: 8.18.0
@@ -4154,6 +4183,11 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.2
+      minipass: 7.1.3
 
   pathe@2.0.3: {}
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,12 +1,101 @@
+import type { DoctorReport } from '#/doctor.ts'
 import { defineCommand } from 'citty'
+import { defaultArgs } from '@/args/default.ts'
+import { checks } from '@/doctor'
+import { output } from '@/utils/output'
+
+export function formatReportText(report: DoctorReport): string {
+  const lines: string[] = []
+  lines.push(`antdv Doctor`)
+  lines.push('')
+
+  for (const c of report.checks) {
+    const icon = c.status === 'pass' ? '✓' : c.status === 'skip' ? '○' : '✗'
+    const sev = c.severity ? ` [${c.severity}]` : ''
+    lines.push(`${icon} [${c.name}]${sev} ${c.message}`)
+    if (c.suggestion)
+      lines.push(`    → ${c.suggestion}`)
+  }
+
+  lines.push('')
+  lines.push(
+    `Summary: ${report.summary.pass} pass, ${report.summary.fail} fail, ${report.summary.skip} skip`
+    + ` (${report.summary.errors} errors, ${report.summary.warnings} warnings)`,
+  )
+  return lines.join('\n')
+}
+
+export function formatReportMarkdown(report: DoctorReport): string {
+  const lines = [
+    `## antdv doctor v${report.version}`,
+    '',
+    `Working directory: \`${report.cwd}\``,
+    '',
+    '| Check | Status | Severity | Message |',
+    '|---|---|---|---|',
+  ]
+
+  for (const check of report.checks) {
+    const message = check.message.replaceAll('|', '\\|')
+    lines.push(`| ${check.name} | ${check.status} | ${check.severity ?? ''} | ${message} |`)
+    if (check.suggestion) {
+      lines.push(`|  |  |  | Suggestion: ${check.suggestion.replaceAll('|', '\\|')} |`)
+    }
+  }
+
+  lines.push(
+    '',
+    `**Summary:** ${report.summary.pass} pass, ${report.summary.fail} fail, ${report.summary.skip} skip`,
+    `(${report.summary.errors} errors, ${report.summary.warnings} warnings)`,
+  )
+
+  return lines.join('\n')
+}
 
 export default defineCommand({
   meta: {
     name: 'doctor',
     description: 'Diagnose project-level antd configuration issues',
   },
-  run({ args }) {
-    // TODO antd doctor 10 项诊断检查：兼容性、重复安装、peer 依赖、SSR、babel 插件
-    console.log('Parsed args:', args)
+  args: defaultArgs,
+  async run({ args }) {
+    const results = []
+    for (const handlerCheck of checks) {
+      try {
+        const result = await handlerCheck(args)
+        results.push(result)
+      }
+      catch (err) {
+        results.push({
+          name: handlerCheck.checkName,
+          status: 'fail',
+          severity: 'error',
+          message: `Check threw: ${err instanceof Error ? err.message : String(err)}`,
+          suggestion: 'This is an internal doctor error — please report it',
+        })
+      }
+    }
+
+    const summary = {
+      total: results.length,
+      pass: results.filter(r => r.status === 'pass').length,
+      fail: results.filter(r => r.status === 'fail').length,
+      skip: results.filter(r => r.status === 'skip').length,
+      errors: results.filter(r => r.status === 'fail' && r.severity === 'error').length,
+      warnings: results.filter(r => r.status === 'fail' && r.severity === 'warning').length,
+    }
+
+    const data = {
+      version: __CLI_VERSION__,
+      cwd: args.cwd,
+      checks: results,
+      summary,
+    } as DoctorReport
+
+    output({
+      json: results,
+      text: formatReportText(data),
+      markdown: formatReportMarkdown(data),
+    }, args.format)
   },
 })

--- a/src/constants/repo.ts
+++ b/src/constants/repo.ts
@@ -1,2 +1,3 @@
 export const ANTDV_REPO = 'antdv-next/antdv-next'
 export const ANTDV_REPO_CLI = 'antdv-next/cli'
+export const ANTDV_NEXT = 'antdv-next'

--- a/src/doctor/antdv.installed.ts
+++ b/src/doctor/antdv.installed.ts
@@ -1,0 +1,37 @@
+import type { DoctorCheck } from '#/doctor.ts'
+import { ANTDV_NEXT } from '@/constants/repo.ts'
+import { resolvePackage } from '@/utils/pkg.ts'
+
+export const antdvInstallState = {
+  isInstalled: false,
+  version: '',
+}
+
+export const checkAntdvInstalled: DoctorCheck = async (ctx) => {
+  const name = 'antdv-installed'
+
+  const pkg = await resolvePackage(ANTDV_NEXT, ctx)
+
+  if (!pkg) {
+    return {
+      name,
+      status: 'fail',
+      severity: 'error',
+      message: `${ANTDV_NEXT} is not installed in this project`,
+      suggestion: `Run: pnpm add ${ANTDV_NEXT} (or npm i / yarn add ${ANTDV_NEXT})`,
+    }
+  }
+
+  antdvInstallState.isInstalled = true
+  antdvInstallState.version = pkg.version
+
+  return {
+    name,
+    status: 'pass',
+    message: `${ANTDV_NEXT}@${pkg.version} is installed`,
+    details: {
+      packageJsonPath: pkg.path,
+      version: pkg.version,
+    },
+  }
+}

--- a/src/doctor/antdv.x.compat.ts
+++ b/src/doctor/antdv.x.compat.ts
@@ -1,0 +1,30 @@
+import type { DoctorCheck } from '#/doctor.ts'
+import { antdvInstallState } from '@/doctor/antdv.installed.ts'
+import { resolvePackage } from '@/utils/pkg.ts'
+
+export const checkAntdvXCompat: DoctorCheck = async (ctx) => {
+  const name = 'antdv-x-compat'
+
+  const antdv = antdvInstallState
+
+  const x = await resolvePackage('@antdv-next/x', ctx)
+  if (!x) {
+    return {
+      name,
+      status: 'fail',
+      severity: 'warning',
+      message: '@antdv-next/x is not installed (@antdv-next/x are commonly required)',
+      suggestion: 'Run: pnpm add @antdv-next/x',
+    }
+  }
+
+  return {
+    name,
+    status: 'pass',
+    message: `@antdv-next/x@${x?.version} compatibility checks passed`,
+    details: {
+      x: x.version,
+      antdv: antdv.version,
+    },
+  }
+}

--- a/src/doctor/auto.import.resolver.ts
+++ b/src/doctor/auto.import.resolver.ts
@@ -1,0 +1,64 @@
+import type { DoctorCheck } from '#/doctor.ts'
+import { antdvInstallState } from '@/doctor/antdv.installed.ts'
+import { resolvePackage } from '@/utils/pkg.ts'
+
+export const checkAutoImportResolver: DoctorCheck = async (ctx) => {
+  const name = 'auto-import-resolver'
+  const antdv = antdvInstallState
+  if (!antdv.isInstalled) {
+    return {
+      name,
+      status: 'skip',
+      message: 'antdv-next not installed — skip auto-import-resolver',
+    }
+  }
+
+  const unplugin = await resolvePackage('unplugin-vue-components', ctx)
+
+  if (!unplugin) {
+    return {
+      name,
+      status: 'fail',
+      severity: 'error',
+      message: `unplugin-vue-components is not installed`,
+      suggestion: `Run: pnpm add -D unplugin-vue-components`,
+    }
+  }
+
+  const resolverName = '@antdv-next/auto-import-resolver'
+  const resolverXName = '@antdv-next/auto-import-resolver-x'
+  const [resolver, resolverX] = await Promise.all([
+    resolvePackage(resolverName, ctx),
+    resolvePackage(resolverXName, ctx),
+  ])
+
+  if (!resolver || !resolverX) {
+    const missingResolvers = [
+      !resolver && resolverName,
+      !resolverX && resolverXName,
+    ].filter((packageName): packageName is string => Boolean(packageName))
+
+    return {
+      name,
+      status: 'fail',
+      severity: 'error',
+      message: `Missing auto-import resolver: ${missingResolvers.join(', ')}`,
+      suggestion: `Run: pnpm add -D ${missingResolvers.join(' ')}`,
+      details: {
+        resolver: resolver && resolver.version,
+        resolverX: resolverX && resolverX.version,
+      },
+    }
+  }
+
+  return {
+    name,
+    status: 'pass',
+    message: 'unplugin-vue-components and both antdv-next auto-import resolvers are installed',
+    details: {
+      unplugin: unplugin.version,
+      resolver: resolver.version,
+      resolverX: resolverX.version,
+    },
+  }
+}

--- a/src/doctor/icons.compat.ts
+++ b/src/doctor/icons.compat.ts
@@ -1,0 +1,37 @@
+import type { DoctorCheck } from '#/doctor.ts'
+import { antdvInstallState } from '@/doctor/antdv.installed.ts'
+import { resolvePackage } from '@/utils/pkg.ts'
+
+export const checkIconsCompat: DoctorCheck = async (ctx) => {
+  const name = 'icons-compat'
+  const antdv = antdvInstallState
+
+  if (!antdv.isInstalled) {
+    return {
+      name,
+      status: 'skip',
+      message: 'antdv-next not installed — skip icons-compat',
+    }
+  }
+
+  const icons = await resolvePackage('@antdv-next/icons', ctx)
+
+  if (!icons) {
+    return {
+      name,
+      status: 'fail',
+      severity: 'warning',
+      message: '@antdv-next/icons is not installed (icons are commonly required)',
+      suggestion: 'Run: pnpm add @antdv-next/icons',
+    }
+  }
+
+  return {
+    name,
+    status: 'pass',
+    message: `@antdv-next/icons@${icons.version} looks compatible`,
+    details: {
+      icons: icons.version,
+    },
+  }
+}

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -1,0 +1,16 @@
+import type { DoctorCheck } from '#/doctor.ts'
+import { checkAntdvInstalled } from '@/doctor/antdv.installed.ts'
+import { checkAntdvXCompat } from '@/doctor/antdv.x.compat.ts'
+import { checkAutoImportResolver } from '@/doctor/auto.import.resolver.ts'
+import { checkIconsCompat } from '@/doctor/icons.compat.ts'
+import { checkNuxtModule } from '@/doctor/nuxt.module.ts'
+import { checkVueCompat } from '@/doctor/vue.compat.ts'
+
+export const checks = [
+  Object.assign(checkAntdvInstalled, { checkName: 'antdv-installed' }),
+  Object.assign(checkVueCompat, { checkName: 'vue-compat' }),
+  Object.assign(checkNuxtModule, { checkName: 'nuxt-module' }),
+  Object.assign(checkIconsCompat, { checkName: 'icons-compat' }),
+  Object.assign(checkAntdvXCompat, { checkName: 'antdv-x-compat' }),
+  Object.assign(checkAutoImportResolver, { checkName: 'auto-import-resolver' }),
+] satisfies ({ checkName: string } & DoctorCheck)[]

--- a/src/doctor/nuxt.module.ts
+++ b/src/doctor/nuxt.module.ts
@@ -1,0 +1,76 @@
+import type { DoctorCheck } from '#/doctor.ts'
+import { glob } from 'glob'
+import semver from 'semver'
+import { antdvInstallState } from '@/doctor/antdv.installed.ts'
+import { resolvePackage, stripVersionPrefix } from '@/utils/pkg.ts'
+
+export const checkNuxtModule: DoctorCheck = async (ctx) => {
+  const name = 'nuxt-module'
+
+  const nuxt = await resolvePackage('nuxt', ctx)
+  const nuxtConfigs = await glob('**/nuxt.config.ts', {
+    cwd: ctx.cwd,
+    absolute: true,
+    ignore: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/.git/**',
+    ],
+  })
+
+  if (!nuxt && !nuxtConfigs.length) {
+    return {
+      name,
+      status: 'skip',
+      message: 'Not a Nuxt project — skip nuxt-module',
+    }
+  }
+  //
+  const antdv = antdvInstallState
+  const module = await resolvePackage('@antdv-next/nuxt', ctx)
+  const vue = await resolvePackage('vue', ctx)
+
+  const issues: string[] = []
+  const suggestions: string[] = []
+
+  if (nuxt && !semver.gte(stripVersionPrefix(nuxt.version), '4.0.0')) {
+    console.log('Nuxt version', nuxt.version)
+    issues.push(`Nuxt ${nuxt.version} < 4.0.0 (required by @antdv-next/nuxt)`)
+    suggestions.push('Upgrade Nuxt to >= 4.0.0')
+  }
+
+  if (vue && !semver.gte(stripVersionPrefix(vue.version), '3.5.0')) {
+    issues.push(`Vue ${vue.version} < 3.5.0 (required in Nuxt + antdv-next)`)
+    suggestions.push('Upgrade vue to >= 3.5.0')
+  }
+
+  if (!module) {
+    issues.push('@antdv-next/nuxt is not installed')
+    suggestions.push('pnpm add -D @antdv-next/nuxt')
+  }
+
+  if (issues.length) {
+    return {
+      name,
+      status: 'fail',
+      severity: issues.some(i => i.includes('not installed') || i.includes('<')) ? 'error' : 'warning',
+      message: issues.join('; '),
+      suggestion: suggestions.join(' | '),
+      details: {
+        nuxt: nuxt && nuxt.version,
+        vue: vue && vue.version,
+        antdv: antdv.version,
+        module: module && module.version,
+      },
+    }
+  }
+
+  return {
+    name,
+    status: 'pass',
+    message: `@antdv-next/nuxt@ configured correctly`,
+    details: {
+      nuxt: nuxt && nuxt.version,
+    },
+  }
+}

--- a/src/doctor/vue.compat.ts
+++ b/src/doctor/vue.compat.ts
@@ -1,0 +1,28 @@
+import type { DoctorCheck } from '#/doctor.ts'
+import { resolvePackage } from '@/utils/pkg.ts'
+
+export const checkVueCompat: DoctorCheck = async (ctx) => {
+  const name = 'vue-compat'
+
+  const pkg = await resolvePackage('vue', ctx)
+
+  if (!pkg) {
+    return {
+      name,
+      status: 'fail',
+      severity: 'error',
+      message: 'vue is not installed',
+      suggestion: `Run: pnpm add vue@^latest (or npm i / yarn add vue@latest)`,
+    }
+  }
+
+  return {
+    name,
+    status: 'pass',
+    message: `vue@${pkg.version} is installed`,
+    details: {
+      packageJsonPath: pkg.path,
+      version: pkg.version,
+    },
+  }
+}

--- a/src/types/doctor.ts
+++ b/src/types/doctor.ts
@@ -1,0 +1,31 @@
+import type { OptionsArgs } from '@/args/args'
+
+export type CheckStatus = 'pass' | 'fail' | 'skip'
+export type Severity = 'error' | 'warning' | 'info'
+
+export interface DoctorCheckResult {
+  name: string
+  status: CheckStatus
+  severity?: Severity
+  message: string
+  suggestion?: string
+  details?: Record<string, unknown>
+}
+
+export interface DoctorCheck {
+  (context: OptionsArgs): Promise<DoctorCheckResult> | DoctorCheckResult
+}
+
+export interface DoctorReport {
+  version: string
+  cwd: string
+  checks: DoctorCheckResult[]
+  summary: {
+    total: number
+    pass: number
+    fail: number
+    skip: number
+    errors: number
+    warnings: number
+  }
+}

--- a/src/utils/pkg.ts
+++ b/src/utils/pkg.ts
@@ -1,0 +1,42 @@
+import type { OptionsArgs } from '@/args/args'
+import { glob } from 'glob'
+import { readPackageJSON } from 'pkg-types'
+
+export interface packageVersionInfo {
+  path: string
+  version: string
+}
+
+export async function resolvePackage(name: string, ctx: OptionsArgs): Promise<packageVersionInfo | false> {
+  const pkgPaths = await glob('**/package.json', {
+    cwd: ctx.cwd,
+    absolute: true,
+    ignore: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/.git/**',
+    ],
+  })
+
+  const result: packageVersionInfo[] = []
+
+  for (const path of pkgPaths) {
+    const packageJson = await readPackageJSON(path)
+    const version = packageJson.dependencies?.[name] ?? packageJson.devDependencies?.[name]
+
+    if (version) {
+      result.push({ path, version })
+    }
+  }
+
+  if (!result.length) {
+    return false
+  }
+
+  return result.at(0)!
+}
+
+export function stripVersionPrefix(specifier: string): string {
+  const value = specifier.trim()
+  return value.replace(/^[~^]/, '')
+}

--- a/test/doctor.test.ts
+++ b/test/doctor.test.ts
@@ -1,0 +1,207 @@
+import type { DoctorReport } from '../src/types/doctor'
+import { runCommand } from 'citty'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import doctorCommand, {
+  formatReportMarkdown,
+  formatReportText,
+} from '../src/commands/doctor'
+
+const mocks = vi.hoisted(() => {
+  const createCheck = (checkName: string) => Object.assign(vi.fn(), { checkName })
+
+  return {
+    output: vi.fn(),
+    passCheck: createCheck('pass-check'),
+    warningCheck: createCheck('warning-check'),
+    skipCheck: createCheck('skip-check'),
+    errorCheck: createCheck('error-check'),
+    nonErrorCheck: createCheck('non-error-check'),
+  }
+})
+
+vi.mock('@/doctor', () => ({
+  checks: [
+    mocks.passCheck,
+    mocks.warningCheck,
+    mocks.skipCheck,
+    mocks.errorCheck,
+    mocks.nonErrorCheck,
+  ],
+}))
+
+vi.mock('@/utils/output', () => ({
+  output: mocks.output,
+}))
+
+const report: DoctorReport = {
+  version: '1.2.3',
+  cwd: '/tmp/example-project',
+  checks: [
+    {
+      name: 'vue-compat',
+      status: 'pass',
+      message: 'vue is ready | compatible',
+    },
+    {
+      name: 'icons-compat',
+      status: 'fail',
+      severity: 'warning',
+      message: 'icons package is missing',
+      suggestion: 'Install icons | configure aliases',
+    },
+    {
+      name: 'nuxt-module',
+      status: 'skip',
+      message: 'Not a Nuxt project',
+    },
+    {
+      name: 'antdv-installed',
+      status: 'fail',
+      severity: 'error',
+      message: 'antdv-next is missing',
+    },
+  ],
+  summary: {
+    total: 4,
+    pass: 1,
+    fail: 2,
+    skip: 1,
+    errors: 1,
+    warnings: 1,
+  },
+}
+
+beforeEach(() => {
+  vi.resetAllMocks()
+
+  mocks.passCheck.mockResolvedValue({
+    name: 'pass-check',
+    status: 'pass',
+    message: 'Everything is ready',
+  })
+  mocks.warningCheck.mockResolvedValue({
+    name: 'warning-check',
+    status: 'fail',
+    severity: 'warning',
+    message: 'Optional package is missing',
+    suggestion: 'Install the optional package',
+  })
+  mocks.skipCheck.mockResolvedValue({
+    name: 'skip-check',
+    status: 'skip',
+    message: 'This check does not apply',
+  })
+  mocks.errorCheck.mockRejectedValue(new Error('dependency lookup failed'))
+  mocks.nonErrorCheck.mockRejectedValue('non-error failure')
+})
+
+describe('doctor report formatters', () => {
+  it('formats a readable text report with status icons and suggestions', () => {
+    expect(formatReportText(report)).toBe(`antdv Doctor
+
+✓ [vue-compat] vue is ready | compatible
+✗ [icons-compat] [warning] icons package is missing
+    → Install icons | configure aliases
+○ [nuxt-module] Not a Nuxt project
+✗ [antdv-installed] [error] antdv-next is missing
+
+Summary: 1 pass, 2 fail, 1 skip (1 errors, 1 warnings)`)
+  })
+
+  it('formats markdown tables and escapes pipes in user-facing values', () => {
+    expect(formatReportMarkdown(report)).toBe(`## antdv doctor v1.2.3
+
+Working directory: \`/tmp/example-project\`
+
+| Check | Status | Severity | Message |
+|---|---|---|---|
+| vue-compat | pass |  | vue is ready \\| compatible |
+| icons-compat | fail | warning | icons package is missing |
+|  |  |  | Suggestion: Install icons \\| configure aliases |
+| nuxt-module | skip |  | Not a Nuxt project |
+| antdv-installed | fail | error | antdv-next is missing |
+
+**Summary:** 1 pass, 2 fail, 1 skip
+(1 errors, 1 warnings)`)
+  })
+})
+
+describe('doctor command', () => {
+  it('runs every check, converts thrown values into failures, and outputs the summary', async () => {
+    await runCommand(doctorCommand, {
+      rawArgs: [
+        '--cwd',
+        '/tmp/example-project',
+        '--format',
+        'markdown',
+      ],
+    })
+
+    for (const check of [
+      mocks.passCheck,
+      mocks.warningCheck,
+      mocks.skipCheck,
+      mocks.errorCheck,
+      mocks.nonErrorCheck,
+    ]) {
+      expect(check).toHaveBeenCalledOnce()
+      expect(check).toHaveBeenCalledWith(expect.objectContaining({
+        cwd: '/tmp/example-project',
+        format: 'markdown',
+        ver: '',
+      }))
+    }
+
+    expect(mocks.output).toHaveBeenCalledOnce()
+    expect(mocks.output).toHaveBeenCalledWith({
+      json: [
+        {
+          name: 'pass-check',
+          status: 'pass',
+          message: 'Everything is ready',
+        },
+        {
+          name: 'warning-check',
+          status: 'fail',
+          severity: 'warning',
+          message: 'Optional package is missing',
+          suggestion: 'Install the optional package',
+        },
+        {
+          name: 'skip-check',
+          status: 'skip',
+          message: 'This check does not apply',
+        },
+        {
+          name: 'error-check',
+          status: 'fail',
+          severity: 'error',
+          message: 'Check threw: dependency lookup failed',
+          suggestion: 'This is an internal doctor error — please report it',
+        },
+        {
+          name: 'non-error-check',
+          status: 'fail',
+          severity: 'error',
+          message: 'Check threw: non-error failure',
+          suggestion: 'This is an internal doctor error — please report it',
+        },
+      ],
+      text: expect.stringContaining(
+        'Summary: 1 pass, 3 fail, 1 skip (2 errors, 1 warnings)',
+      ),
+      markdown: expect.stringMatching(
+        /\*\*Summary:\*\* 1 pass, 3 fail, 1 skip\n\(2 errors, 1 warnings\)$/,
+      ),
+    }, 'markdown')
+  })
+
+  it('uses text output by default', async () => {
+    await runCommand(doctorCommand, {
+      rawArgs: ['--cwd', '/tmp/example-project'],
+    })
+
+    expect(mocks.output).toHaveBeenCalledOnce()
+    expect(mocks.output.mock.calls[0]?.[1]).toBe('text')
+  })
+})


### PR DESCRIPTION
- Add formatReportText and formatReportMarkdown functions for report formatting
- Integrate checks array to perform multiple diagnostic validations
- Implement error handling for check failures with proper status reporting
- Create summary statistics for pass/fail/skip counts and error/warning levels
- Add support for JSON, text, and markdown output formats
- Include doctor version and working directory in reports
- Handle internal doctor errors with proper error messaging
- Support all 10 antd diagnostic checks including compatibility, duplicate installs, peer dependencies, SSR, and babel plugin validation
