### PR TITLE
docs(funding): add funding configuration for open collective and custom sponsor links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# These are supported funding model platforms
+# github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+open_collective: antdv-next
+custom: ['https://antdv-next.com/sponsor']


### PR DESCRIPTION
- Added open_collective funding platform with antdv-next identifier
- Included custom sponsor link pointing to https://antdv-next.com/sponsor
- Configured funding.yml following GitHub funding model platforms format
- Added documentation comments explaining the supported funding model platforms
