### PR TITLE
feat(info): add common props support to component info command

### DIFF
--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -1,5 +1,6 @@
 import type { ComponentApiItemRecord, ComponentApiRecord, ComponentRecord } from '#/components.ts'
 import type { OutputFormat } from '@/args/default.ts'
+import type { ResolvedVersion } from '@/types.ts'
 import { defineCommand } from 'citty'
 import { Table } from 'console-table-printer'
 import { componentArgs } from '@/args/component.ts'
@@ -13,9 +14,33 @@ import { output } from '@/utils/output.ts'
 import { resolveVersion } from '@/utils/version.ts'
 
 const COMMAND_ANCHOR_FIELDS = ['properties', 'events', 'slots', 'methods'] as (keyof ComponentApiRecord)[]
+const COMMON_PROPS: ComponentApiItemRecord[] = [
+  {
+    name: 'style',
+    type: 'CSSProperties',
+    default: '-',
+    description: 'The additional style',
+    descriptionZh: '自定义样式',
+  },
+  { name: 'class', type: 'string', default: '-', description: 'The additional css class', descriptionZh: '自定义类名' },
+  {
+    name: 'rootClass',
+    type: 'string',
+    default: '-',
+    description: 'ClassName on the root element',
+    descriptionZh: '添加在组件最外层的 className',
+  },
+  {
+    name: 'autoFocus',
+    type: 'boolean',
+    default: 'false',
+    description: 'Auto focus when component mounted, only effective for focusable elements like forms, links, etc.',
+    descriptionZh: '自动获取焦点，仅对表单类、链接、交互容器等可聚焦元素生效',
+  },
+]
 
 function outputJson(component: ComponentRecord): object {
-  const { name, nameZh, description, props, subComponentProps } = component
+  const { name, nameZh, description, props, subComponentProps, commonProps } = component
   return {
     name,
     nameZh,
@@ -25,6 +50,7 @@ function outputJson(component: ComponentRecord): object {
     slots: props.slots,
     methods: props.methods,
     subComponentProps,
+    commonProps,
   }
 }
 
@@ -90,7 +116,56 @@ function outputTextTableOrMarkdown(component: ComponentRecord, type: OutputForma
     })
   }
 
+  if (component.commonProps) {
+    if (type === 'text') {
+      content += '\n通用属性（所有组件均支持，无需单独列出）\n'
+      const p = new Table({
+        style: tableBorderStyle,
+        columns: [
+          { name: 'Property', alignment: 'left' },
+          { name: 'Type', alignment: 'left' },
+          { name: 'Default', alignment: 'left' },
+          { name: 'Description', alignment: 'left' },
+        ],
+      })
+
+      component.commonProps.forEach((prop) => {
+        p.addRow({
+          Property: prop.name,
+          Type: prop.type,
+          Default: prop.default,
+          Description: prop.descriptionZh,
+        })
+      })
+
+      content += p.render()
+    }
+
+    if (type === 'markdown') {
+      content += '\n通用属性（所有组件均支持，无需单独列出）\n\n'
+      content += `| Property | Type | Default | Description |\n`
+      content += '| --- | --- | --- | --- |\n'
+
+      component.commonProps.forEach((prop) => {
+        content += `| ${prop.name} | ${prop.type} | ${prop.default} | ${prop.descriptionZh} |`
+      })
+    }
+  }
+
   return content
+}
+
+const COMMON_PROPS_EXCLUDED = new Set(['ConfigProvider'])
+
+async function getComponentInfo(name: string, version: ResolvedVersion): Promise<ComponentRecord> {
+  const component = loadComponent(name, await loadVersionMetaData(version))
+
+  const commonProps = COMMON_PROPS_EXCLUDED.has(component.name) ? undefined : COMMON_PROPS
+
+  return {
+    ...component,
+    commonProps,
+  }
 }
 
 export default defineCommand({
@@ -106,7 +181,7 @@ export default defineCommand({
     const config = resolveConfig(args)
     try {
       const version = await resolveVersion(config)
-      const component = loadComponent(config.component, await loadVersionMetaData(version))
+      const component = await getComponentInfo(config.component, version)
 
       console.log(`${capitalize(config.component)} (${component.nameZh}) — ${component.description}`)
 

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -74,4 +74,5 @@ export interface ComponentRecord {
   faq: ComponentFaqRecord[]
   demos: ComponentDemoRecord[]
   semanticStructure: ComponentSemanticStructureRecord[]
+  commonProps?: ComponentApiItemRecord[]
 }


### PR DESCRIPTION
- Add commonProps field to ComponentRecord type definition
- Define COMMON_PROPS array with standard properties (style, class, rootClass, autoFocus)
- Include commonProps in JSON output format
- Add text and markdown rendering for common properties section
- Create getComponentInfo function to inject common props data
- Exclude ConfigProvider from common props injection
- Update command to use enhanced component info with common props
