### PR TITLE
refactor(doc): extract component document retrieval logic

### DIFF
--- a/src/commands/doc.ts
+++ b/src/commands/doc.ts
@@ -1,3 +1,5 @@
+import type { ComponentRecord } from '#/components.ts'
+import type { ResolvedVersion } from '@/types.ts'
 import { defineCommand } from 'citty'
 import { componentArgs } from '@/args/component.ts'
 import { defaultArgs } from '@/args/default.ts'
@@ -7,6 +9,11 @@ import { logErrorComponent } from '@/utils/error.ts'
 import { loadComponent, loadVersionMetaData } from '@/utils/loader.ts'
 import { output } from '@/utils/output.ts'
 import { resolveVersion } from '@/utils/version.ts'
+
+export async function getComponentDocument(component: string, version: ResolvedVersion): Promise<ComponentRecord> {
+  const metaData = await loadVersionMetaData(version)
+  return loadComponent(component, metaData)
+}
 
 export default defineCommand({
   meta: {
@@ -22,8 +29,7 @@ export default defineCommand({
     const component = capitalize(args.component)
     try {
       const version = await resolveVersion(config)
-      const metaData = await loadVersionMetaData(version)
-      const components = loadComponent(component, metaData)
+      const components = await getComponentDocument(component, version)
 
       if (!components.doc) {
         logErrorComponent(args)


### PR DESCRIPTION
- Added import for ComponentRecord and ResolvedVersion types
- Extracted component document loading into separate getComponentDocument function
- Replaced inline metadata loading with reusable function call
- Simplified main command logic by using the new helper function
- Improved code organization and maintainability
