### PR TITLE
chore(package): remove types field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     ".": "./dist/index.mjs",
     "./package.json": "./package.json"
   },
-  "types": "./dist/index.d.mts",
   "bin": {
     "antdv": "./bin/antdv.js"
   },


### PR DESCRIPTION
- Removed the types field pointing to ./dist/index.d.mts
- This change affects the module's type declaration distribution
- The types are likely now bundled with the main entry point
- This simplifies the package.json configuration for better maintainability
