### PR TITLE
feat(cli): add init command for project initialization

### DIFF
--- a/src/args/args.d.ts
+++ b/src/args/args.d.ts
@@ -3,10 +3,12 @@ import type { bugArgs } from '@/args/bug.ts'
 import type { componentArgs } from '@/args/component.ts'
 import type { defaultArgs } from '@/args/default.ts'
 import type { demoArgs } from '@/args/demo.ts'
+import type { initArgs } from '@/args/init.ts'
 
 export type OptionsArgs = ParsedArgs<typeof defaultArgs>
   & Partial<
     ParsedArgs<typeof bugArgs>
     & ParsedArgs<typeof componentArgs>
     & ParsedArgs<typeof demoArgs>
+    & ParsedArgs<typeof initArgs>
   >

--- a/src/args/init.ts
+++ b/src/args/init.ts
@@ -1,0 +1,19 @@
+import type { ArgsDef } from 'citty'
+
+export const initArgs = {
+  name: {
+    type: 'positional',
+    description: 'Project Name',
+    default: 'antdv-next-project',
+  },
+  nuxt: {
+    type: 'boolean',
+    description: 'Whether to initialize the Nuxt project template',
+    default: false,
+  },
+  git: {
+    type: 'boolean',
+    description: 'Whether or not to initialize the Git repository',
+    default: true,
+  },
+} satisfies ArgsDef

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,0 +1,62 @@
+import { resolve } from 'node:path'
+import { box, intro, outro } from '@clack/prompts'
+import { defineCommand } from 'citty'
+import { downloadTemplate } from 'giget'
+import { cyan, green } from 'picocolors'
+import { x } from 'tinyexec'
+import { defaultArgs } from '@/args/default.ts'
+import { initArgs } from '@/args/init.ts'
+import { resolveConfig } from '@/config.ts'
+
+export default defineCommand({
+  meta: {
+    name: 'init',
+    description: 'Initialize a fresh project',
+  },
+  args: {
+    ...defaultArgs,
+    ...initArgs,
+  },
+  async run({ args }) {
+    intro('Welcome to Antdv!')
+
+    const config = resolveConfig(args)
+
+    const dir = resolve(config.cwd, args.name)
+    const template = `https://codeload.github.com/antdv-next/${args.nuxt ? 'nuxt-template' : 'starter-template'}/tar.gz/refs/heads/main`
+
+    await downloadTemplate(template, {
+      cwd: config.cwd,
+      dir,
+      force: true,
+      forceClean: true,
+    })
+
+    if (args.git) {
+      await x('git', ['init'], {
+        nodeOptions: {
+          cwd: dir,
+          stdio: 'pipe',
+        },
+      })
+    }
+
+    outro(`🚀  Successfully created project ${green(args.name)}`)
+
+    const nextStep = [
+      `cd ${args.name}`,
+      'pnpm install',
+      'pnpm run dev',
+    ]
+
+    box(`\n${nextStep.map(step => ` › ${cyan(step)}`).join('\n')}\n`, ' 👉 Next steps ', {
+      contentAlign: 'left',
+      titleAlign: 'left',
+      width: 'auto',
+      rounded: true,
+      titlePadding: 2,
+      contentPadding: 2,
+      withGuide: false,
+    })
+  },
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { description, name, version } from '../package.json' with { type: 'json'
 const CLI_VERSION = __CLI_VERSION__
 
 const subCommands = {
+  'init': () => import('./commands/init.ts').then(r => r.default),
   'bug': () => import('./commands/bug.ts').then(r => r.default),
   'bug-cli': () => import('./commands/bug-cli.ts').then(r => r.default),
   'changelog': () => import('./commands/changelog.ts').then(r => r.default),


### PR DESCRIPTION
#2

- Add initArgs type definition for project initialization options
- Integrate init command into main CLI index with dynamic import
- Implement init command with project template downloading functionality
- Add support for Nuxt project template selection via --nuxt flag
- Include Git repository initialization option via --git flag
- Provide interactive UI with clack prompts for project setup flow
- Show next steps guidance after successful project creation
- Support custom project naming with default antdv-next-project value
