### PR TITLE
test(cli): update version reference in test files

### DIFF
--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises'
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { version } from '../package.json' with { type: 'json' }
 import { createMockDir, genPath, run } from './run'
 
 beforeEach(async () => await createMockDir())
@@ -12,6 +13,6 @@ describe('cli', () => {
   it('run antdv command', async () => {
     const { stdout } = await run()
 
-    expect(stdout).toContain('@antdv-next/cli v0.0.0')
+    expect(stdout).toContain(`@antdv-next/cli v${version}`)
   })
 })

--- a/test/issue.test.ts
+++ b/test/issue.test.ts
@@ -1,6 +1,7 @@
 import type { ResolvedAntdvVersionEnv } from '../src/types'
 import process from 'node:process'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { version as cliVersion } from '../package.json' with { type: 'json' }
 import { buildIssueUrl, collectAntdvEnv, createIssueBody } from '../src/utils/issue'
 
 const mocks = vi.hoisted(() => ({
@@ -72,7 +73,7 @@ describe('collectAntdvEnv', () => {
         bun: '1.2.21',
       },
       system: 'test-platform test-release',
-      cli: '0.0.0',
+      cli: cliVersion,
     })
 
     expect(mocks.getInstalledPackageVersion).toHaveBeenNthCalledWith(1, '/project', 'antdv-next')


### PR DESCRIPTION
- Import version from package.json using JSON module import
- Replace hardcoded '0.0.0' version with dynamic version variable
- Update CLI version assertion to use imported version constant
- Maintain consistent version testing across all test cases
- Ensure version tests reflect actual package version instead of placeholder
