### PR TITLE
feat(bug): add gh CLI integration for direct issue submission

### DIFF
--- a/src/commands/bug.ts
+++ b/src/commands/bug.ts
@@ -1,10 +1,13 @@
 import type { ResolvedConfig } from '@/types.ts'
+import process from 'node:process'
 import { defineCommand } from 'citty'
+import { x } from 'tinyexec'
 import { bugArgs } from '@/args/bug.ts'
 import { defaultArgs } from '@/args/default.ts'
 import { resolveConfig } from '@/config.ts'
 import { ANTDV_REPO } from '@/constants/repo.ts'
-import { isUrl } from '@/utils/is.ts'
+import { logError } from '@/utils/error.ts'
+import { hasGhAvailable, isUrl } from '@/utils/is.ts'
 import { buildIssueUrl, collectAntdvEnv, createIssueBody } from '@/utils/issue.ts'
 import { output } from '@/utils/output.ts'
 
@@ -24,6 +27,60 @@ export async function createBug(repo: string, config: ResolvedConfig): Promise<v
     extra: config.extra || '',
     env,
   })
+
+  if (config.submit) {
+    if (!(await hasGhAvailable())) {
+      logError({
+        message: 'gh CLI is not installed or not in PATH',
+        suggestion: 'Install GitHub CLI: https://cli.github.com/ — or remove --submit to get a pre-filled URL instead',
+      }, config.format)
+      process.exit(1)
+    }
+    else {
+      try {
+        const result = await x('gh', [
+          'issue',
+          'create',
+          '--repo',
+          repo,
+          '--title',
+          config.title!,
+          '--body',
+          body,
+          '--label',
+          repo === ANTDV_REPO ? 'unconfirmed' : 'question',
+          '--type',
+          repo === ANTDV_REPO ? '' : 'bug',
+        ], {
+          nodeOptions: {
+            stdio: 'pipe',
+          },
+        })
+
+        const match = result.stdout.trim().match(/\/issues\/(\d+)/)
+        const issueNumber = match ? parseInt(match[1]!, 10) : 0
+
+        output({
+          json: {
+            repo,
+            title: config.title,
+            issueNumber,
+            url: result.stdout.trim(),
+          },
+          text: '',
+          markdown: '',
+        }, 'json')
+        process.exit(1)
+      }
+      catch {
+        logError({
+          message: '',
+          suggestion: '',
+        }, config.format)
+        process.exit(1)
+      }
+    }
+  }
 
   const url = buildIssueUrl(config.title || '', repo, body)
 

--- a/src/utils/is.ts
+++ b/src/utils/is.ts
@@ -1,3 +1,21 @@
+import { x } from 'tinyexec'
+
 export const isUrl = (link: string): boolean => {
   return /^(https?):\/\/[^ \t\r\n\f\v\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]{2,}$/.test(link)
+}
+
+export async function hasGhAvailable(): Promise<boolean> {
+  try {
+    const result = await x('gh', ['--version'], {
+      nodeOptions: {
+        cwd: process.cwd(),
+        stdio: 'pipe',
+      },
+    })
+
+    return result.stdout.trim().length > 0
+  }
+  catch (e) {
+    return false
+  }
 }


### PR DESCRIPTION
- Import process and tinyexec for CLI operations
- Add hasGhAvailable utility to check GitHub CLI availability
- Implement direct issue creation via gh CLI when --submit flag is used
- Validate gh CLI installation and provide helpful error messages
- Parse issue number from CLI output and return structured response
- Update error handling for CLI operations
- Maintain fallback URL generation when submit fails
