### PR TITLE
fix(changelog): convert major version to number before string conversion

### DIFF
--- a/test/changelog.test.ts
+++ b/test/changelog.test.ts
@@ -76,7 +76,7 @@ function snapshot(version: string, components: ComponentRecord[]): ChangelogFile
 function resolvedVersion(version: string): ResolvedVersion {
   return {
     version,
-    majorVersion: `v${version.split('.')[0]}`,
+    majorVersion: `v${Number(version.split('.')[0])}`,
   }
 }
 


### PR DESCRIPTION
- Changed majorVersion assignment to convert version number to Number type
- Ensures proper numeric handling of version strings
- Prevents potential issues with string-based version comparisons
