### PR TITLE
feat(mcp): add changelog comparison tool

### DIFF
--- a/src/mcp/handler.ts
+++ b/src/mcp/handler.ts
@@ -1,4 +1,5 @@
 import type { AntdvToolStrategyRegistry, handlerContext } from '@/mcp/tools.ts'
+import process from 'node:process'
 import { getComponentDemo } from '@/commands/demo.ts'
 import { getDesignMarkdown } from '@/commands/design.ts'
 import { getComponentDocument } from '@/commands/doc.ts'
@@ -6,7 +7,9 @@ import { getComponentInfo } from '@/commands/info.ts'
 import { outputJson as outputComponentListJson } from '@/commands/list.ts'
 import { getComponentSemantic } from '@/commands/semantic.ts'
 import { getComponentToken } from '@/commands/token.ts'
+import { diffComponent } from '@/utils/api-diff.ts'
 import { loadVersionMetaData } from '@/utils/loader.ts'
+import { resolveVersion } from '@/utils/version.ts'
 
 const antdvListHandler = async (ctx: Readonly<handlerContext>, params: Record<string, unknown>): Promise<any> => {
   const metaData = await loadVersionMetaData(ctx.version)
@@ -54,6 +57,23 @@ const antdvDesignMdHandler = async (ctx: Readonly<handlerContext>, params: Recor
   }
 }
 
+const antdvChangelogHandler = async (ctx: Readonly<handlerContext>, params: Record<string, string>): Promise<any> => {
+  const v1 = await resolveVersion({
+    cwd: process.cwd(),
+    format: 'json',
+    component: params.component || '',
+    version: params.from || '',
+  })
+  const v2 = await resolveVersion({
+    cwd: process.cwd(),
+    format: 'json',
+    component: params.component || '',
+    version: params.to || '',
+  })
+
+  return await diffComponent(v1, v2, params.component)
+}
+
 export default {
   antdv_list: antdvListHandler,
   antdv_info: antdvInfoHandler,
@@ -62,4 +82,5 @@ export default {
   antdv_semantic: antdvSemanticHandler,
   antdv_doc: antdvDocHandler,
   antdv_design_md: antdvDesignMdHandler,
+  antdv_changelog: antdvChangelogHandler,
 } as AntdvToolStrategyRegistry

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -69,6 +69,16 @@ export const antdvMcpToolDefinitions = [
     inputSchema: z.object({}).strict(),
     annotations: readOnlyAnnotations,
   },
+  {
+    name: 'antdv_changelog',
+    description: 'Obtain the changelog of the target main version',
+    inputSchema: z.object({
+      from: z.string().trim().describe('Source antdv-next version (e.g. 1.0.5)'),
+      to: z.string().trim().describe('Target antdv-next version (e.g. 1.5.2)'),
+      component: z.string().optional().describe('Component name (e.g. Button, Table)'),
+    }).strict(),
+    annotations: readOnlyAnnotations,
+  },
 ] as const
 
 export type AntdvMcpToolName = typeof antdvMcpToolDefinitions[number]['name']


### PR DESCRIPTION
## Summary

- Add a read-only `antdv_changelog` MCP tool for comparing API changes between two antdv-next versions.
- Resolve the `from` and `to` versions through the existing project-aware version resolver before generating the diff.
- Support an optional component filter while preserving existing CLI and MCP behavior.

## Testing

- `git diff --check main...HEAD`
- Pre-commit lint-staged hook (`eslint --fix`)
- Not run: `pnpm lint` and `pnpm test:all` (the execution environment blocks project validation commands; developer verification is required)
